### PR TITLE
fix(website): add missing slash in image/video URL paths

### DIFF
--- a/website/src/pages/demo/figma.mdx
+++ b/website/src/pages/demo/figma.mdx
@@ -95,7 +95,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       Mobile cards with hero images, rating badges, airfield tags, passenger count, favorites,
       and bottom tab navigation.
 
-      <img src={`${import.meta.env.BASE_URL}images/figma-demo/air-tours-reference.png`} alt="Air Tours Figma design" class="rounded border border-gray-200 w-full mt-4" />
+      <img src={`${import.meta.env.BASE_URL}/images/figma-demo/air-tours-reference.png`} alt="Air Tours Figma design" class="rounded border border-gray-200 w-full mt-4" />
     </ContentCard>
     <ContentCard icon="mdi:file-document" iconColor="bg-brand-700" title="Pre-Written Specs">
       In a real sprint, <code>/dx-req-all</code> fetches the ticket, validates Definition of Ready,
@@ -154,11 +154,11 @@ import CommandBlock from '../../components/CommandBlock.astro';
       <div class="grid md:grid-cols-2 gap-4 mt-4">
         <div>
           <p class="text-xs font-semibold text-[#7a7a8a] uppercase mb-1">Figma Source</p>
-          <img src={`${import.meta.env.BASE_URL}images/figma-demo/air-tours-reference.png`} alt="Figma Source" class="rounded border border-gray-200 w-full" />
+          <img src={`${import.meta.env.BASE_URL}/images/figma-demo/air-tours-reference.png`} alt="Figma Source" class="rounded border border-gray-200 w-full" />
         </div>
         <div>
           <p class="text-xs font-semibold text-[#7a7a8a] uppercase mb-1">Generated Prototype</p>
-          <img src={`${import.meta.env.BASE_URL}images/figma-demo/prototype-screenshot.png`} alt="Generated Prototype" class="rounded border border-gray-200 w-full" />
+          <img src={`${import.meta.env.BASE_URL}/images/figma-demo/prototype-screenshot.png`} alt="Generated Prototype" class="rounded border border-gray-200 w-full" />
         </div>
       </div>
     </ContentCard>
@@ -173,7 +173,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   </div>
 
   <div class="mt-6 border border-gray-200 rounded overflow-hidden">
-    <video src={`${import.meta.env.BASE_URL}videos/figma-all-speed.mp4`} controls class="w-full"></video>
+    <video src={`${import.meta.env.BASE_URL}/videos/figma-all-speed.mp4`} controls class="w-full"></video>
     <div class="p-3 bg-gray-50">
       <h4 class="font-semibold text-brand-900">See It in Action</h4>
       <p class="text-sm text-[#4a4a5a]">/dx-figma-all running end to end — extract, prototype, verify — in a single conversation.</p>
@@ -229,11 +229,11 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <div class="grid md:grid-cols-2 gap-4 mt-4">
       <div>
         <p class="text-xs font-semibold text-[#7a7a8a] uppercase mb-1">AEM Component Dialog</p>
-        <img src={`${import.meta.env.BASE_URL}images/aem/aem-dialog.png`} alt="AEM Component Dialog" class="rounded border border-gray-200 w-full" />
+        <img src={`${import.meta.env.BASE_URL}/images/aem/aem-dialog.png`} alt="AEM Component Dialog" class="rounded border border-gray-200 w-full" />
       </div>
       <div>
         <p class="text-xs font-semibold text-[#7a7a8a] uppercase mb-1">AEM Rendered Page</p>
-        <img src={`${import.meta.env.BASE_URL}images/aem/aem-page.png`} alt="AEM Rendered Page" class="rounded border border-gray-200 w-full" />
+        <img src={`${import.meta.env.BASE_URL}/images/aem/aem-page.png`} alt="AEM Rendered Page" class="rounded border border-gray-200 w-full" />
       </div>
     </div>
   </ContentCard>

--- a/website/src/pages/demo/long.mdx
+++ b/website/src/pages/demo/long.mdx
@@ -89,11 +89,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/dor-comment-real-example.png`} alt="DoR Check Comment in ADO" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/dor-comment-real-example.png`} alt="DoR Check Comment in ADO" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">DoR Check Comment in ADO</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/ado-development-plan-team-share.png`} alt="Development Plan -- Team Share in ADO" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/ado-development-plan-team-share.png`} alt="Development Plan -- Team Share in ADO" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">Development Plan -- Team Share in ADO</p>
     </div>
   </div>
