### PR TITLE
feat(dx-core): Intent workspace sync + visual task progress

### DIFF
--- a/plugins/dx-core/rules/task-progress.md
+++ b/plugins/dx-core/rules/task-progress.md
@@ -1,0 +1,36 @@
+# Visual Progress Tracking
+
+When executing any skill that contains a multi-step workflow (3 or more trackable steps), create visual task progress using `TaskCreate` and `TaskUpdate` so the user can see live progress in the CLI.
+
+## Detecting Steps
+
+Scan the skill content for one of these patterns (in priority order):
+
+1. **Phase table** — rows in a `| # | Phase | Condition |` table. Each row is a trackable step. Conditional phases (e.g., "only if Figma URL in story") are included but may be skipped at runtime.
+2. **DOT digraph** — nodes with `[shape=box]` are trackable steps. Skip decision nodes (`[shape=diamond]`) and terminal nodes (`[shape=doublecircle]`). If box nodes contain sub-steps (e.g., "Phase 1: Requirements (fetch - dor - explain - research - share)"), track the phase, not each sub-step.
+3. **Numbered steps** — lines matching `## Step N`, `### Step N`, or a top-level numbered list (`1.`, `2.`, `3.`). Each is a trackable step.
+
+If the skill has fewer than 3 trackable steps, skip progress tracking — the overhead isn't worth it.
+
+## Creating Tasks
+
+Before starting execution:
+
+1. Extract all trackable steps from the skill
+2. Create one `TaskCreate` per step:
+   - **subject**: The step name as written in the skill (e.g., "Phase 2: Planning")
+   - **activeForm**: Convert to present continuous (e.g., "Running planning phase"). Keep it short — under 40 characters.
+3. For conditional steps, append `(conditional)` to the subject
+
+## Updating Tasks During Execution
+
+- Mark `in_progress` when you begin a step
+- Mark `completed` when the step succeeds
+- Use `status: "deleted"` for steps that get skipped (conditional phases that don't apply)
+- For retry/healing loops: update the active task's subject to show the attempt (e.g., "Build (retry 1)")
+
+## Scope Rules
+
+- **Top-level only.** Only the main orchestrator creates tasks. Subagents (invoked via the Agent tool) must NOT create their own task trees — this prevents nested/duplicate progress indicators.
+- **One task list per skill invocation.** If a skill delegates to another skill (e.g., `dx-agent-all` invokes `dx-step-all`), only the outer skill's tasks appear. The inner skill suppresses its own task creation.
+- **No tasks for single-purpose skills.** Skills that do one thing (e.g., `dx-step-commit`, `dx-plan-validate`) skip progress tracking entirely.

--- a/plugins/dx-core/shared/intent-sync-contract.md
+++ b/plugins/dx-core/shared/intent-sync-contract.md
@@ -1,0 +1,172 @@
+# Intent Sync Contract
+
+Optional bridge: when skills run inside an Intent workspace, mirror `.ai/specs/` output to Intent notes with rich blocks. Zero impact without Intent.
+
+## Guard Check
+
+Before any sync, check once per session:
+
+```
+Is the tool `mcp__workspace-mcp__add_to_note` available?
+  YES → INTENT_AVAILABLE = true
+  NO  → skip all Intent sync (no errors, no warnings)
+```
+
+Cache the result. Do NOT re-check per skill invocation.
+
+## Timing Rule
+
+Intent sync happens in this order:
+
+1. Primary output file saved to `.ai/specs/`
+2. Subagent return envelope (`## Result`) prepared
+3. **→ Intent sync executes here ←**
+4. Envelope extended with `**Intent:**` field
+5. Envelope printed
+
+If Intent sync fails at any point, stop sync immediately and continue to step 4 with failure status.
+
+## Note Naming
+
+| Content | Note | How |
+|---------|------|-----|
+| Ticket overview, requirements, plan, pipeline | Spec note | `noteId="spec"` (always exists) |
+| Research findings | Separate note | Title: `Research: #<ticket-id>` |
+| DoR report | Separate note | Title: `DoR: #<ticket-id>` |
+| AEM snapshot | Separate note | Title: `AEM: <component-name>` |
+
+## Block ID Conventions
+
+Format: `<type>-<ticket-id>-<n>` where `n` is a 1-based sequence per type per note.
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Reference | `ref-<id>-<n>` | `ref-2446035-1` |
+| CLI | `cli-<id>-<n>` | `cli-2446035-1` |
+| Patch | `patch-<id>-<n>` | `patch-2446035-1` |
+| Agent action | `action-<id>-<n>` | `action-2446035-1` |
+| Diagram | `diag-<id>-<n>` | `diag-2446035-1` |
+
+## Per-Skill Mapping
+
+| Skill | Spec File | Intent Target | What to Write |
+|-------|-----------|---------------|---------------|
+| dx-req-fetch | raw-story.md | Spec note | Ticket overview table, set workspace title |
+| dx-req-explain | explain.md | Spec note | Requirements table (numbered, status column) |
+| dx-req-research | research.md | New "Research: #ID" note | Reference blocks for files, cross-repo scope table |
+| dx-req-dor | dor-report.md | New "DoR: #ID" note | Checklist with pass/fail indicators |
+| dx-plan | implement.md | Spec note | `@@@task` blocks (one per step), CLI + patch blocks |
+| dx-req-share | share-plan.md | Spec note | Plain markdown summary section |
+| dx-step | implement.md | Spec note | Update task status for completed step |
+| dx-step-all | implement.md | Spec note | Update task statuses, pipeline progress table |
+| dx-agent-all | dev-all-progress.md | Spec note | Pipeline progress table, agent action blocks |
+| aem-snapshot | aem-before.md | New "AEM: \<name\>" note | Dialog fields table, JCR properties |
+| aem-verify | aem-after.md | Spec note | Verification results section |
+
+## Idempotency Rules
+
+1. **Before creating a note:** Call `list_notes`, match by title. If exists, use `add_to_note` or `edit_note` on the existing note.
+2. **Before adding to Spec:** Call `read_note(noteId="spec")`, search for the section header. If section exists, use `edit_note` to update. If not, use `add_to_note`.
+3. **Task blocks:** Only add new `@@@task` blocks. Never duplicate tasks already present.
+4. **Workspace title:** Only call `set_workspace_title` if the title is the default. Check with `get_workspace_details` first.
+
+## Block Format Examples
+
+### Reference (clickable code link)
+
+```
+add_reference_primitive(
+  noteId = "research-note-id",
+  semanticId = "ui.frontend/src/core/components/hero/default-hero.js#class:HeroDefault",
+  description = "Hero component — default variation"
+)
+```
+
+### CLI (runnable command)
+
+```
+add_cli_primitive(
+  noteId = "spec",
+  command = "cd ui.frontend && npm run build",
+  description = "Build frontend assets"
+)
+```
+
+### Patch (applyable diff)
+
+```
+add_patch_primitive(
+  noteId = "task-note-id",
+  filePath = "ui.frontend/src/core/components/hero/default-hero.js",
+  diff = "--- a/default-hero.js\n+++ b/default-hero.js\n@@ -10,3 +10,4 @@\n+  this.setAttribute('aria-label', this.data.ariaLabel);",
+  description = "Add aria-label to hero component"
+)
+```
+
+### Agent Action (trigger button)
+
+```
+add_agent_action_primitive(
+  noteId = "spec",
+  goal = "Run dx-step-all to execute remaining implementation steps",
+  description = "Execute pending implementation steps"
+)
+```
+
+## Return Envelope Extension
+
+Add `**Intent:**` to the subagent return envelope:
+
+```
+## Result
+- **Status:** success
+- **Summary:** Generated implement.md with 8 steps.
+- **Files:** 1 created (implement.md)
+- **Next:** dx-step-all
+- **Intent:** synced (3 blocks) | skipped (not available) | failed (timeout)
+```
+
+Values: `synced (<N> blocks)`, `skipped (not available)`, `failed (<reason>)`.
+
+## Error Handling
+
+If any Intent MCP call fails:
+
+1. Do NOT retry the failed call
+2. Do NOT block the pipeline
+3. Log: `Intent sync: <tool_name> failed — skipping remaining sync`
+4. Set envelope `**Intent:** failed (<reason>)`
+5. Continue with normal skill completion
+
+## Example: dx-req-fetch Sync
+
+After writing `raw-story.md`:
+
+```
+1. Guard: check INTENT_AVAILABLE → true
+2. set_workspace_title(title = "Hero Accessibility Fix")
+3. add_to_note(noteId = "spec", heading = "## Ticket Overview",
+     content = "| Field | Value |\n|---|---|\n| ID | #2446035 |\n| Title | Hero Accessibility Fix |\n| Type | User Story |\n| State | Active |")
+4. Set envelope: **Intent:** synced (1 block)
+```
+
+## Example: dx-plan Sync
+
+After writing `implement.md`:
+
+```
+1. Guard: check INTENT_AVAILABLE → true
+2. read_note(noteId = "spec") → check for existing tasks
+3. For each step in implement.md:
+   a. add_to_note(noteId = "spec", content = "@@@task\n# Step 1: Add aria-label to hero\n...")
+   b. add_cli_primitive(noteId = latest_task_note_id,
+        command = "cd ui.frontend && npm run build",
+        description = "Verify build after hero changes")
+   c. add_patch_primitive(noteId = latest_task_note_id, ...) — if diff known
+4. Set envelope: **Intent:** synced (8 tasks, 8 CLI, 3 patches)
+```
+
+## Scope
+
+- **In scope:** dx-core skills, dx-aem skills (aem-snapshot, aem-verify)
+- **Out of scope:** dx-automation plugin, any non-dx plugin

--- a/plugins/dx-core/skills/dx-plan/SKILL.md
+++ b/plugins/dx-core/skills/dx-plan/SKILL.md
@@ -99,7 +99,56 @@ The step-* skills update these statuses as they execute.
 - **No time estimates**
 - **Scale to complexity** — simple change = 3-4 steps, complex feature = 10+
 
-## 7. Present Summary
+## 7. Intent Workspace Sync (optional)
+
+If running inside an Intent workspace, mirror the plan to the Spec note as task blocks. Read `shared/intent-sync-contract.md` for full conventions.
+
+**Guard:** Is the tool `mcp__workspace-mcp__add_to_note` available? If NO → set `INTENT_STATUS = "skipped"` and go to Step 8.
+
+**If available:**
+
+1. **Read Spec note** — call `read_note(noteId="spec")` to check for existing tasks. If tasks for this plan already exist, skip to avoid duplicates.
+
+2. **Create task blocks** — call `add_to_note(noteId="spec")` with content containing one `@@@task` block per implement.md step:
+
+   ```
+   @@@task
+   # Step <N>: <step title>
+   <What this step does and why>
+
+   **Files:** <list from step>
+   @@@
+   ```
+
+   Intent auto-converts each `@@@task` block into a Task Note.
+
+3. **Add rich blocks to task notes** — after the tasks are created, for each task note:
+   - If the step has a **Test** line → `add_cli_primitive(noteId=<task_note_id>, command=<test command>, description="Verify: <step title>")`
+   - If the step has a code diff or specific code to add → `add_patch_primitive(noteId=<task_note_id>, filePath=<primary file>, diff=<change>, description=<step title>)`
+
+4. **Add pipeline progress table** — call `add_to_note(noteId="spec")`:
+
+   ```markdown
+   heading: "## Pipeline Progress"
+   content:
+   | Phase | Status |
+   |-------|--------|
+   | Requirements | ✅ Done |
+   | Planning | ✅ Done |
+   | Execution | ⬜ Pending |
+   | Build | ⬜ Pending |
+   | Review | ⬜ Pending |
+   | Commit | ⬜ Pending |
+   | PR | ⬜ Pending |
+   ```
+
+5. Set `INTENT_STATUS = "synced (<N> tasks, <M> blocks)"` where N = task count, M = total CLI + patch blocks added.
+
+**Error handling:** If any MCP call fails, log `Intent sync: <tool_name> failed — skipping remaining sync`, set `INTENT_STATUS = "failed (<reason>)"`, and continue to Step 8. Do NOT retry or block.
+
+## 8. Present Summary
+
+Print the result envelope:
 
 ```markdown
 ## implement.md created
@@ -110,6 +159,7 @@ The step-* skills update these statuses as they execute.
 - Files to create: <count>
 - Tests planned: <count> unit, manual verification included
 - Risks identified: <count or "none">
+- **Intent:** <INTENT_STATUS>
 
 ### Next steps:
 - `/dx-plan-validate` — verify plan covers all requirements

--- a/plugins/dx-core/skills/dx-req-fetch/SKILL.md
+++ b/plugins/dx-core/skills/dx-req-fetch/SKILL.md
@@ -304,7 +304,39 @@ ADO fields return HTML. When converting:
 - Strip all other HTML tags (keep display text from `data-vss-mention` spans)
 - Trim excessive whitespace
 
-## 11. Present Summary
+## 11. Intent Workspace Sync (optional)
+
+If running inside an Intent workspace, mirror the ticket overview to the Spec note. Read `shared/intent-sync-contract.md` for full conventions.
+
+**Guard:** Is the tool `mcp__workspace-mcp__add_to_note` available? If NO → set `INTENT_STATUS = "skipped"` and go to Step 12.
+
+**If available:**
+
+1. **Set workspace title** — call `get_workspace_details`. If the title is still the default, call `set_workspace_title` with the work item title (truncated to 50 chars if needed). If already set, skip.
+
+2. **Add ticket overview to Spec note** — call `add_to_note(noteId="spec")` with:
+
+```markdown
+heading: "## Ticket Overview"
+content:
+| Field | Value |
+|-------|-------|
+| ID | #<id> |
+| Title | <title> |
+| Type | <type> |
+| State | <state> |
+| Priority | <priority> |
+| Sprint | <iteration path — last segment> |
+| Assigned To | <name> |
+
+> <One-line summary of the ticket — first sentence of description or title>
+```
+
+3. Set `INTENT_STATUS = "synced (1 block)"`.
+
+**Error handling:** If any MCP call fails, log `Intent sync: <tool_name> failed — skipping remaining sync`, set `INTENT_STATUS = "failed (<reason>)"`, and continue to Step 12. Do NOT retry or block.
+
+## 12. Present Summary
 
 After saving, print:
 
@@ -317,6 +349,8 @@ After saving, print:
 
 ### Saved:
 - `raw-story.md` — <X> sections, <Y> comments, <Z> relations
+
+**Intent:** <INTENT_STATUS>
 
 ### Next steps:
 - `/dx-req-explain` — distill into developer requirements

--- a/plugins/dx-core/skills/dx-req-research/SKILL.md
+++ b/plugins/dx-core/skills/dx-req-research/SKILL.md
@@ -188,7 +188,47 @@ Do NOT duplicate ticket data verbatim — research.md should be deeper (code ana
 
 Read `.ai/templates/spec/research.md.template` and follow that structure exactly. The template defines all sections: Existing Components, Component Config, Backing Code (Models, Services, Exporters, API Endpoints), Frontend, Test Coverage, Related Components, Existing Implementation Check (MANDATORY), Key Findings, Files Inventory table, and Cross-Repo Scope.
 
-## 6. Present Summary
+## 6. Intent Workspace Sync (optional)
+
+If running inside an Intent workspace, mirror the research findings to a dedicated Research note. Read `shared/intent-sync-contract.md` for full conventions.
+
+**Guard:** Is the tool `mcp__workspace-mcp__add_to_note` available? If NO → set `INTENT_STATUS = "skipped"` and go to Step 7.
+
+**If available:**
+
+1. **Find or create Research note** — call `list_notes` and search for a note titled `Research: #<id>`. If found, use its `noteId`. If not, call `create_note(title="Research: #<id>", content="Research findings for ADO #<id>")` and use the returned `noteId`.
+
+2. **Add summary** — call `add_to_note(noteId=<research-note-id>)` with the Key Findings section content from `research.md` (reuse verbatim — do not regenerate).
+
+3. **Add reference blocks** — for each file in the Files Inventory table of `research.md`, call:
+   ```
+   add_reference_primitive(
+     noteId = <research-note-id>,
+     semanticId = "<file-path>",
+     description = "<one-line description from table>"
+   )
+   ```
+   Use the file path as `semanticId`. If the table includes a class/component name, append `#class:<Name>` to the semanticId.
+
+4. **Add cross-repo scope** — if `research.md` contains a Cross-Repo Scope section, call `add_to_note(noteId=<research-note-id>, heading="## Cross-Repo Scope")` with that section's content.
+
+5. **Add architecture diagram (conditional)** — if ≥3 distinct components or services were discovered in research.md, call `add_to_note(noteId=<research-note-id>)` with a diagram block:
+   ```
+   ~~~architecture layout=layered LR
+   [Component1] --> [Service1]
+   [Component2] --> [Service1]
+   [Service1] --> [Model1]
+   ~~~
+   ```
+   Map the actual component/service/model names from findings. Skip if <3 nodes.
+
+6. **Link from Spec note** — call `add_to_note(noteId="spec", content="### Research\nSee [Research: #<id>](intent://local/note/<research-note-id>)")`.
+
+7. Set `INTENT_STATUS = "synced (N references, 1 note)"` where N is the number of `add_reference_primitive` calls made.
+
+**Error handling:** If any MCP call fails, log `Intent sync: <tool_name> failed — skipping remaining sync`, set `INTENT_STATUS = "failed (<reason>)"`, and continue to Step 7. Do NOT retry or block.
+
+## 7. Present Summary
 
 After saving:
 
@@ -201,6 +241,8 @@ After saving:
 - Files to modify: <count> (estimated)
 - Test coverage: <existing test count> tests found
 - Cross-repo: <"all files in this repo" OR "also needs work in <repo1>, <repo2>">
+
+**Intent:** <INTENT_STATUS>
 
 ### Next steps:
 - `/dx-plan` — create implementation plan based on findings


### PR DESCRIPTION
## Summary
- **Intent workspace sync:** dx-req-fetch, dx-req-research, and dx-plan now optionally mirror their output to Intent workspace notes via `workspace-mcp`. Guarded by tool availability — gracefully skips when not in an Intent workspace.
- **Visual task progress:** New universal `task-progress` rule auto-creates CLI task checklists from any multi-step skill's DOT digraph, phase table, or numbered steps. Gives users live progress indicators (like superpowers) without modifying individual skills.
- **Shared contract:** `intent-sync-contract.md` documents the conventions for workspace note sync across all skills.

## Test plan
- [ ] Run `/dx-req-fetch <id>` in an Intent workspace — verify Spec note is created/updated
- [ ] Run `/dx-req-fetch <id>` outside Intent workspace — verify graceful skip
- [ ] Run `/dx-req-research <id>` — verify Research note created
- [ ] Run `/dx-plan <id>` — verify task blocks mirrored to Spec note
- [ ] Run any multi-step skill (e.g., `/dx-req-all`) — verify task checklist appears in CLI
- [ ] Run a simple skill (<3 steps) — verify no task overhead
- [ ] Verify subagents do NOT create their own task trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)