### PR TITLE
fix: broken docs links in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Autonomous AI agents (DoR checker, DoD checker, DoD fixer, PR reviewer, PR answe
 
 ## Client-Specific Plugins
 
-Client-specific plugins can live alongside these plugins for project-specific enrichment (market data, brand config, etc.). See the [authoring guide](https://easingthemes.github.io/dx-aem-flow/reference/authoring/) for how to create them.
+Client-specific plugins can live alongside these plugins for project-specific enrichment (market data, brand config, etc.). See the [authoring guide](https://easingthemes.github.io/dx-aem-flow/contributing/authoring/) for how to create them.
 
 ## Quick Start
 

--- a/website/src/pages/architecture/hub.mdx
+++ b/website/src/pages/architecture/hub.mdx
@@ -12,6 +12,8 @@ import HighlightBox from '../../components/HighlightBox.astro';
 import PipelineBlock from '../../components/PipelineBlock.astro';
 import CommandBlock from '../../components/CommandBlock.astro';
 
+export const base = import.meta.env.BASE_URL;
+
 <PageHero
   title="Multi-Repo Hub"
   subtitle="Local multi-repo orchestration — run dx skills across sibling repositories from a single hub directory, with dispatch tracking and PR aggregation."
@@ -138,7 +140,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <tbody>
       <tr class="border-t border-gray-200">
         <td class="p-3"><code>DX_PIPELINE_MODE=true</code></td>
-        <td class="p-3">Pipeline delegation (write <code>delegate.json</code>) — see <a href="/architecture/cross-repo/">Cross-Repo</a></td>
+        <td class="p-3">Pipeline delegation (write <code>delegate.json</code>) — see <a href={`${base}/architecture/cross-repo/`}>Cross-Repo</a></td>
       </tr>
       <tr class="border-t border-gray-200">
         <td class="p-3"><code>hub.enabled: true</code> + repos registered</td>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -93,7 +93,7 @@ export const base = import.meta.env.BASE_URL;
   </div>
 
   <p class="text-center mt-4">
-    <a href={`${base}/figma/`} class="text-brand-700 font-semibold hover:text-cyan transition-colors">
+    <a href={`${base}/workflows/figma/`} class="text-brand-700 font-semibold hover:text-cyan transition-colors">
       See the full Figma-to-Code pipeline →
     </a>
   </p>
@@ -368,25 +368,22 @@ export const base = import.meta.env.BASE_URL;
     <a href={`${base}/overview/`} class="no-underline">
       <ContentCard icon="mdi:star" iconColor="bg-brand-700" title="Overview">What KAI does, who it's for, and how it works at a high level.</ContentCard>
     </a>
-    <a href={`${base}/figma/`} class="no-underline">
+    <a href={`${base}/workflows/figma/`} class="no-underline">
       <ContentCard icon="mdi:pencil" iconColor="bg-brand-700" title="Figma-to-Code">The full design-to-code pipeline: extract, auto-map tokens, generate prototypes, verify visually.</ContentCard>
     </a>
-    <a href={`${base}/local-workflow/`} class="no-underline">
+    <a href={`${base}/workflows/local/`} class="no-underline">
       <ContentCard icon="mdi:cog" iconColor="bg-brand-700" title="Local Workflow">Requirements, planning, execution, review -- the full sprint lifecycle.</ContentCard>
     </a>
-    <a href={`${base}/bug-flow/`} class="no-underline">
+    <a href={`${base}/workflows/bug-flow/`} class="no-underline">
       <ContentCard icon="mdi:bug" iconColor="bg-brand-700" title="Bug Flow">Triage, reproduce with browser automation, fix, and PR -- end to end.</ContentCard>
     </a>
-    <a href={`${base}/automation/`} class="no-underline">
+    <a href={`${base}/architecture/automation/`} class="no-underline">
       <ContentCard icon="mdi:lightning-bolt" iconColor="bg-brand-700" title="Automation">10 autonomous agents, AWS infrastructure, event routing, cross-repo delegation.</ContentCard>
     </a>
-    <a href={`${base}/architecture/`} class="no-underline">
+    <a href={`${base}/architecture/overview/`} class="no-underline">
       <ContentCard icon="mdi:sitemap" iconColor="bg-brand-700" title="Architecture">Plugin system, config, conventions, subagents, model tiers, MCP integration.</ContentCard>
     </a>
-    <a href={`${base}/costs/`} class="no-underline">
-      <ContentCard icon="mdi:currency-usd" iconColor="bg-brand-700" title="Costs">Two pricing models, per-operation costs, safety controls, cost optimization.</ContentCard>
-    </a>
-    <a href={`${base}/demo-guide/`} class="no-underline">
+    <a href={`${base}/demo/guide/`} class="no-underline">
       <ContentCard icon="mdi:rocket-launch" iconColor="bg-brand-700" title="Demo Guide">Step-by-step live demo scripts for business and developer audiences.</ContentCard>
     </a>
   </div>

--- a/website/src/pages/workflows/dor-dod.mdx
+++ b/website/src/pages/workflows/dor-dod.mdx
@@ -182,7 +182,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       </ul>
     </ContentCard>
     <ContentCard icon="mdi:format-list-checks" iconColor="bg-cyan-dark" title="Wiki Format">
-      Both pages use the same format: numbered sections (<code>## N. Title</code>), criteria tables with three columns (<code>Criterion | Who checks | What to verify</code>), and optional skip triggers. See the <a href={`${base}/contributing/wiki-format`}>Wiki Format</a> page for full details.
+      Both pages use the same format: numbered sections (<code>## N. Title</code>), criteria tables with three columns (<code>Criterion | Who checks | What to verify</code>), and optional skip triggers. See the <a href={`${base}/contributing/wiki-format/`}>Wiki Format</a> page for full details.
     </ContentCard>
   </div>
 </Section>


### PR DESCRIPTION
## Summary
- Fix 10 broken internal links across README.md, index.mdx, hub.mdx, and dor-dod.mdx
- Correct path prefixes for homepage "Dive Deeper" cards (figma, local-workflow, bug-flow, automation, architecture, demo-guide)
- Fix README authoring guide link (`/reference/authoring/` → `/contributing/authoring/`)
- Add missing `${base}` URL prefix in hub.mdx cross-repo link
- Add missing trailing slash in dor-dod.mdx wiki-format link
- Remove costs card (page does not exist)

## Test plan
- [ ] Run `cd website && npm run dev` and verify all homepage "Dive Deeper" links navigate correctly
- [ ] Verify hub.mdx cross-repo link works under base path
- [ ] Verify dor-dod.mdx wiki-format link works
- [ ] Confirm README authoring guide link resolves on GitHub Pages