### PR TITLE
chore: remove Run docs locally section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,6 @@ Full documentation: [KAI Website](https://easingthemes.github.io/dx-aem-flow/)
 - [Architecture](https://easingthemes.github.io/dx-aem-flow/architecture/overview/) — System design
 - [Setup](https://easingthemes.github.io/dx-aem-flow/setup/claude-code/) — Installation guides
 
-### Run docs locally
-
-```bash
-cd website && npm install && npm run dev
-# Opens at http://localhost:4321
-```
-
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Remove "Run docs locally" section from README — not needed for end users

## Test plan
- [ ] Verify README renders correctly without the section