### PR TITLE
fix(website): clean up demo pages and genericize examples

### DIFF
--- a/website/src/content/tips/claude-md-your-projects-brain.md
+++ b/website/src/content/tips/claude-md-your-projects-brain.md
@@ -50,5 +50,5 @@ mvn clean install # full deploy
 - PR target: development (never main)
 
 ## Architecture
-Custom Elements extending BATComponent
+Custom Elements extending CustomComponent
 ```

--- a/website/src/content/tips/writing-your-first-custom-skill.md
+++ b/website/src/content/tips/writing-your-first-custom-skill.md
@@ -32,7 +32,7 @@ slackText: |
   *Step 3:* Write instructions
   ```
   1. Find the component file matching the given name in src/
-  2. Verify it extends BATComponent
+  2. Verify it extends CustomComponent
   3. Check that lifecycle methods (beforeLoad, afterLoad) exist
   4. Check that data-model parsing is implemented
   5. Report findings with specific file:line references
@@ -63,7 +63,7 @@ allowed-tools: [read, grep, glob]
 ---
 
 1. Find the component file in src/
-2. Verify it extends BATComponent
+2. Verify it extends CustomComponent
 3. Check lifecycle methods exist
 4. Report any missing patterns
 ```

--- a/website/src/pages/demo/long.mdx
+++ b/website/src/pages/demo/long.mdx
@@ -356,47 +356,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <ContentCard icon="mdi:lightning-bolt" iconColor="bg-red-500" title="10 Agents, 24/7" horizontal>
       DoR validation, PR review, bug triage, DevAgent, QA, estimation, documentation -- all triggered automatically via ADO pipelines and AWS Lambda. Jira webhook support planned.
     </ContentCard>
-    <ContentCard icon="mdi:database" iconColor="bg-amber-500" title="Multiple Projects" horizontal>
-      Runs daily across several BAT projects. DevAgent implements real stories. QA agent files real bugs. Production infrastructure.
+    <ContentCard icon="mdi:database" iconColor="bg-amber-500" title="Production Proven" horizontal>
+      Runs daily across multiple projects. DevAgent implements real stories. QA agent files real bugs. Production infrastructure.
     </ContentCard>
     <ContentCard icon="mdi:puzzle" iconColor="bg-cyan-dark" title="Project-Agnostic" horizontal>
       3 plugins, independently installable. AEM logic stays in its own plugin. Works with any tech stack across connected multi repos.
-    </ContentCard>
-    <ContentCard icon="mdi:account-group" iconColor="bg-emerald-600" title="AthenAI Convergence" horizontal>
-      The AthenAI team builds a complementary human-in-the-loop approach. Planning to merge both platforms. Two roads to the same destination.
-    </ContentCard>
-  </div>
-</Section>
-
-{/* What's Next */}
-<SectionHeading
-  badge="Next Steps"
-  badgeColor="warning"
-  title="Where This Goes"
-  subtitle="Scaling from BAT to company-wide -- with the right investment."
-  bg="primary"
-/>
-<Section>
-  <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:rocket-launch" iconColor="bg-amber-500" title="How It Was Built" horizontal>
-      <ul class="m-0 pl-4 text-sm">
-        <li>Built over 6 months on personal time -- evenings and weekends</li>
-        <li>Alongside full project load, PSL (7 protegees), and community roles</li>
-        <li>AI Champion role gave direction but no time allocation</li>
-        <li>Scaling requires dedicated time and organizational mandate</li>
-      </ul>
-    </ContentCard>
-    <ContentCard icon="mdi:school" iconColor="bg-cyan-dark" title="Roadmap" horizontal>
-      <ul class="m-0 pl-4 text-sm">
-        <li>Company-wide rollout beyond BAT</li>
-        <li>Training and workshops -- from basic prompts to agentic workflows</li>
-        <li>AI governance and standards framework</li>
-        <li>Continuous evolution -- AI moves daily</li>
-      </ul>
-    </ContentCard>
-    <ContentCard icon="mdi:account-group" iconColor="bg-emerald-600" title="AthenAI Convergence" horizontal>
-      The AthenAI team builds a complementary human-in-the-loop approach. Planning to merge both platforms.
-      Two roads to the same destination -- full lifecycle automation with the right level of human control.
     </ContentCard>
   </div>
 </Section>

--- a/website/src/pages/demo/short.mdx
+++ b/website/src/pages/demo/short.mdx
@@ -228,34 +228,3 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
   </div>
 </Section>
 
-<SectionHeading
-  badge="Next Steps"
-  badgeColor="warning"
-  title="Where This Goes"
-  subtitle="Scaling from BAT to company-wide -- with the right investment."
-  bg="alt"
-/>
-<Section>
-  <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:rocket-launch" iconColor="bg-amber-500" title="How It Was Built" horizontal>
-      <ul class="m-0 pl-4 text-sm">
-        <li>Built over 6 months on personal time -- evenings and weekends</li>
-        <li>Alongside full project load, PSL (7 protegees), and community roles</li>
-        <li>AI Champion role gave direction but no time allocation</li>
-        <li>Scaling requires dedicated time and organizational mandate</li>
-      </ul>
-    </ContentCard>
-    <ContentCard icon="mdi:school" iconColor="bg-cyan-dark" title="Roadmap" horizontal>
-      <ul class="m-0 pl-4 text-sm">
-        <li>Company-wide rollout beyond BAT</li>
-        <li>Training and workshops -- from basic prompts to agentic workflows</li>
-        <li>AI governance and standards framework</li>
-        <li>Continuous evolution -- AI moves daily</li>
-      </ul>
-    </ContentCard>
-    <ContentCard icon="mdi:account-group" iconColor="bg-emerald-600" title="AthenAI Convergence" horizontal>
-      The AthenAI team builds a complementary human-in-the-loop approach. Planning to merge both platforms.
-      Two roads to the same destination -- full lifecycle automation with the right level of human control.
-    </ContentCard>
-  </div>
-</Section>

--- a/website/src/pages/learn/mcps.mdx
+++ b/website/src/pages/learn/mcps.mdx
@@ -134,7 +134,7 @@ remediate -- suggest fixes`}</CommandBlock>
     "ado": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@azure-devops/mcp", "batdigital"]
+      "args": ["-y", "@azure-devops/mcp", "my-org"]
     }
   }
 }`}</CommandBlock>

--- a/website/src/pages/learn/prompts.mdx
+++ b/website/src/pages/learn/prompts.mdx
@@ -74,7 +74,7 @@ paths: ["**/*.js"]
 applyTo: "**/*.js"
 ---
 # JavaScript Conventions
-- Use BATComponent custom elements (extends HTMLElement)
+- Use CustomComponent custom elements (extends HTMLElement)
 - Lifecycle: options() -> beforeLoad() -> afterLoad()
 - No ES modules -- use Gulp concat pipeline
 - Externalize selectors to component config`}</CommandBlock>


### PR DESCRIPTION
## Summary
- Remove "Where This Goes" section from demo pages (not relevant for open-source)
- Genericize code examples: use placeholder org names and component names
- Remove references to specific internal teams and roles

## Test plan
- [ ] `cd website && npm run dev` — verify demo pages render correctly
- [ ] No broken references or missing content