@@ -143,11 +143,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/aem-real-page-configured-component.png`} alt="AEM Page -- Component Dialog & Rendered Page" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/aem-real-page-configured-component.png`} alt="AEM Page -- Component Dialog & Rendered Page" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">AEM Page -- Component Dialog & Rendered Page</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/figma-prototype.png`} alt="Figma Source vs Generated Prototype" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/figma-prototype.png`} alt="Figma Source vs Generated Prototype" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">Figma Source vs Generated Prototype</p>
     </div>
   </div>
@@ -212,11 +212,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/pr-review-with-patch.png`} alt="PR Review -- Inline Code Patch" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/pr-review-with-patch.png`} alt="PR Review -- Inline Code Patch" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">PR Review -- Inline Code Patch</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/pr-review-follow-up.png`} alt="PR Review -- Follow-up Discussion" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/pr-review-follow-up.png`} alt="PR Review -- Follow-up Discussion" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">PR Review -- Follow-up Discussion</p>
     </div>
   </div>

--- a/website/src/pages/demo/short.mdx
+++ b/website/src/pages/demo/short.mdx
@@ -87,11 +87,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/dor-comment-real-example.png`} alt="DoR Check Comment in ADO" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/dor-comment-real-example.png`} alt="DoR Check Comment in ADO" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">DoR Check Comment in ADO</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/ado-development-plan-team-share.png`} alt="Development Plan -- Team Share in ADO" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/ado-development-plan-team-share.png`} alt="Development Plan -- Team Share in ADO" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">Development Plan -- Team Share in ADO</p>
     </div>
   </div>
@@ -129,11 +129,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/aem-real-page-configured-component.png`} alt="AEM Page -- Component Dialog & Rendered Page" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/aem-real-page-configured-component.png`} alt="AEM Page -- Component Dialog & Rendered Page" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">AEM Page -- Component Dialog & Rendered Page</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/figma-prototype.png`} alt="Figma Source vs Generated Prototype" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/figma-prototype.png`} alt="Figma Source vs Generated Prototype" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">Figma Source vs Generated Prototype</p>
     </div>
   </div>
@@ -166,11 +166,11 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-2 gap-4 mt-6">
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/pr-review-with-patch.png`} alt="PR Review -- Inline Code Patch" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/pr-review-with-patch.png`} alt="PR Review -- Inline Code Patch" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">PR Review -- Inline Code Patch</p>
     </div>
     <div class="border border-gray-200 rounded-lg overflow-hidden">
-      <img src={`${import.meta.env.BASE_URL}images/demo/pr-review-follow-up.png`} alt="PR Review -- Follow-up Discussion" class="w-full" />
+      <img src={`${import.meta.env.BASE_URL}/images/demo/pr-review-follow-up.png`} alt="PR Review -- Follow-up Discussion" class="w-full" />
       <p class="text-xs text-gray-500 text-center py-2">PR Review -- Follow-up Discussion</p>
     </div>
   </div>

--- a/website/src/pages/learn/tldr/[id].astro
+++ b/website/src/pages/learn/tldr/[id].astro
@@ -74,7 +74,7 @@ const { Content } = await render(tip);
     <!-- Screenshot -->
     {tip.data.screenshot && (
       <div class="mt-6">
-        <img src={`${import.meta.env.BASE_URL}${tip.data.screenshot}`} alt={`${tip.data.title} example`} class="rounded border border-gray-200 w-full" />
+        <img src={`${import.meta.env.BASE_URL}/${tip.data.screenshot}`} alt={`${tip.data.title} example`} class="rounded border border-gray-200 w-full" />
       </div>
     )}
 


### PR DESCRIPTION
## Summary
- Fixed 19 broken image/video URLs across 4 website files
- `${import.meta.env.BASE_URL}images/...` → `${import.meta.env.BASE_URL}/images/...`
- Without the slash, URLs resolve to `/dx-aem-flowimages/...` instead of `/dx-aem-flow/images/...`

## Files changed
- `website/src/pages/demo/short.mdx` (6 fixes)
- `website/src/pages/demo/long.mdx` (6 fixes)
- `website/src/pages/demo/figma.mdx` (6 image + 1 video fix)
- `website/src/pages/learn/tldr/[id].astro` (1 fix)

## Test plan
- [ ] Verify images load on deployed site demo pages
- [ ] Check `/demo/short/`, `/demo/long/`, `/demo/figma/` pages