### PR TITLE
docs(website): update skill references and counts for simplification refactor

### DIFF
--- a/website/src/content/tips/agent-model-tiering-cost-vs-quality.md
+++ b/website/src/content/tips/agent-model-tiering-cost-vs-quality.md
@@ -3,7 +3,7 @@ title: "Agent Model Tiering: Cost vs Quality"
 category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Opus","Sonnet","Haiku","Cost"]
-overview: "Every agent gets exactly the model it needs — no more, no less. Our code reviewer uses Opus ($15/M tokens) because judgment quality matters. Our step executor uses Sonnet ($3/M tokens) for implementation. Our file resolver uses Haiku ($0.25/M tokens) for speed. Wrong tier = wasted money or poor quality."
+overview: "Every agent gets exactly the model it needs — no more, no less. Our code reviewer uses Opus ($15/M tokens) because judgment quality matters. Our PR reviewer uses Sonnet ($3/M tokens) for implementation. Our file resolver uses Haiku ($0.25/M tokens) for speed. Wrong tier = wasted money or poor quality."
 codeLabel: "Our model distribution"
 screenshot: null
 week: 5
@@ -12,19 +12,19 @@ order: 23
 slackText: |
   🤖 Agentic AI Tip #23 — Agent Model Tiering: Cost vs Quality
   
-  We run 13 agents across 3 plugins. Only ONE uses Opus. Here's why.
+  We run 12 agents across 4 plugins. Only ONE uses Opus. Here's why.
   
   *Opus ($15/M tokens) — 1 agent:*
   `dx-code-reviewer` — Reviews code with confidence scoring. Needs deep reasoning to distinguish real bugs from style preferences. Worth the cost because a bad review wastes more human time than the tokens cost.
   
-  *Sonnet ($3/M tokens) — 8 agents:*
-  `dx-pr-reviewer`, `dx-step-executor`, `aem-inspector`, etc. — These need good judgment AND they need to take actions (read files, run commands, edit code). Sonnet is the sweet spot.
+  *Sonnet ($3/M tokens) — 7 agents:*
+  `dx-pr-reviewer`, `aem-inspector`, `aem-demo-capture`, etc. — These need good judgment AND they need to take actions (read files, run commands, edit code). Sonnet is the sweet spot.
   
   *Haiku ($0.25/M tokens) — 4 agents:*
   `dx-file-resolver`, `dx-doc-searcher`, `aem-file-resolver`, `aem-page-finder` — Pure lookups. "Find files matching this pattern." No reasoning needed, just fast execution.
   
   *The math:*
-  If a pipeline spawns all 13 agents, using Opus for all of them costs ~60x more than our tiered approach. For a team running 50 pipelines/day, that's the difference between $500/month and $30,000/month.
+  If a pipeline spawns all 12 agents, using Opus for all of them costs ~60x more than our tiered approach. For a team running 50 pipelines/day, that's the difference between $500/month and $30,000/month.
   
   💡 Try it: Review your agent definitions. Is any agent using a model tier higher than it needs?
   
@@ -32,11 +32,11 @@ slackText: |
 ---
 
 ```
-# 13 agents across 3 plugins:
+# 12 agents across 4 plugins:
 # Opus (1):  dx-code-reviewer
-# Sonnet (8): dx-pr-reviewer,
-#   dx-step-executor, aem-inspector,
-#   aem-demo-capture, aem-bug-executor,
+# Sonnet (7): dx-pr-reviewer,
+#   aem-inspector, aem-demo-capture,
+#   aem-bug-executor, aem-fe-verifier,
 #   dx-figma-markup, dx-figma-styles
 # Haiku (4):  dx-file-resolver,
 #   dx-doc-searcher, aem-file-resolver,

--- a/website/src/content/tips/argument-hint-making-skills-discoverable.md
+++ b/website/src/content/tips/argument-hint-making-skills-discoverable.md
@@ -3,7 +3,7 @@ title: "argument-hint: Making Skills Discoverable"
 category: "Skills — Advanced"
 focus: "Claude Code · CLI"
 tags: ["argument-hint","Autocomplete","UX"]
-overview: 'When you type / in Claude Code, you see a list of skills. The argument-hint field tells users what to pass before they even read the docs. "/dx-req-fetch <ticket-id>" is instantly clear. Without it, users have to guess what the skill expects.'
+overview: 'When you type / in Claude Code, you see a list of skills. The argument-hint field tells users what to pass before they even read the docs. "/dx-req <ticket-id>" is instantly clear. Without it, users have to guess what the skill expects.'
 codeLabel: "UX difference"
 screenshot: null
 week: 4

--- a/website/src/content/tips/chaining-skills-building-pipelines.md
+++ b/website/src/content/tips/chaining-skills-building-pipelines.md
@@ -3,7 +3,7 @@ title: "Chaining Skills: Building Pipelines"
 category: "Skills — Advanced"
 focus: "Claude Code"
 tags: ["Pipeline","Chaining","Workflow"]
-overview: "Individual skills are building blocks. The real power comes from chaining them into pipelines. fetch → explain → research → plan → execute → verify → PR. Each step reads the previous step's output. You can run the full pipeline or any individual step."
+overview: "Individual skills are building blocks. The real power comes from chaining them into pipelines. req → plan → execute → verify → PR. Each step reads the previous step's output. You can run the full pipeline or any individual step."
 codeLabel: "Complete pipeline"
 screenshot: null
 week: 4
@@ -15,20 +15,17 @@ slackText: |
   Individual skills are useful. Chained skills are transformative.
   
   Here's a real pipeline that takes a ticket from ADO to a pull request:
-  
+
   ```
-  /dx-req-fetch 12345     → fetches the story
-  /dx-req-explain         → distills dev requirements
-  /dx-req-research        → finds affected files
+  /dx-req 12345           → full requirements pipeline (fetch, DoR, explain, research, share)
   /dx-plan                → generates implementation plan
   /dx-step                → executes step 1
   /dx-step                → executes step 2...
   /dx-step-verify         → 6-phase verification
   /dx-pr                  → creates the pull request
   ```
-  
+
   *Key insight:* You don't have to run the full pipeline. Each skill is independent:
-  • Already know the requirements? Skip `/dx-req-explain`
   • Want to code manually? Skip `/dx-step`, just use `/dx-plan` as a guide
   • Already coded? Jump straight to `/dx-step-verify`
   
@@ -43,9 +40,7 @@ slackText: |
 
 ```
 # Full pipeline for a feature:
-/dx-req-fetch 12345
-/dx-req-explain
-/dx-req-research
+/dx-req 12345     # full requirements pipeline
 /dx-plan
 /dx-step          # execute step 1
 /dx-step          # execute step 2

--- a/website/src/content/tips/consumer-sync-one-source-many-projects.md
+++ b/website/src/content/tips/consumer-sync-one-source-many-projects.md
@@ -15,7 +15,7 @@ slackText: |
   Building a plugin is half the battle. Distributing it across multiple projects is the other half.
   
   *Our setup:*
-  • 3 plugins developed in one source location
+  • 4 plugins developed in one source location
   • 4 consumer repos that use these plugins
   • A sync script that handles distribution
   
@@ -26,13 +26,14 @@ slackText: |
   • Reporting what changed
   
   *The version bump trap:*
-  When bumping plugin versions, you must update 4 files:
+  When bumping plugin versions, you must update 5 files:
   1. `dx-core/plugin.json`
-  2. `dx-aem/plugin.json`
-  3. `dx-automation/plugin.json`
-  4. `.claude-plugin/marketplace.json` (consumer repo root)
+  2. `dx-hub/plugin.json`
+  3. `dx-aem/plugin.json`
+  4. `dx-automation/plugin.json`
+  5. `.claude-plugin/marketplace.json` (consumer repo root)
   
-  Miss #4 and the consumer repo thinks it has an old version. This causes "already up to date" messages when you try to reinstall.
+  Miss #5 and the consumer repo thinks it has an old version. This causes "already up to date" messages when you try to reinstall.
   
   *Lessons learned:*
   • Always read the consumer's local config before applying changes — branch names, paths, and feature flags vary per project
@@ -45,11 +46,12 @@ slackText: |
 ---
 
 ```
-# Version lives in 4 files:
+# Version lives in 5 files:
 # 1. dx-core/plugin.json
-# 2. dx-aem/plugin.json
-# 3. dx-automation/plugin.json
-# 4. .claude-plugin/marketplace.json
+# 2. dx-hub/plugin.json
+# 3. dx-aem/plugin.json
+# 4. dx-automation/plugin.json
+# 5. .claude-plugin/marketplace.json
 
 # Sync to consumers:
 ./scripts/sync-consumers.sh

--- a/website/src/content/tips/file-convention-over-data-passing.md
+++ b/website/src/content/tips/file-convention-over-data-passing.md
@@ -18,9 +18,9 @@ slackText: |
   
   ```
   .ai/specs/<ticket-id>-<slug>/
-  ├── raw-story.md      ← /dx-req-fetch writes this
-  ├── explain.md        ← /dx-req-explain reads raw-story, writes this
-  ├── research.md       ← /dx-req-research reads explain, writes this
+  ├── raw-story.md      ← /dx-req writes this (Phase 1: fetch)
+  ├── explain.md        ← /dx-req writes this (Phase 3: explain)
+  ├── research.md       ← /dx-req writes this (Phase 4: research)
   ├── implement.md      ← /dx-plan reads all above, writes this
   └── figma-extract.md  ← /dx-figma-extract writes this
   ```
@@ -33,18 +33,16 @@ slackText: |
   
   *No APIs, no return values, no coupling.* Skills find each other's output by convention. This is the same principle as Unix pipes — small tools, predictable I/O.
   
-  💡 Try it: Run `/dx-req-fetch <id>` then look inside `.ai/specs/`. Read the files. You'll see exactly what the AI captured.
+  💡 Try it: Run `/dx-req <id>` then look inside `.ai/specs/`. Read the files. You'll see exactly what the AI captured.
   
   #AgenticAI #Day19
 ---
 
 ```
-# /dx-req-fetch writes:
+# /dx-req writes all phases:
 .ai/specs/12345-login-bug/raw-story.md
-
-# /dx-req-explain reads raw-story.md,
-# writes:
 .ai/specs/12345-login-bug/explain.md
+.ai/specs/12345-login-bug/research.md
 
 # /dx-plan reads explain.md, writes:
 .ai/specs/12345-login-bug/implement.md

--- a/website/src/content/tips/maxturns-the-agent-safety-net.md
+++ b/website/src/content/tips/maxturns-the-agent-safety-net.md
@@ -51,7 +51,7 @@ maxTurns: 15    # simple lookup
 ---
 
 ---
-name: dx-step-executor
+name: dx-pr-reviewer
 model: sonnet
 maxTurns: 50    # complex implementation
 ---

--- a/website/src/content/tips/multi-provider-ado-jira.md
+++ b/website/src/content/tips/multi-provider-ado-jira.md
@@ -49,7 +49,7 @@ tracker:
 # if jira → use mcp__atlassian__*
 
 # Same skill, different backend:
-/dx-req-fetch 12345
+/dx-req 12345
 # → ADO: mcp__ado__wit_get_work_item
 # → Jira: mcp__atlassian__get_issue
 ```

--- a/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
+++ b/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
@@ -3,7 +3,7 @@ title: "Plugin = Skills + Agents + Hooks in a Box"
 category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Plugin","Bundle","Reusable"]
-overview: "A plugin bundles skills, agents, hooks, MCP configs, and rules into a single installable package. Install once, available in every project. Our three plugins (dx-core, dx-aem, dx-automation) contain 74 skills, 13 agents, and 4 hooks — all distributed from a single source."
+overview: "A plugin bundles skills, agents, hooks, MCP configs, and rules into a single installable package. Install once, available in every project. Our four plugins (dx-core, dx-hub, dx-aem, dx-automation) contain 69 skills, 12 agents, and 4 hooks — all distributed from a single source."
 codeLabel: "Plugin anatomy"
 screenshot: null
 week: 8
@@ -30,8 +30,9 @@ slackText: |
   5. *Updateable* — bump version, sync to all projects
   
   *Our setup:*
-  Three plugins, 74 skills, 13 agents, distributed to 4 consumer repos:
+  Four plugins, 69 skills, 12 agents, distributed to 4 consumer repos:
   • `dx-core` — universal development workflow
+  • `dx-hub` — multi-repo hub orchestration
   • `dx-aem` — AEM-specific tools
   • `dx-automation` — autonomous CI/CD agents
   
@@ -47,7 +48,7 @@ dx-core/
 │   └── plugin.json    # manifest
 ├── .mcp.json          # MCP servers
 ├── hooks/hooks.json   # hooks
-├── skills/            # 53 skills
-├── agents/            # 7 agents
+├── skills/            # 43 skills
+├── agents/            # 6 agents
 └── rules/             # path-scoped rules
 ```

--- a/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
+++ b/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
@@ -3,7 +3,7 @@ title: "Terminal Agents: Claude Code vs Copilot CLI"
 category: "Meet Your AI Tools"
 focus: "Claude Code · CLI"
 tags: ["Claude Code","Copilot CLI","Terminal"]
-overview: "Both Claude Code and Copilot CLI are terminal-native autonomous agents. Claude Code has 1M token context, worktree isolation, and persistent memory. Copilot CLI (GA Feb 2026) has /fleet for parallel subagents, multi-model support (Claude + GPT + Gemini), and cloud delegation. Same 78 skills run in both."
+overview: "Both Claude Code and Copilot CLI are terminal-native autonomous agents. Claude Code has 1M token context, worktree isolation, and persistent memory. Copilot CLI (GA Feb 2026) has /fleet for parallel subagents, multi-model support (Claude + GPT + Gemini), and cloud delegation. Same 69 skills run in both."
 codeLabel: "Two terminal agents"
 screenshot: null
 week: 1
@@ -12,7 +12,7 @@ order: 3
 slackText: |
   🤖 Agentic AI Tip #3 — Terminal Agents: Claude Code vs Copilot CLI
   
-  Both are terminal-native agents. Both run our 78 skills. But they have distinct superpowers:
+  Both are terminal-native agents. Both run our 69 skills. But they have distinct superpowers:
   
   *Claude Code:*
   • 1M token context (8x more than Copilot CLI)

--- a/website/src/content/tips/the-coordinator-pattern.md
+++ b/website/src/content/tips/the-coordinator-pattern.md
@@ -43,14 +43,11 @@ disable-model-invocation: true
 ---
 
 # Step 1: Extract
-Invoke dx-step-executor:
-  "Execute dx-figma-extract"
+Invoke Skill("dx-figma-extract")
 
 # Step 2: Prototype
-Invoke dx-step-executor:
-  "Execute dx-figma-prototype"
+Invoke Skill("dx-figma-prototype")
 
 # Step 3: Verify
-Invoke dx-step-executor:
-  "Execute dx-figma-verify"
+Invoke Skill("dx-figma-verify")
 ```

--- a/website/src/content/tips/the-spec-directory-convention.md
+++ b/website/src/content/tips/the-spec-directory-convention.md
@@ -45,11 +45,11 @@ slackText: |
 
 ```
 .ai/specs/12345-login-bug/
-├── raw-story.md       # /dx-req-fetch
-├── explain.md         # /dx-req-explain
-├── research.md        # /dx-req-research
+├── raw-story.md       # /dx-req (Phase 1)
+├── explain.md         # /dx-req (Phase 3)
+├── research.md        # /dx-req (Phase 4)
 ├── implement.md       # /dx-plan
-├── share-plan.md      # /dx-req-share
+├── share-plan.md      # /dx-req (Phase 5)
 ├── dod.md             # /dx-req-dod
 ├── figma-extract.md   # /dx-figma-extract
 └── prototype/         # /dx-figma-prototype

--- a/website/src/content/tips/your-plugin-journey-zero-to-production.md
+++ b/website/src/content/tips/your-plugin-journey-zero-to-production.md
@@ -12,7 +12,7 @@ order: 51
 slackText: |
   🤖 Agentic AI Tip #51 — Your Plugin Journey: Zero to Production
   
-  You've made it to Day 50! Here's the meta-lesson from building 74 skills across 3 plugins.
+  You've made it to Day 50! Here's the meta-lesson from building 69 skills across 4 plugins.
   
   *Don't plan a plugin. Grow one.*
   

--- a/website/src/pages/architecture/automation.mdx
+++ b/website/src/pages/architecture/automation.mdx
@@ -62,7 +62,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
       title="PR Answerer"
       tags={[{ label: 'PR comment', color: 'primary' }, { label: 'webhook', color: 'secondary' }]}
     >
-      Webhook on PR comment. Runs <code>/dx-pr-answer</code> + <code>/dx-pr-fix</code> -- researches
+      Webhook on PR comment. Runs <code>/dx-pr-answer</code> -- researches
       codebase, drafts replies, and applies agreed fixes automatically.
     </ContentCard>
   </div>
@@ -97,7 +97,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
       icon="mdi:wrench"
       iconColor="bg-emerald-600"
       title="DoD Fixer"
-      tags={[{ label: 'KAI-DOD-FIX-AUTOMATION', color: 'success' }, { label: '/dx-req-dod-fix', color: 'secondary' }]}
+      tags={[{ label: 'KAI-DOD-FIX-AUTOMATION', color: 'success' }, { label: '/dx-req-dod', color: 'secondary' }]}
     >
       Fixes DoD gaps found by the checker -- adds missing tests, docs, or acceptance criteria evidence.
     </ContentCard>

--- a/website/src/pages/architecture/cross-agent.mdx
+++ b/website/src/pages/architecture/cross-agent.mdx
@@ -97,7 +97,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <td class="p-3">ADO PR review with comment posting</td>
       </tr>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>dx-step-executor</code></td>
+        <td class="p-3">(direct Skill() invocation)</td>
         <td class="p-3">DxPlanExecutor</td>
         <td class="p-3">Execute implementation plan steps</td>
       </tr>

--- a/website/src/pages/architecture/cross-repo.mdx
+++ b/website/src/pages/architecture/cross-repo.mdx
@@ -197,7 +197,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <td class="p-3"><code>research.md</code> &rarr; Cross-Repo Scope section</td>
       </tr>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>dx-req-dod-fix</code></td>
+        <td class="p-3"><code>dx-req-dod</code></td>
         <td class="p-3">After Step 1 (DoD read)</td>
         <td class="p-3"><code>research.md</code> &rarr; Cross-Repo Scope (if exists)</td>
       </tr>

--- a/website/src/pages/architecture/data-flow.mdx
+++ b/website/src/pages/architecture/data-flow.mdx
@@ -28,12 +28,12 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <CommandBlock>
 {`.ai/specs/<ticket-id>-<slug>/
   .branch                   -- ensure-feature-branch.sh
-  raw-story.md              -- dx-req-fetch
-  explain.md                -- dx-req-explain (reads: raw-story.md)
-  research.md               -- dx-req-research (reads: raw-story.md + explain.md)
+  raw-story.md              -- dx-req (Phase 1: fetch)
+  explain.md                -- dx-req (Phase 3: explain, reads: raw-story.md)
+  research.md               -- dx-req (Phase 4: research, reads: raw-story.md + explain.md)
   ticket-research.md        -- dx-ticket-analyze
-  share-plan.md             -- dx-req-share (reads: explain + research + dor-report)
-  dor-report.md             -- dx-req-dor (reads: raw-story.md)
+  share-plan.md             -- dx-req (Phase 5: share, reads: explain + research + dor-report)
+  dor-report.md             -- dx-req (Phase 2: DoR, reads: raw-story.md)
   figma-extract.md          -- dx-figma-extract (optional)
   figma-conventions.md      -- dx-figma-prototype Phase A (optional)
   prototype/
@@ -49,7 +49,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   demo/
     dialog-*.png            -- aem-demo
     authoring-guide.md      -- aem-demo
-  images/                   -- dx-req-fetch (ADO attachments)
+  images/                   -- dx-req (ADO attachments)
   screenshots/              -- dx-bug-verify (browser screenshots)`}
     </CommandBlock>
   </HighlightBox>
@@ -73,10 +73,10 @@ import CommandBlock from '../../components/CommandBlock.astro';
     label="Primary Pipeline"
     description="Main data flow from story fetch through to code delivery."
     steps={[
-      { title: 'raw-story.md', subtitle: 'dx-req-fetch', color: '#0891b2' },
-      { title: 'dor-report.md', subtitle: 'dx-req-dor', color: '#0891b2' },
-      { title: 'explain.md', subtitle: 'dx-req-explain', color: '#8b5cf6' },
-      { title: 'research.md', subtitle: 'dx-req-research', color: '#8b5cf6' },
+      { title: 'raw-story.md', subtitle: 'dx-req (fetch)', color: '#0891b2' },
+      { title: 'dor-report.md', subtitle: 'dx-req (DoR)', color: '#0891b2' },
+      { title: 'explain.md', subtitle: 'dx-req (explain)', color: '#8b5cf6' },
+      { title: 'research.md', subtitle: 'dx-req (research)', color: '#8b5cf6' },
       { title: 'implement.md', subtitle: 'dx-plan', color: '#d97706' },
       { title: 'Code Changes', subtitle: 'dx-step', color: '#059669' },
       { title: 'Pull Request', subtitle: 'dx-pr', color: '#059669' },
@@ -124,7 +124,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 **Why:** Expose component data as JSON
 **Test:** mvn test -pl core
 
-### Step 3h: Fix missing import          -- added by dx-step-heal
+### Step 3h: Fix missing import          -- added by dx-step-fix (escalation)
 **Status:** done
 **Files:** core/.../FooExporter.java
 **What:** Corrective fix for compilation error
@@ -176,7 +176,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       </tr>
       <tr class="border-t border-gray-200">
         <td class="p-3"><code>scm.org</code></td>
-        <td class="p-3">dx-req-fetch (ADO URLs)</td>
+        <td class="p-3">dx-req (ADO URLs)</td>
       </tr>
       <tr class="border-t border-gray-200">
         <td class="p-3"><code>build.command</code></td>

--- a/website/src/pages/architecture/learning.mdx
+++ b/website/src/pages/architecture/learning.mdx
@@ -27,7 +27,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <ContentCard icon="mdi:wrench" iconColor="bg-emerald-600" title="Self-Healing Loop">
       <strong>Scope:</strong> Per-session, per-step.
-      dx-step-fix and dx-step-heal recover from failures during execution.
+      dx-step-fix recovers from failures during execution (targeted fix + root cause escalation).
       Memory is lost after the session ends -- each run starts fresh.
     </ContentCard>
 
@@ -132,7 +132,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <ContentCard icon="mdi:wrench" iconColor="bg-emerald-600" title="1. Fix Pattern Memory">
       <strong>Storage:</strong> <code>fixes.md</code> + <code>fixes.jsonl</code>
-      <br />After every dx-step-fix or dx-step-heal, capture error type, message pattern, fix applied,
+      <br />After every dx-step-fix cycle, capture error type, message pattern, fix applied,
       and result. Before attempting a fix, dx-step-fix checks <code>fixes.md</code> for known patterns.
       If a strategy worked 3/3 times, try that first. Every 10 entries, <code>fixes.md</code> is regenerated.
     </ContentCard>

--- a/website/src/pages/architecture/overview.mdx
+++ b/website/src/pages/architecture/overview.mdx
@@ -18,15 +18,16 @@ import HighlightBox from '../../components/HighlightBox.astro';
 
 <SectionHeading
   badge="Plugins"
-  title="Three-Plugin Architecture"
-  subtitle="All skills, agents, and rules are organized into three self-contained plugins."
+  title="Four-Plugin Architecture"
+  subtitle="All skills, agents, and rules are organized into four self-contained plugins."
   bg="alt"
 />
 <Section>
   <HighlightBox severity="info" title="Plugin Directory Structure">
     <CommandBlock>
 {`dx-aem-flow/dx/plugins/
-  dx-core/   55 skills, 7 agents -- ADO/Jira workflow (any stack)
+  dx-core/   43 skills, 6 agents -- ADO/Jira workflow (any stack)
+  dx-hub/              3 skills -- multi-repo hub orchestration
   dx-aem/              12 skills, 6 agents -- AEM verification & QA
   dx-automation/       11 skills -- autonomous 24/7 agents`}
     </CommandBlock>
@@ -263,8 +264,8 @@ aem:
     </HighlightBox>
 
     <HighlightBox severity="error" title="Agent Type Naming">
-      Always use the full prefixed name: <code>dx-core:dx-step-executor</code>, NOT just
-      <code>dx-step-executor</code>. The short name fails with "Agent type not found".
+      Always use the full prefixed name: <code>dx-core:dx-code-reviewer</code>, NOT just
+      <code>dx-code-reviewer</code>. The short name fails with "Agent type not found".
     </HighlightBox>
 
     <HighlightBox severity="success" title="Fork Auto-Isolation">
@@ -452,12 +453,6 @@ aem:
     </thead>
     <tbody>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>dx-step-executor</code></td>
-        <td class="p-3">Sonnet</td>
-        <td class="p-3"><code>coordinators</code></td>
-        <td class="p-3">Execute single skill</td>
-      </tr>
-      <tr class="border-t border-gray-200">
         <td class="p-3"><code>dx-pr-reviewer</code></td>
         <td class="p-3">Sonnet</td>
         <td class="p-3"><code>/dx-pr-review</code></td>
@@ -572,7 +567,7 @@ aem:
       icon="mdi:wrench"
       iconColor="bg-cyan"
       title="Claude Code"
-      tags={[{ label: '78 skills', color: 'secondary' }, { label: '13 agents', color: 'secondary' }]}
+      tags={[{ label: '69 skills', color: 'secondary' }, { label: '13 agents', color: 'secondary' }]}
     >
       Full plugin system with MCP servers, subagents, hooks, and shared libraries.
     </ContentCard>
@@ -581,9 +576,9 @@ aem:
       icon="mdi:monitor"
       iconColor="bg-brand-700"
       title="GitHub Copilot CLI"
-      tags={[{ label: '78 skills', color: 'primary' }, { label: '25 agents', color: 'primary' }]}
+      tags={[{ label: '69 skills', color: 'primary' }, { label: '25 agents', color: 'primary' }]}
     >
-      Same 78 skills auto-discovered from plugins. 25 Copilot agents with <code>allowed-tools</code> for auto-approval
+      Same 69 skills auto-discovered from plugins. 25 Copilot agents with <code>allowed-tools</code> for auto-approval
       and <code>handoffs:</code> for navigation.
     </ContentCard>
   </div>
@@ -712,9 +707,9 @@ aem:
 />
 <Section>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="Three Plugins, One Repo">
-      Three independently installable plugins in a single monorepo. Non-AEM projects only need
-      <code>dx-core</code>; AEM projects add <code>dx-aem</code>; any project wanting
+    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="Four Plugins, One Repo">
+      Four independently installable plugins in a single monorepo. Non-AEM projects only need
+      <code>dx-core</code>; multi-repo projects add <code>dx-hub</code>; AEM projects add <code>dx-aem</code>; any project wanting
       24/7 autonomous agents adds <code>dx-automation</code>. Single repo simplifies maintenance.
     </ContentCard>
 
@@ -724,10 +719,9 @@ aem:
       a config lookup makes skills reusable across any project.
     </ContentCard>
 
-    <ContentCard icon="mdi:merge" iconColor="bg-emerald-600" title="Merged Step Executors">
-      <code>ado-step-executor</code> and <code>bug-step-executor</code> merged into one
-      <code>dx-step-executor</code>. Both did the same thing -- receive a skill name, execute it,
-      return a compact summary. Merging eliminates duplication.
+    <ContentCard icon="mdi:merge" iconColor="bg-emerald-600" title="Direct Skill Invocation">
+      Coordinators invoke skills directly via <code>Skill()</code> calls instead of routing through
+      an intermediary executor agent. Simpler architecture, fewer context switches, lower token cost.
     </ContentCard>
 
     <ContentCard icon="mdi:layers" iconColor="bg-amber-500" title="Three-Layer Override System">

--- a/website/src/pages/architecture/self-healing.mdx
+++ b/website/src/pages/architecture/self-healing.mdx
@@ -28,8 +28,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
     label="Recovery Layers"
     description="Escalation path from first-responder fix to deep healing to coordinator retry."
     steps={[
-      { title: 'Layer 1', subtitle: 'dx-step-fix\nOne-shot fixer', color: '#059669' },
-      { title: 'Layer 2', subtitle: 'dx-step-heal\nDeep analysis', color: '#d97706' },
+      { title: 'Layer 1', subtitle: 'dx-step-fix\nTargeted fix', color: '#059669' },
+      { title: 'Layer 2', subtitle: 'dx-step-fix\nEscalation (root cause)', color: '#d97706' },
       { title: 'Layer 3', subtitle: 'Coordinator\nRetry loop', color: '#dc2626' },
     ]}
   />
@@ -40,14 +40,14 @@ import CommandBlock from '../../components/CommandBlock.astro';
       report success or failure. No refactoring, no exploration.
     </ContentCard>
 
-    <ContentCard icon="mdi:medical-bag" iconColor="bg-amber-500" title="Layer 2: dx-step-heal">
-      Triggered after 2 consecutive fix failures. Uses extended thinking (ultrathink) for deep
-      root-cause analysis. Creates corrective steps with a DIFFERENT approach.
+    <ContentCard icon="mdi:medical-bag" iconColor="bg-amber-500" title="Layer 2: dx-step-fix (escalation)">
+      Triggered after 2 consecutive fix failures. dx-step-fix escalates to root cause analysis using extended thinking (ultrathink).
+      Creates corrective steps with a DIFFERENT approach.
     </ContentCard>
 
     <ContentCard icon="mdi:refresh" iconColor="bg-red-500" title="Layer 3: Coordinator">
       The coordinator loop (dx-step-all, dx-agent-all) orchestrates the retry cadence: fix, fix,
-      heal, execute corrective steps, repeat up to 2 healing cycles.
+      escalate, execute corrective steps, repeat up to 2 escalation cycles.
     </ContentCard>
   </div>
 </Section>
@@ -85,7 +85,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 <SectionHeading
   badge="Layer 2"
   badgeColor="warning"
-  title="dx-step-heal -- Deep Root-Cause Analysis"
+  title="dx-step-fix (escalation) -- Deep Root-Cause Analysis"
   subtitle="After 2 consecutive fix failures, the healer takes over with extended thinking and a fundamentally different approach."
   bg="alt"
 />
@@ -137,7 +137,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       { title: 'Execute', subtitle: 'dx-step\nRun step', color: '#059669' },
       { title: 'Fix #1', subtitle: 'dx-step-fix\nFirst attempt', color: '#d97706' },
       { title: 'Fix #2', subtitle: 'dx-step-fix\nSecond attempt', color: '#d97706' },
-      { title: 'Heal #1', subtitle: 'dx-step-heal\nNew strategy', color: '#dc2626' },
+      { title: 'Heal #1', subtitle: 'dx-step-fix (escalation)\nNew strategy', color: '#dc2626' },
       { title: 'Execute', subtitle: 'Corrective\nsteps', color: '#059669' },
       { title: 'Heal #2', subtitle: 'Last resort\nor STOP', color: '#dc2626' },
     ]}
@@ -149,7 +149,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <strong>Execution failures:</strong>
         <ul class="mt-1 text-sm">
           <li>2 fix attempts (dx-step-fix)</li>
-          <li>2 healing cycles (dx-step-heal)</li>
+          <li>2 healing cycles (dx-step-fix (escalation))</li>
           <li>Each healing cycle: corrective step + 2 more fix attempts</li>
           <li>Total: up to 6 fix attempts + 2 heal analyses</li>
         </ul>
@@ -158,7 +158,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <strong>Code review failures:</strong>
         <ul class="mt-1 text-sm">
           <li>3 review-fix cycles (dx-step-verify)</li>
-          <li>2 healing cycles (dx-step-heal in coordinator)</li>
+          <li>2 healing cycles (dx-step-fix (escalation) in coordinator)</li>
           <li>Each healing: corrective steps + rebuild + re-review</li>
           <li>Total: up to 9 review cycles</li>
         </ul>
@@ -281,7 +281,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <ContentCard icon="mdi:counter" iconColor="bg-brand-700" title="Per-Step Execution Failures">
       <ul class="text-sm space-y-1 mt-2">
         <li>2 fix attempts (dx-step-fix)</li>
-        <li>2 healing cycles (dx-step-heal)</li>
+        <li>2 healing cycles (dx-step-fix (escalation))</li>
         <li>Each healing cycle: new corrective step + 2 more fix attempts</li>
         <li><strong>Total: up to 6 fix attempts + 2 heal analyses</strong></li>
       </ul>
@@ -290,7 +290,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <ContentCard icon="mdi:counter" iconColor="bg-cyan-dark" title="Code Review Failures">
       <ul class="text-sm space-y-1 mt-2">
         <li>3 review-fix cycles (dx-step-verify)</li>
-        <li>2 healing cycles (dx-step-heal in coordinator)</li>
+        <li>2 healing cycles (dx-step-fix (escalation) in coordinator)</li>
         <li>Each healing: corrective steps + rebuild + re-review</li>
         <li><strong>Total: up to 9 review cycles</strong></li>
       </ul>

--- a/website/src/pages/contributing/authoring.mdx
+++ b/website/src/pages/contributing/authoring.mdx
@@ -80,7 +80,7 @@ disable-model-invocation: false   # Optional. Prevent auto-invocation
   </div>
 
   <HighlightBox severity="warning" title="$ARGUMENTS">
-    <code>$ARGUMENTS</code> is replaced with whatever the user typed after the command. Example: <code>/dx-req-fetch 2416553</code> sets <code>$ARGUMENTS = "2416553"</code>.
+    <code>$ARGUMENTS</code> is replaced with whatever the user typed after the command. Example: <code>/dx-req 2416553</code> sets <code>$ARGUMENTS = "2416553"</code>.
   </HighlightBox>
 </Section>
 

--- a/website/src/pages/contributing/wiki-format.mdx
+++ b/website/src/pages/contributing/wiki-format.mdx
@@ -25,7 +25,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 <Section>
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:book-open" iconColor="bg-brand-700" title="Wiki as Config">
-      The <code>/dx-req-dor</code> and <code>/dx-req-dod</code> skills fetch criteria from ADO wiki pages configured in <code>.ai/config.yaml</code>. Editing the wiki page immediately changes what the skill checks -- no code changes needed.
+      The <code>/dx-req</code> and <code>/dx-req-dod</code> skills fetch criteria from ADO wiki pages configured in <code>.ai/config.yaml</code>. Editing the wiki page immediately changes what the skill checks -- no code changes needed.
     </ContentCard>
     <ContentCard icon="mdi:cog" iconColor="bg-cyan" title="Config Keys">
       <CommandBlock>{`scm:

--- a/website/src/pages/demo/figma.mdx
+++ b/website/src/pages/demo/figma.mdx
@@ -31,8 +31,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
       iconColor="bg-brand-700"
       title="dx-core"
       tags={[
-        { label: '55 skills' },
-        { label: '7 agents', color: 'secondary' },
+        { label: '43 skills' },
+        { label: '6 agents', color: 'secondary' },
         { label: 'Figma + ADO/Jira MCP', color: 'success' },
       ]}
     >
@@ -128,8 +128,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
   </CommandBlock>
 
   <HighlightBox severity="warning" title="Multi-Agent Orchestration Under the Hood">
-    The coordinator dispatches a <code>dx-step-executor</code> subagent for each phase — a composable
-    microservice pattern applied to AI agents. Each subagent runs in its own isolated context window,
+    The coordinator invokes each phase skill directly via Skill() calls — a composable
+    pattern applied to AI agents. Each skill runs in its own isolated context window,
     performing deep repository intelligence without polluting the orchestrator's context. Only a compact
     summary propagates upward. This is <strong>context engineering</strong> in practice.
   </HighlightBox>

--- a/website/src/pages/demo/guide.mdx
+++ b/website/src/pages/demo/guide.mdx
@@ -110,8 +110,8 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <ContentCard icon="mdi:code-tags" iconColor="bg-emerald-600" title="4. Execute One Step">
       Run /dx-step to execute a single step. Show code changes.
     </ContentCard>
-    <ContentCard icon="mdi:sync" iconColor="bg-cyan-dark" title="5. Test/Review/Commit">
-      Show the /dx-step-test, /dx-step-review, /dx-step-commit loop.
+    <ContentCard icon="mdi:sync" iconColor="bg-cyan-dark" title="5. Verify & Commit">
+      Show /dx-step-verify and /dx-pr-commit -- the verification and commit loop.
     </ContentCard>
     <ContentCard icon="mdi:lightning-bolt" iconColor="bg-red-500" title="6. Automation Preview">
       Show ADO/Jira pipeline triggers, PR review bot, webhook flow.
@@ -201,9 +201,8 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
   <CommandBlock label="/dx-req-all">/dx-req-all &lt;Story-ID&gt;</CommandBlock>
   <CommandBlock label="/dx-plan">/dx-plan</CommandBlock>
   <CommandBlock label="/dx-step">/dx-step</CommandBlock>
-  <CommandBlock label="/dx-step-test">/dx-step-test</CommandBlock>
-  <CommandBlock label="/dx-step-review">/dx-step-review</CommandBlock>
-  <CommandBlock label="/dx-step-commit">/dx-step-commit</CommandBlock>
+  <CommandBlock label="/dx-step-verify">/dx-step-verify</CommandBlock>
+  <CommandBlock label="/dx-pr-commit">/dx-pr-commit</CommandBlock>
   <CommandBlock label="/dx-step-build">/dx-step-build</CommandBlock>
   <CommandBlock label="/dx-pr-review">/dx-pr-review &lt;PR-URL&gt;</CommandBlock>
   <CommandBlock label="/dx-bug-triage">/dx-bug-triage &lt;Bug-ID&gt;</CommandBlock>

--- a/website/src/pages/demo/long.mdx
+++ b/website/src/pages/demo/long.mdx
@@ -297,7 +297,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     </div>
     <div class="border border-brand-700 rounded-lg p-5 bg-white h-full">
       <h3 class="text-base font-semibold text-brand-900 mb-1">Layer 2: Local Workflow (Claude Code + Copilot CLI)</h3>
-      <p class="text-sm text-gray-500">78 skills on both IDEs -- requirements, planning, execution, review, PR</p>
+      <p class="text-sm text-gray-500">69 skills on both IDEs -- requirements, planning, execution, review, PR</p>
     </div>
     <div class="border border-emerald-600 rounded-lg p-5 bg-white h-full">
       <h3 class="text-base font-semibold text-brand-900 mb-1">Layer 1: Foundation</h3>
@@ -307,8 +307,8 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
   <div class="grid md:grid-cols-3 gap-4 mt-6">
     <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="Plugin System" horizontal>
-      3 plugins, each independently installable. dx-core (55 skills, 7 agents),
-      dx-aem (12 skills, 6 agents), dx-automation (11 skills, 10 pipeline agents).
+      4 plugins, each independently installable. dx-core (43 skills, 6 agents),
+      dx-hub (3 skills), dx-aem (12 skills, 6 agents), dx-automation (11 skills, 10 pipeline agents).
     </ContentCard>
     <ContentCard icon="mdi:earth" iconColor="bg-cyan-dark" title="Live MCP Integrations" horizontal>
       Connected to AEM, Chrome DevTools, Figma, ADO, Jira/Confluence, axe. Agents query live systems --
@@ -360,7 +360,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
       Runs daily across multiple projects. DevAgent implements real stories. QA agent files real bugs. Production infrastructure.
     </ContentCard>
     <ContentCard icon="mdi:puzzle" iconColor="bg-cyan-dark" title="Project-Agnostic" horizontal>
-      3 plugins, independently installable. AEM logic stays in its own plugin. Works with any tech stack across connected multi repos.
+      4 plugins, independently installable. AEM logic stays in its own plugin. Works with any tech stack across connected multi repos.
     </ContentCard>
   </div>
 </Section>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -14,13 +14,13 @@ export const base = import.meta.env.BASE_URL;
 
 <PageHero
   title="AI-Powered Development Platform"
-  subtitle="From ticket to production -- how AI transforms sprint delivery with 78 skills, 10 autonomous agents, and self-learning capabilities across your entire development lifecycle."
+  subtitle="From ticket to production -- how AI transforms sprint delivery with 69 skills, 10 autonomous agents, and self-learning capabilities across your entire development lifecycle."
 />
 
 <Section>
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 text-center">
     <div>
-      <div class="text-4xl font-extrabold text-cyan">78</div>
+      <div class="text-4xl font-extrabold text-cyan">69</div>
       <div class="text-sm text-gray-500">Skills</div>
     </div>
     <div>
@@ -28,7 +28,7 @@ export const base = import.meta.env.BASE_URL;
       <div class="text-sm text-gray-500">Copilot Agents</div>
     </div>
     <div>
-      <div class="text-4xl font-extrabold text-cyan">3</div>
+      <div class="text-4xl font-extrabold text-cyan">4</div>
       <div class="text-sm text-gray-500">Plugins</div>
     </div>
     <div>
@@ -56,7 +56,7 @@ export const base = import.meta.env.BASE_URL;
     </div>
     <div class="border border-brand-700 rounded p-5 bg-white">
       <h3 class="text-[1.1rem] font-semibold text-[#1a1a2e] mb-1">Layer 2: Local Workflow (Claude Code + Copilot CLI)</h3>
-      <p class="text-[0.9rem] text-[#4a4a5a]">78 skills on both IDEs -- /dx-req-all, /dx-plan, /dx-step-all, /dx-pr</p>
+      <p class="text-[0.9rem] text-[#4a4a5a]">69 skills on both IDEs -- /dx-req-all, /dx-plan, /dx-step-all, /dx-pr</p>
     </div>
     <div class="border border-emerald-500 rounded p-5 bg-white">
       <h3 class="text-[1.1rem] font-semibold text-[#1a1a2e] mb-1">Layer 1: Foundation</h3>
@@ -164,7 +164,7 @@ export const base = import.meta.env.BASE_URL;
       { title: 'Review with Patch', subtitle: 'Inline code fix', command: '/dx-pr-review' },
       { title: 'Question Only', subtitle: 'Clarification needed', command: '/dx-pr-answer', color: '#0891b2' },
       { title: 'Lower Acceptance', subtitle: 'Reduced threshold', color: '#d97706' },
-      { title: 'Follow-up Comment', subtitle: 'Ongoing discussion', command: '/dx-pr-fix', color: '#059669' },
+      { title: 'Follow-up Comment', subtitle: 'Ongoing discussion', command: '/dx-pr-answer', color: '#059669' },
     ]}
   />
 </Section>
@@ -172,13 +172,13 @@ export const base = import.meta.env.BASE_URL;
 <SectionHeading
   badge="Plugins"
   badgeColor="success"
-  title="Three Plugins, Independently Installable"
+  title="Four Plugins, Independently Installable"
   subtitle="Non-AEM projects only need dx. AEM-specific logic never pollutes a pure frontend project."
   bg="primary"
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:wrench" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '55 skills' }, { label: '7 agents', color: 'secondary' }]}>
+    <ContentCard icon="mdi:wrench" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '43 skills' }, { label: '6 agents', color: 'secondary' }]}>
       Full development lifecycle -- requirements, planning, execution, review, PR, accessibility, documentation. Works with any stack.
     </ContentCard>
     <ContentCard icon="mdi:cube-outline" iconColor="bg-amber-500" title="dx-aem" tags={[{ label: '12 skills', color: 'warning' }, { label: '6 agents', color: 'secondary' }]}>
@@ -218,11 +218,11 @@ export const base = import.meta.env.BASE_URL;
   </div>
 
   <div class="grid md:grid-cols-2 gap-4 mt-4">
-    <ContentCard icon="mdi:wrench" iconColor="bg-cyan" title="Claude Code" tags={[{label: "78 skills", color: "secondary"}, {label: "13 agents", color: "secondary"}]}>
-      Run <code>/dx-*</code> skills directly in the terminal. 78 skills, 13 agents, full MCP integrations.
+    <ContentCard icon="mdi:wrench" iconColor="bg-cyan" title="Claude Code" tags={[{label: "69 skills", color: "secondary"}, {label: "13 agents", color: "secondary"}]}>
+      Run <code>/dx-*</code> skills directly in the terminal. 69 skills, 13 agents, full MCP integrations.
     </ContentCard>
-    <ContentCard icon="mdi:monitor" iconColor="bg-brand-700" title="GitHub Copilot CLI" tags={[{label: "78 skills", color: "primary"}, {label: "25 agents", color: "primary"}]}>
-      Same 78 skills + 25 Copilot agents with <code>@AgentName</code> invocation. Same plugins, same marketplace -- install once.
+    <ContentCard icon="mdi:monitor" iconColor="bg-brand-700" title="GitHub Copilot CLI" tags={[{label: "69 skills", color: "primary"}, {label: "25 agents", color: "primary"}]}>
+      Same 69 skills + 25 Copilot agents with <code>@AgentName</code> invocation. Same plugins, same marketplace -- install once.
     </ContentCard>
   </div>
 </Section>
@@ -368,8 +368,8 @@ export const base = import.meta.env.BASE_URL;
     <ContentCard icon="mdi:brain" iconColor="bg-brand-700" title="Subagents to Protect Context" horizontal>
       Heavy operations run in isolated subagents that return compact summaries. The coordinator's context window stays clean. Right model for the job.
     </ContentCard>
-    <ContentCard icon="mdi:lightning-bolt" iconColor="bg-emerald-600" title="Step Executor -- Skill Chaining Engine" horizontal>
-      One agent that can execute any of 41 skills. Coordinators chain skills in sequence. Self-healing with 3 layers: fix, heal, retry loop.
+    <ContentCard icon="mdi:lightning-bolt" iconColor="bg-emerald-600" title="Direct Skill Invocation -- No Middleman" horizontal>
+      Coordinators invoke skills directly via Skill() calls. No intermediary agent needed. Self-healing with 3 layers: fix, heal, retry loop.
     </ContentCard>
     <ContentCard icon="mdi:lock" iconColor="bg-red-500" title="Explicit Tool Allowlists" horizontal>
       Every agent declares exactly which tools it can use. A PR reviewer cannot run Bash. Optional tools are discovered at runtime via ToolSearch.
@@ -412,13 +412,13 @@ export const base = import.meta.env.BASE_URL;
   <HighlightBox severity="info" title="Beyond Anthropic's Official Skill Guide">
     <ul class="list-none p-0 m-0">
       <li class="py-0.5"><strong>Plugin architecture</strong> -- the guide has standalone skills; KAI has versioned, installable plugin packages with marketplace</li>
-      <li class="py-0.5"><strong>Coordinator + Step Executor</strong> -- the guide shows sequential orchestration; KAI chains 41 skills through a single executor agent with self-healing</li>
+      <li class="py-0.5"><strong>Coordinator + Direct Skill Invocation</strong> -- the guide shows sequential orchestration; KAI coordinators chain skills directly via Skill() calls with self-healing</li>
       <li class="py-0.5"><strong>Memory via files</strong> -- the guide mentions MCP data passing; KAI uses convention-based .md files that persist across sessions</li>
       <li class="py-0.5"><strong>Model tiering</strong> -- the guide doesn't address cost optimization per agent; KAI assigns Opus/Sonnet/Haiku per capability</li>
       <li class="py-0.5"><strong>Persona system</strong> -- not in the guide; KAI's me.md makes AI output indistinguishable from human teammates</li>
       <li class="py-0.5"><strong>Hooks for LLM offloading</strong> -- the guide focuses on skill instructions; KAI uses shell hooks for deterministic work</li>
       <li class="py-0.5"><strong>24/7 autonomous agents</strong> -- the guide covers interactive use; KAI runs the same skills unattended on ADO pipelines</li>
-      <li class="py-0.5"><strong>Dual-IDE support</strong> -- same 78 skills + shared marketplace work in both Claude Code and GitHub Copilot CLI</li>
+      <li class="py-0.5"><strong>Dual-IDE support</strong> -- same 69 skills + shared marketplace work in both Claude Code and GitHub Copilot CLI</li>
     </ul>
   </HighlightBox>
 

--- a/website/src/pages/learn/agents.mdx
+++ b/website/src/pages/learn/agents.mdx
@@ -129,11 +129,11 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <ContentCard
       icon="mdi:diamond-stone"
       iconColor="bg-amber-500"
-      title="dx-step-executor"
+      title="dx-pr-reviewer"
       tags={[{ label: 'Sonnet', color: 'warning' }]}
     >
-      Executes implementation plan steps. Has 22 preloaded skills and
-      <code>acceptEdits</code> permission for autonomous file changes.
+      Reviews PR diffs with project conventions. Posts structured findings
+      with severity levels and inline code patches.
     </ContentCard>
     <ContentCard
       icon="mdi:circle"
@@ -200,8 +200,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
   </div>
 
   <HighlightBox severity="warning" title="Agent Type Naming">
-    Always use the full prefixed name: <code>dx-core:dx-step-executor</code>, NOT
-    just <code>dx-step-executor</code>. The short name fails with "Agent type not found".
+    Always use the full prefixed name: <code>dx-core:dx-code-reviewer</code>, NOT
+    just <code>dx-code-reviewer</code>. The short name fails with "Agent type not found".
   </HighlightBox>
 </Section>
 

--- a/website/src/pages/learn/cli-vs-chat.mdx
+++ b/website/src/pages/learn/cli-vs-chat.mdx
@@ -194,7 +194,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="Skills"
   badgeColor="info"
   title="VS Code Chat -- Skill Compatibility"
-  subtitle="38 of 78 skills work. 17 need context:fork or agent: dispatch (Claude Code-only features)."
+  subtitle="38 of 69 skills work. 17 need context:fork or agent: dispatch (Claude Code-only features)."
   bg="primary"
 />
 <Section>
@@ -204,10 +204,10 @@ import CommandBlock from '../../components/CommandBlock.astro';
       MCP-dependent skills work if servers are mirrored in <code>.vscode/mcp.json</code>.
 
       <strong>Best candidates:</strong> <code>dx-help</code>, <code>dx-doctor</code>, <code>dx-plan</code>,
-      <code>dx-req-explain</code>, <code>dx-req-research</code>, <code>dx-step</code>,
-      <code>dx-step-review</code>, <code>aem-component</code>, <code>aem-doctor</code>
+      <code>dx-req</code>, <code>dx-step</code>,
+      <code>dx-step-verify</code>, <code>aem-component</code>, <code>aem-doctor</code>
 
-      <strong>With MCP:</strong> <code>dx-req-fetch</code>, <code>dx-bug-triage</code>,
+      <strong>With MCP:</strong> <code>dx-req</code>, <code>dx-bug-triage</code>,
       <code>dx-pr-commit</code>, <code>dx-pr-review</code>, <code>dx-ticket-analyze</code>
     </ContentCard>
     <ContentCard icon="mdi:alert" iconColor="bg-amber-500" title="Limited (17 skills)" tags={[{ label: 'Degraded', color: 'warning' }]}>
@@ -308,14 +308,14 @@ import CommandBlock from '../../components/CommandBlock.astro';
 />
 <Section>
   <HighlightBox severity="info" title="Key Insight">
-    Claude Code and Copilot CLI are <strong>nearly identical in capability</strong> -- both are terminal-based, both run the same 78 skills, both load plugins and MCP servers.
+    Claude Code and Copilot CLI are <strong>nearly identical in capability</strong> -- both are terminal-based, both run the same 69 skills, both load plugins and MCP servers.
     The real difference is between <strong>terminal CLIs</strong> (Claude Code + Copilot CLI) and <strong>VS Code Chat</strong> (IDE-integrated, visual, different file discovery).
   </HighlightBox>
 
   <div class="grid md:grid-cols-3 gap-4 mt-4">
     <ContentCard icon="mdi:console" iconColor="bg-cyan" title="Terminal CLIs (Claude Code / Copilot CLI)" tags={[{ label: 'Full power', color: 'secondary' }]}>
       <ul class="mt-2 list-none p-0 text-sm space-y-1">
-        <li><strong>All 78 skills</strong> via /dx-&#42; commands</li>
+        <li><strong>All 69 skills</strong> via /dx-&#42; commands</li>
         <li>Full plugin system (hooks, MCP, agents)</li>
         <li>Subagent orchestration</li>
         <li>CI/CD pipeline automation (headless -p mode)</li>

--- a/website/src/pages/learn/intro.mdx
+++ b/website/src/pages/learn/intro.mdx
@@ -133,7 +133,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <ContentCard icon="mdi:rocket-launch" iconColor="bg-brand-700" title="Skills + Agents = What & Who">
       <strong>Skills</strong> tell the AI <em>what</em> to do (instructions, steps, expected output).
       <strong> Agents</strong> define <em>who</em> does it (which model, which tools, what persona).
-      A skill like <code>/dx-step-all</code> delegates each step to the <code>dx-step-executor</code> agent.
+      A skill like <code>/dx-step-all</code> coordinates execution by invoking skills directly.
     </ContentCard>
     <ContentCard icon="mdi:source-branch" iconColor="bg-cyan" title="Hooks + MCP = Automation & Data">
       <strong>Hooks</strong> fire automatically on events (validate before commit, log after subagent).
@@ -169,8 +169,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
     </ContentCard>
     <ContentCard icon="mdi:swap-horizontal" iconColor="bg-emerald-600" title="With AI">
       <ol class="mt-2 pl-5 text-sm space-y-1">
-        <li><code>/dx-req-fetch 12345</code> -- AI reads the story</li>
-        <li><code>/dx-req-research</code> -- AI finds affected files</li>
+        <li><code>/dx-req 12345</code> -- AI reads the story and researches codebase</li>
+        <li><code>/dx-plan</code> -- AI generates implementation plan</li>
         <li><code>/dx-pr-review</code> -- AI reviews the diff</li>
         <li><code>/dx-pr-answer</code> -- AI drafts replies to comments</li>
       </ol>
@@ -192,7 +192,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       icon="mdi:puzzle"
       iconColor="bg-brand-700"
       title="dx-core"
-      tags={[{ label: '55 skills', color: 'primary' }, { label: '7 agents', color: 'primary' }]}
+      tags={[{ label: '43 skills', color: 'primary' }, { label: '6 agents', color: 'primary' }]}
     >
       Core development workflow -- requirements, planning, execution, review, bug fix.
       Works with any tech stack.

--- a/website/src/pages/learn/skills.mdx
+++ b/website/src/pages/learn/skills.mdx
@@ -98,7 +98,7 @@ a step-by-step implementation plan.
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>allowed-tools</code></td><td class="py-2 px-4">Tools the AI can use</td><td class="py-2 px-4"><code>all, or [read, edit, grep]</code></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>disable-model-invocation</code></td><td class="py-2 px-4">Skip AI reasoning (template-only)</td><td class="py-2 px-4"><code>true</code></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>context: fork</code></td><td class="py-2 px-4">Run in isolated subagent context</td><td class="py-2 px-4"><code>fork</code></td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>agent:</code></td><td class="py-2 px-4">Run as a specific agent type</td><td class="py-2 px-4"><code>dx-step-executor</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>agent:</code></td><td class="py-2 px-4">Run as a specific agent type</td><td class="py-2 px-4"><code>dx-code-reviewer</code></td></tr>
       </tbody>
     </table>
   </div>
@@ -108,14 +108,14 @@ a step-by-step implementation plan.
   badge="Categories"
   badgeColor="warning"
   title="Skill Categories in KAI"
-  subtitle="78 skills organized by workflow phase."
+  subtitle="69 skills organized by workflow phase."
   bg="alt"
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
     <ContentCard icon="mdi:magnify" iconColor="bg-brand-700" title="Requirements (/dx-req-*)">
       Fetch work items (ADO or Jira), explain requirements, research the codebase, share plans with the team.
-      <CommandBlock label="Example">/dx-req-fetch 2467362</CommandBlock>
+      <CommandBlock label="Example">/dx-req 2467362</CommandBlock>
     </ContentCard>
     <ContentCard icon="mdi:playlist-check" iconColor="bg-cyan" title="Planning (/dx-plan)">
       Generate step-by-step implementation plans with file paths, code changes, and rationale.

--- a/website/src/pages/learn/tips.mdx
+++ b/website/src/pages/learn/tips.mdx
@@ -13,7 +13,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
 <PageHero
   title="Tips & Best Practices"
-  subtitle="Practical advice from building 78 skills and running 10 autonomous agents"
+  subtitle="Practical advice from building 69 skills and running 10 autonomous agents"
 />
 
 <SectionHeading
@@ -31,10 +31,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
     </ContentCard>
     <ContentCard icon="mdi:play" iconColor="bg-emerald-600" title="Start Small">
       Don't run <code>/dx-agent-all</code> on day one. Start with the building blocks:
-      <CommandBlock label="Learning path">{`/dx-req-fetch <id>    # fetch a story
-/dx-req-explain       # understand requirements
-/dx-req-research      # find affected files
-/dx-plan              # generate a plan`}</CommandBlock>
+      <CommandBlock label="Learning path">{`/dx-req <id>          # full requirements pipeline
+/dx-plan              # generate a plan
+/dx-step              # execute a step`}</CommandBlock>
     </ContentCard>
     <ContentCard icon="mdi:eye" iconColor="bg-cyan-dark" title="Review, Don't Trust Blindly">
       AI makes mistakes. Code review exists for a reason. <code>/dx-step-verify</code> runs

--- a/website/src/pages/reference/agents.mdx
+++ b/website/src/pages/reference/agents.mdx
@@ -64,7 +64,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="dx-core"
   badgeColor="primary"
   title="Claude Code Agents"
-  subtitle="7 agents for the platform-agnostic workflow"
+  subtitle="6 agents for the platform-agnostic workflow"
   bg="primary"
 />
 <Section>
@@ -91,13 +91,6 @@ import CommandBlock from '../../components/CommandBlock.astro';
           <td class="p-3"><code>/dx-pr-review</code>, <code>/dx-pr-review-all</code></td>
           <td class="p-3">Read, Glob, Grep, Bash, Write, Edit</td>
           <td class="p-3">PR diff analysis with structured findings. Fetches PR diff, loads project conventions, returns findings with severity (MUST-FIX, QUESTION) and line-level comments. Does NOT post to ADO directly.</td>
-        </tr>
-        <tr>
-          <td class="p-3 font-mono text-xs"><code>dx-step-executor</code></td>
-          <td class="p-3"><span class="inline-block px-2 py-0.5 border rounded text-xs font-mono font-semibold border-amber-500 text-amber-600">Sonnet</span></td>
-          <td class="p-3"><code>/dx-step-all</code>, <code>/dx-agent-all</code>, <code>/dx-bug-all</code>, <code>/dx-req-all</code></td>
-          <td class="p-3">Read, Write, Edit, Bash, Glob, Grep, Task, ToolSearch</td>
-          <td class="p-3">Focused execution agent that runs exactly ONE skill per invocation. Permission mode: <code>acceptEdits</code>. Handles 29 skills. Returns <code>OK</code> or <code>FAIL</code> with compact summary.</td>
         </tr>
         <tr>
           <td class="p-3 font-mono text-xs"><code>dx-file-resolver</code></td>
@@ -201,7 +194,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   </div>
 
   <HighlightBox severity="info" title="Agent Type Naming">
-    Always use the full prefixed name when spawning agents: <code>dx-core:dx-step-executor</code>, <code>dx-aem:aem-inspector</code>. The short name alone fails with "Agent type not found".
+    Always use the full prefixed name when spawning agents: <code>dx-core:dx-code-reviewer</code>, <code>dx-aem:aem-inspector</code>. The short name alone fails with "Agent type not found".
   </HighlightBox>
 </Section>
 
@@ -228,12 +221,12 @@ import CommandBlock from '../../components/CommandBlock.astro';
       <tbody class="divide-y divide-gray-100">
         <tr><td class="p-3"><code>@DxCodeReview</code></td><td class="p-3">dx-code-reviewer</td><td class="p-3">Full branch code review with confidence-based filtering (80%+). Read-only.</td><td class="p-3">DxCommit, DxDebug</td></tr>
         <tr><td class="p-3"><code>@DxPRReview</code></td><td class="p-3">dx-pr-reviewer</td><td class="p-3">Fetches ADO PR diff, analyzes with project conventions, posts findings as PR comments.</td><td class="p-3">DxCodeReview, DxDebug, DxComponent</td></tr>
-        <tr><td class="p-3"><code>@DxPlanExecutor</code></td><td class="p-3">dx-step-executor</td><td class="p-3">Executes implementation plan steps from <code>implement.md</code>.</td><td class="p-3">DxCodeReview, DxCommit, DxDebug</td></tr>
+        <tr><td class="p-3"><code>@DxPlanExecutor</code></td><td class="p-3">/dx-step-all</td><td class="p-3">Executes implementation plan steps from <code>implement.md</code>.</td><td class="p-3">DxCodeReview, DxCommit, DxDebug</td></tr>
         <tr><td class="p-3"><code>@DxComponent</code></td><td class="p-3">dx-file-resolver</td><td class="p-3">Resolves all source files for a component or module.</td><td class="p-3">DxTicket, DxHelp</td></tr>
         <tr><td class="p-3"><code>@DxHelp</code></td><td class="p-3">dx-doc-searcher</td><td class="p-3">Project Q&amp;A from <code>.ai/</code> documentation.</td><td class="p-3">DxComponent, DxTicket</td></tr>
         <tr><td class="p-3"><code>@DxTicket</code></td><td class="p-3">/dx-ticket-analyze</td><td class="p-3">ADO ticket research -- fetches work item, identifies related files.</td><td class="p-3">DxComponent, DxHelp</td></tr>
         <tr><td class="p-3"><code>@DxPRAnswer</code></td><td class="p-3">/dx-pr-answer</td><td class="p-3">Answers PR review comments -- reads threads, drafts responses.</td><td class="p-3">DxPRFix, DxPRReview</td></tr>
-        <tr><td class="p-3"><code>@DxPRFix</code></td><td class="p-3">/dx-pr-fix</td><td class="p-3">Applies agree-will-fix PR review changes.</td><td class="p-3">DxPRAnswer, DxCommit</td></tr>
+        <tr><td class="p-3"><code>@DxPRFix</code></td><td class="p-3">/dx-pr-answer</td><td class="p-3">Applies agree-will-fix PR review changes.</td><td class="p-3">DxPRAnswer, DxCommit</td></tr>
         <tr><td class="p-3"><code>@DxCommit</code></td><td class="p-3">/dx-pr-commit</td><td class="p-3">Smart commit with conventional message. Optionally creates ADO pull request.</td><td class="p-3">DxPRReview, DxCodeReview</td></tr>
         <tr><td class="p-3"><code>@DxDebug</code></td><td class="p-3">--</td><td class="p-3">Systematic error diagnosis. Read-only -- traces errors, identifies root causes.</td><td class="p-3">DxPlanExecutor, DxCodeReview</td></tr>
         <tr><td class="p-3"><code>@DxReqAll</code></td><td class="p-3">/dx-req-all</td><td class="p-3">Full requirements pipeline coordinator.</td><td class="p-3">DxPlanExecutor, DxTicket</td></tr>
@@ -271,7 +264,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <tr><td class="p-3"><code>@AEMVerify</code></td><td class="p-3">aem-bug-executor</td><td class="p-3">Bug verification on a running AEM instance.</td><td class="p-3">DxDebug, DxComponent</td></tr>
         <tr><td class="p-3"><code>@AEMTicket</code></td><td class="p-3">/dx-ticket-analyze + enrichment</td><td class="p-3">ADO ticket research with AEM project enrichment -- 4-signal market detection, parallel agents.</td><td class="p-3">AEMComponent, DxHelp, DxReqAll</td></tr>
         <tr><td class="p-3"><code>@AEMPRAnswer</code></td><td class="p-3">/dx-pr-answer</td><td class="p-3">Answers PR review comments with session persistence. Bot detection, thread categorization.</td><td class="p-3">AEMPRFix, DxPRReview</td></tr>
-        <tr><td class="p-3"><code>@AEMPRFix</code></td><td class="p-3">/dx-pr-fix</td><td class="p-3">Applies agree-will-fix PR review changes. Session-first resolution, minimal fixes.</td><td class="p-3">AEMPRAnswer, AEMCommit</td></tr>
+        <tr><td class="p-3"><code>@AEMPRFix</code></td><td class="p-3">/dx-pr-answer</td><td class="p-3">Applies agree-will-fix PR review changes. Session-first resolution, minimal fixes.</td><td class="p-3">AEMPRAnswer, AEMCommit</td></tr>
         <tr><td class="p-3"><code>@AEMCommit</code></td><td class="p-3">/dx-pr-commit</td><td class="p-3">Smart commit with WI ID extraction (4 sources). Rebase, PR creation via ADO MCP.</td><td class="p-3">DxPRReview, DxCodeReview</td></tr>
       </tbody>
     </table>

--- a/website/src/pages/reference/config.mdx
+++ b/website/src/pages/reference/config.mdx
@@ -100,7 +100,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <tr><td class="p-3"><code>wiki-project</code></td><td class="p-3">string</td><td class="p-3">no</td><td class="p-3">ADO project that owns the wiki (if different from <code>scm.project</code>)</td></tr>
         <tr><td class="p-3"><code>wiki-doc-root</code></td><td class="p-3">string</td><td class="p-3">no</td><td class="p-3">Root wiki path for technical documentation (sprint subfolders created beneath)</td></tr>
         <tr><td class="p-3"><code>wiki-pr-review-root</code></td><td class="p-3">string</td><td class="p-3">no</td><td class="p-3">Root wiki path for PR review reports</td></tr>
-        <tr><td class="p-3"><code>wiki-dor-url</code></td><td class="p-3">string</td><td class="p-3">yes</td><td class="p-3">Full URL to the DoR wiki page -- <code>/dx-req-dor</code> fetches checklist from here</td></tr>
+        <tr><td class="p-3"><code>wiki-dor-url</code></td><td class="p-3">string</td><td class="p-3">yes</td><td class="p-3">Full URL to the DoR wiki page -- <code>/dx-req</code> fetches checklist from here</td></tr>
         <tr><td class="p-3"><code>wiki-dod-url</code></td><td class="p-3">string</td><td class="p-3">yes</td><td class="p-3">Full URL to the DoD wiki page -- <code>/dx-req-dod</code> fetches checklist from here</td></tr>
       </tbody>
     </table>

--- a/website/src/pages/reference/coordinators.mdx
+++ b/website/src/pages/reference/coordinators.mdx
@@ -61,7 +61,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:robot-off" iconColor="bg-brand-700" title="Coordinator-Only Architecture">
       All coordinators use <code>disable-model-invocation: true</code> -- they NEVER write code themselves.
-      Every phase is delegated to <code>dx-step-executor</code> agent via the Task tool, keeping the main
+      Every phase is delegated via direct <code>Skill()</code> invocation, keeping the main
       context lean (approximately 10 tokens per status update vs approximately 200 for full file reads).
     </ContentCard>
     <ContentCard icon="mdi:shield-check" iconColor="bg-cyan-dark" title="Isolated Context Management">
@@ -107,17 +107,13 @@ import CommandBlock from '../../components/CommandBlock.astro';
     label="Requirements Pipeline"
     command="/dx-req-all <work-item-id>"
     steps={[
-      { title: 'fetch', subtitle: 'Pull ADO story', command: '/dx-req-fetch' },
-      { title: 'dor', subtitle: 'DoR validation', command: '/dx-req-dor', color: '#ef4444' },
-      { title: 'explain', subtitle: 'Dev requirements', command: '/dx-req-explain' },
-      { title: 'research', subtitle: 'Codebase search', command: '/dx-req-research' },
-      { title: 'share', subtitle: 'Post to ADO', command: '/dx-req-share' },
+      { title: 'requirements', subtitle: 'Full pipeline (fetch, DoR, explain, research, share)', command: '/dx-req' },
     ]}
   />
 
   <HighlightBox severity="warning" title="DoR Gate">
     The DoR step is a gate -- if blocking questions exist, the pipeline pauses. The BA checks items
-    in the ADO comment. Re-running <code>/dx-req-dor</code> reads the checkbox state and re-validates.
+    in the ADO comment. Re-running <code>/dx-req</code> reads the checkbox state and re-validates.
     Already-completed steps are skipped on re-run.
   </HighlightBox>
 </Section>
@@ -138,10 +134,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
     label="Execution Loop (per step)"
     command="/dx-step-all"
     steps={[
-      { title: 'dx-step', subtitle: 'Execute step', command: '/dx-step' },
-      { title: 'dx-step-test', subtitle: 'Run tests', command: '/dx-step-test' },
-      { title: 'dx-step-review', subtitle: 'Review changes', command: '/dx-step-review' },
-      { title: 'dx-step-commit', subtitle: 'Commit step', command: '/dx-step-commit' },
+      { title: 'dx-step', subtitle: 'Execute + test + review + commit', command: '/dx-step' },
+      { title: 'dx-step-fix', subtitle: 'Fix on failure', command: '/dx-step-fix', color: '#f59e0b' },
     ]}
   />
 
@@ -151,8 +145,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
       one attempt to diagnose and fix the issue.
     </ContentCard>
     <ContentCard icon="mdi:hospital" iconColor="bg-red-500" title="On 2 Consecutive Failures: step-heal">
-      After 2 consecutive fix failures, <code>dx-step-heal</code> performs deep diagnosis and creates
-      corrective steps in <code>implement.md</code>. Maximum 2 healing cycles before stopping for human intervention.
+      After 2 consecutive fix failures, <code>dx-step-fix</code> escalates to root cause analysis and creates
+      corrective steps in <code>implement.md</code>. Maximum 2 escalation cycles before stopping for human intervention.
     </ContentCard>
   </div>
 
@@ -219,7 +213,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <PipelineBlock
     steps={[
       { title: 'Phase 4.5', subtitle: 'Code review', command: 'dx-step-verify' },
-      { title: 'Phase 5a', subtitle: 'Commit', command: 'dx-step-commit' },
+      { title: 'Phase 5a', subtitle: 'Commit', command: 'dx-pr-commit' },
       { title: 'Phase 5', subtitle: 'AEM verify', command: 'aem-verify' },
       { title: 'Phase 6', subtitle: 'Create PR', command: 'dx-pr' },
       { title: 'Phase 7', subtitle: 'Documentation', command: 'dx-doc-gen' },
@@ -492,9 +486,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
       about dependencies, step ordering, and risk assessment. This is the most token-intensive
       phase (≈80K tokens) but produces higher-quality plans with fewer downstream failures.
     </ContentCard>
-    <ContentCard icon="mdi:medical-bag" iconColor="bg-amber-500" title="Healing Phase (Opus)">
-      <code>dx-step-heal</code> uses extended thinking for deep root-cause analysis when 2
-      consecutive fix attempts fail. The healer sees the full error context, previous fix attempts,
+    <ContentCard icon="mdi:medical-bag" iconColor="bg-amber-500" title="Escalation Phase (Opus)">
+      <code>dx-step-fix</code> escalates to extended thinking for deep root-cause analysis when 2
+      consecutive fix attempts fail. The escalated fix sees the full error context, previous fix attempts,
       and the original step intent to devise a fundamentally different approach.
     </ContentCard>
   </div>

--- a/website/src/pages/reference/skills.mdx
+++ b/website/src/pages/reference/skills.mdx
@@ -14,7 +14,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
 <PageHero
   title="Skill Catalog"
-  subtitle="All slash commands across the three plugins -- 78 skills total"
+  subtitle="All slash commands across the four plugins -- 69 skills total"
 />
 
 <SectionHeading
@@ -25,7 +25,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '55 skills', color: 'primary' }]}>
+    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '43 skills', color: 'primary' }]}>
       Platform-agnostic ADO/Jira workflow: requirements, planning, execution, review, PR, bug fix, documentation, and utility.
     </ContentCard>
     <ContentCard icon="mdi:web" iconColor="bg-cyan-dark" title="dx-aem" tags={[{ label: '12 skills', color: 'secondary' }]}>
@@ -68,7 +68,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="dx-core"
   badgeColor="primary"
   title="Requirements (dx-req-&#42;)"
-  subtitle="11 skills"
+  subtitle="6 skills"
   bg="alt"
 />
 <Section>
@@ -81,16 +81,10 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Output</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>/dx-req-all</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Full pipeline: fetch, dor, explain, research, share. Gates on DoR blocking questions. Logs run metrics.</td><td class="p-3">All spec files + ADO comments</td></tr>
-        <tr><td class="p-3"><code>/dx-req-fetch</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Pull work item from Azure DevOps or Jira via MCP, save faithfully.</td><td class="p-3"><code>raw-story.md</code></td></tr>
-        <tr><td class="p-3"><code>/dx-req-dor</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Validate story against DoR wiki checklist, extract BA data, generate open questions. Posts interactive checkbox comment to ADO/Jira (idempotent). On re-run, reads checkbox state -- if BA checked items, re-fetches and re-validates.</td><td class="p-3"><code>dor-report.md</code> + ADO/Jira comment</td></tr>
-        <tr><td class="p-3"><code>/dx-req-explain</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Distill story into developer-focused requirements. Reads DoR report for BA context.</td><td class="p-3"><code>explain.md</code></td></tr>
-        <tr><td class="p-3"><code>/dx-req-research</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Search codebase for related code via parallel agents. Skips discovery when DoR data available.</td><td class="p-3"><code>research.md</code></td></tr>
-        <tr><td class="p-3"><code>/dx-req-share</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Generate non-technical summary with assumptions from DoR. Posts to ADO/Jira (idempotent).</td><td class="p-3"><code>share-plan.md</code> + ADO/Jira comment</td></tr>
-        <tr><td class="p-3"><code>/dx-req-checklist</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Deprecated -- use <code>/dx-req-dor</code> instead. Kept for backward compatibility.</td><td class="p-3"><code>checklist.md</code></td></tr>
+        <tr><td class="p-3"><code>/dx-req-all</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Coordinator: invokes /dx-req. Gates on DoR blocking questions. Logs run metrics.</td><td class="p-3">All spec files + ADO comments</td></tr>
+        <tr><td class="p-3"><code>/dx-req</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Full requirements pipeline: fetch work item, validate DoR, distill dev requirements, research codebase, generate team summary. Posts interactive checkbox comment to ADO/Jira (idempotent).</td><td class="p-3">All spec files + ADO comments</td></tr>
         <tr><td class="p-3"><code>/dx-req-tasks</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Create child Task work items with hour estimates.</td><td class="p-3">ADO/Jira tasks</td></tr>
-        <tr><td class="p-3"><code>/dx-req-dod</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Check Definition of Done against ADO/Jira wiki checklist -- validates actual deliverables: PR, tests, build, docs, child tasks.</td><td class="p-3"><code>dod.md</code></td></tr>
-        <tr><td class="p-3"><code>/dx-req-dod-fix</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Fix DoD failures: auto-fix what is possible, create tasks for the rest.</td><td class="p-3">Updated <code>dod.md</code> + tasks</td></tr>
+        <tr><td class="p-3"><code>/dx-req-dod</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Check Definition of Done against ADO/Jira wiki checklist -- validates actual deliverables: PR, tests, build, docs, child tasks. Auto-fixes what is possible, creates tasks for the rest.</td><td class="p-3"><code>dod.md</code></td></tr>
         <tr><td class="p-3"><code>/dx-req-import</code></td><td class="p-3"><code>&lt;path-to-file&gt;</code></td><td class="p-3">Validate external (non-ADO) requirements document.</td><td class="p-3"><code>explain.md</code></td></tr>
       </tbody>
     </table>
@@ -152,7 +146,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="dx-core"
   badgeColor="primary"
   title="Execution (dx-step-&#42;)"
-  subtitle="9 skills"
+  subtitle="5 skills"
   bg="primary"
 />
 <Section>
@@ -165,13 +159,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Output</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>/dx-step-all</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Execute all plan steps autonomously (step, test, review, commit loop). Loads fix memory, logs fix patterns, promotes proven fixes to <code>.claude/rules/</code>.</td><td class="p-3">All steps done</td></tr>
-        <tr><td class="p-3"><code>/dx-step</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Execute next pending step from implement.md. Optionally invokes <code>superpowers:test-driven-development</code>.</td><td class="p-3">Code changes</td></tr>
-        <tr><td class="p-3"><code>/dx-step-test</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Run tests and parse results into pass/fail summary.</td><td class="p-3">Test report</td></tr>
-        <tr><td class="p-3"><code>/dx-step-review</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Review step changes against plan and conventions.</td><td class="p-3">Review verdict</td></tr>
-        <tr><td class="p-3"><code>/dx-step-fix</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Diagnose and fix a blocked step (compile error, test failure, review rejection). Optionally invokes <code>superpowers:systematic-debugging</code>.</td><td class="p-3">Fix applied</td></tr>
-        <tr><td class="p-3"><code>/dx-step-commit</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Stage and commit completed step changes.</td><td class="p-3">Git commit</td></tr>
-        <tr><td class="p-3"><code>/dx-step-heal</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Diagnose pipeline failures, create corrective fix steps in implement.md.</td><td class="p-3">New fix steps</td></tr>
+        <tr><td class="p-3"><code>/dx-step-all</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Execute all plan steps autonomously (step with test, review, commit loop). Loads fix memory, logs fix patterns, promotes proven fixes to <code>.claude/rules/</code>.</td><td class="p-3">All steps done</td></tr>
+        <tr><td class="p-3"><code>/dx-step</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Execute next pending step from implement.md with integrated test, review, and commit. Optionally invokes <code>superpowers:test-driven-development</code>.</td><td class="p-3">Code changes + commit</td></tr>
+        <tr><td class="p-3"><code>/dx-step-fix</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Diagnose and fix a blocked step (compile error, test failure, review rejection). Escalates to root cause analysis if targeted fixes fail. Optionally invokes <code>superpowers:systematic-debugging</code>.</td><td class="p-3">Fix applied</td></tr>
         <tr><td class="p-3"><code>/dx-step-build</code></td><td class="p-3">none</td><td class="p-3">Build and deploy using config build command, auto-fix errors iteratively.</td><td class="p-3">Build pass/fail</td></tr>
         <tr><td class="p-3"><code>/dx-step-verify</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">6-phase verification: compile, lint, test, secret scan, architecture, code review (max 3 fix cycles). Optionally invokes <code>superpowers:verification-before-completion</code>.</td><td class="p-3">Verdict</td></tr>
       </tbody>
@@ -183,7 +173,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="dx-core"
   badgeColor="primary"
   title="Pull Request (dx-pr-&#42;)"
-  subtitle="8 skills"
+  subtitle="6 skills"
   bg="alt"
 />
 <Section>
@@ -198,11 +188,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
       <tbody class="divide-y divide-gray-100">
         <tr><td class="p-3"><code>/dx-pr</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code> (optional)</td><td class="p-3">Create pull request via ADO MCP, generate description from share-plan.md. Optionally invokes <code>superpowers:finishing-a-development-branch</code>.</td><td class="p-3">PR URL</td></tr>
         <tr><td class="p-3"><code>/dx-pr-commit</code></td><td class="p-3"><code>[pr]</code></td><td class="p-3">Commit changes with ADO work item linking; add <code>pr</code> to also create a PR.</td><td class="p-3">Git commit [+ PR]</td></tr>
-        <tr><td class="p-3"><code>/dx-pr-review</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code></td><td class="p-3">Review a single PR -- analyze diff, save findings, optionally propose fix patches.</td><td class="p-3">Findings file</td></tr>
-        <tr><td class="p-3"><code>/dx-pr-post</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code></td><td class="p-3">Post saved PR review findings to ADO -- threads with optional fix patches + vote.</td><td class="p-3">ADO comments</td></tr>
+        <tr><td class="p-3"><code>/dx-pr-review</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code></td><td class="p-3">Review a single PR -- analyze diff, save findings, post to ADO with optional fix patches + vote.</td><td class="p-3">Findings + ADO comments</td></tr>
         <tr><td class="p-3"><code>/dx-pr-review-all</code></td><td class="p-3">none</td><td class="p-3">Batch-review multiple open PRs assigned to you.</td><td class="p-3">Multiple reviews</td></tr>
-        <tr><td class="p-3"><code>/dx-pr-answer</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code> (optional)</td><td class="p-3">Answer open PR comments with codebase context, detect proposed patches.</td><td class="p-3">ADO replies</td></tr>
-        <tr><td class="p-3"><code>/dx-pr-fix</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code> (optional)</td><td class="p-3">Apply agree-will-fix code changes from reviews, commit, push, reply to threads.</td><td class="p-3">Code + replies</td></tr>
+        <tr><td class="p-3"><code>/dx-pr-answer</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code> (optional)</td><td class="p-3">Answer open PR comments with codebase context, detect proposed patches. Applies agree-will-fix code changes, commits, pushes, and replies to threads.</td><td class="p-3">ADO replies + code</td></tr>
         <tr><td class="p-3"><code>/dx-pr-review-report</code></td><td class="p-3"><code>&lt;PR-id or URL&gt;</code></td><td class="p-3">Generate categorized report from PR review -- groups by category, tracks patch resolution, posts to wiki.</td><td class="p-3">Report + wiki page</td></tr>
         <tr><td class="p-3"><code>/dx-pr-reviews-report</code></td><td class="p-3"><code>[--any] [PR URL | Repo URL | count]</code></td><td class="p-3">Generate categorized reports for multiple PR reviews -- batch reports posted to ADO Wiki or Confluence.</td><td class="p-3">Batch reports + wiki</td></tr>
       </tbody>
@@ -482,13 +470,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
 <Section>
   <ContentCard icon="mdi:source-branch" iconColor="bg-brand-700" title="dx-req-all chain">
     <code class="text-xs block mt-2 whitespace-pre-wrap bg-gray-50 p-3 rounded">{`dx-req-all
-  ├─ dx-req-fetch
-  ├─ dx-req-dor (needs fetch) → posts checkbox comment to ADO
-  │    GATE: blocks if blocking questions exist
-  │    BA checks items → re-run reads state → re-validates
-  ├─ dx-req-explain (needs fetch, reads dor-report.md)
-  ├─ dx-req-research (needs explain, reads dor-report.md)
-  └─ dx-req-share (needs explain, reads dor-report.md)`}</code>
+  └─ dx-req (full pipeline: fetch → DoR → explain → research → share)
+       GATE: blocks if blocking questions exist
+       BA checks items → re-run reads state → re-validates`}</code>
   </ContentCard>
 
   <ContentCard icon="mdi:source-branch" iconColor="bg-cyan-dark" title="dx-agent-all chain" class="mt-4">
@@ -496,9 +480,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
   ├─ dx-agent-re
   ├─ dx-plan → dx-plan-validate → dx-plan-resolve
   ├─ dx-step-all
-  │    ├─ dx-step → dx-step-test → dx-step-review
-  │    ├─ dx-step-fix
-  │    └─ dx-step-commit
+  │    ├─ dx-step (includes test, review, commit)
+  │    └─ dx-step-fix (targeted fix + escalation)
   ├─ dx-step-build
   ├─ dx-step-verify
   ├─ dx-pr

--- a/website/src/pages/setup/claude-code.mdx
+++ b/website/src/pages/setup/claude-code.mdx
@@ -155,7 +155,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-req-fetch &lt;id&gt;</code></td><td class="py-2 px-4">Fetch work item (ADO or Jira) and save raw spec</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-req &lt;id&gt;</code></td><td class="py-2 px-4">Full requirements pipeline (fetch, DoR, explain, research, share)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-plan</code></td><td class="py-2 px-4">Generate implementation plan from specs</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-step &lt;n&gt;</code></td><td class="py-2 px-4">Execute a single plan step</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-step-all</code></td><td class="py-2 px-4">Execute all plan steps with self-healing</td></tr>
@@ -178,7 +178,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <CommandBlock label="Check installed skills">claude skills list | grep "dx-"</CommandBlock>
 
   <HighlightBox severity="success" title="Expected Output">
-    You should see 78 skills listed (55 from dx-core, 12 from dx-aem, plus 11 automation skills if installed).
+    You should see 69 skills listed (43 from dx-core, 3 from dx-hub, 12 from dx-aem, plus 11 automation skills if installed).
   </HighlightBox>
 </Section>
 

--- a/website/src/pages/setup/copilot-cli.mdx
+++ b/website/src/pages/setup/copilot-cli.mdx
@@ -159,7 +159,7 @@ export AXE_API_KEY="your-axe-api-key"  # optional, for accessibility testing`}</
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-req-fetch &lt;id&gt;</code></td><td class="py-2 px-4">Fetch work item (ADO or Jira) and save raw spec</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-req &lt;id&gt;</code></td><td class="py-2 px-4">Full requirements pipeline (fetch, DoR, explain, research, share)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-plan</code></td><td class="py-2 px-4">Generate implementation plan from specs</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-step-all</code></td><td class="py-2 px-4">Execute all plan steps with self-healing</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>/dx-pr-review</code></td><td class="py-2 px-4">Review a PR with inline comments</td></tr>
@@ -207,7 +207,7 @@ export AXE_API_KEY="your-axe-api-key"  # optional, for accessibility testing`}</
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Skills</td><td class="py-2 px-4">78 skills auto-discovered from plugins</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Skills</td><td class="py-2 px-4">69 skills auto-discovered from plugins</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Copilot Agents</td><td class="py-2 px-4">25 agents with allowed-tools for auto-approval</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">MCP Servers</td><td class="py-2 px-4">AEM, Chrome DevTools, Figma, axe, ADO, Jira/Confluence</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Hooks</td><td class="py-2 px-4">SessionStart, branch guard, Figma caching</td></tr>
@@ -249,7 +249,7 @@ export AXE_API_KEY="your-axe-api-key"  # optional, for accessibility testing`}</
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Skills</td><td class="py-2 px-4">78 skills, same commands</td><td class="py-2 px-4"></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Skills</td><td class="py-2 px-4">69 skills, same commands</td><td class="py-2 px-4"></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Marketplace</td><td class="py-2 px-4">Same git URL</td><td class="py-2 px-4"></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">Hooks</td><td class="py-2 px-4">Same hooks.json (version: 1)</td><td class="py-2 px-4"></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4 font-semibold">MCP Servers</td><td class="py-2 px-4">Same servers and tools</td><td class="py-2 px-4"></td></tr>

--- a/website/src/pages/workflows/ado.mdx
+++ b/website/src/pages/workflows/ado.mdx
@@ -78,7 +78,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <ContentCard
       icon="mdi:format-list-checks"
       iconColor="bg-amber-500"
-      title="/dx-req-dor"
+      title="/dx-req (DoR phase)"
       tags={[{ label: '[DoRAgent]', color: 'warning' }, { label: 'dor-check.md.template', color: 'default' }]}
     >
       Definition of Ready checklist with interactive checkboxes. BAs can check items directly in ADO, then re-run DoR to update the scorecard. Three modes: full post, update, or skip if unchanged.
@@ -87,7 +87,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <ContentCard
       icon="mdi:chat"
       iconColor="bg-cyan"
-      title="/dx-req-share"
+      title="/dx-req (share phase)"
       tags={[{ label: '[DevPlan]', color: 'info' }, { label: 'share-plan.md.template', color: 'default' }]}
     >
       Non-technical implementation plan for the team. Covers what's being built, the approach, scope (S/M/L), assumptions, and open questions. Suitable for pasting into Teams or standup notes.
@@ -174,13 +174,13 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     </thead>
     <tbody>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>/dx-req-dor</code></td>
+        <td class="p-3"><code>/dx-req (DoR phase)</code></td>
         <td class="p-3"><code class="text-xs">[DoRAgent] Definition of Ready Check</code></td>
         <td class="p-3 text-xs">A: full | B: update | C: skip</td>
         <td class="p-3"><code class="text-xs">dor-check.md.template</code></td>
       </tr>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>/dx-req-share</code></td>
+        <td class="p-3"><code>/dx-req</code> (share)</td>
         <td class="p-3"><code class="text-xs">[DevPlan] Development Plan</code></td>
         <td class="p-3 text-xs">A: full | B: update</td>
         <td class="p-3"><code class="text-xs">share-plan.md.template</code></td>
@@ -271,7 +271,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <ContentCard
       icon="mdi:clipboard-check-outline"
       iconColor="bg-amber-500"
-      title="/dx-req-dod-fix"
+      title="/dx-req-dod"
       tags={[{ label: 'Task', color: 'warning' }, { label: 'fix items', color: 'warning' }]}
     >
       Creates Task work items for failed Definition of Done criteria that cannot be auto-fixed.
@@ -308,7 +308,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
         <td class="p-3"><code class="text-xs">&lt;FE/BE/Authoring task&gt;</code></td>
       </tr>
       <tr class="border-t border-gray-200">
-        <td class="p-3"><code>/dx-req-dod-fix</code></td>
+        <td class="p-3"><code>/dx-req-dod</code></td>
         <td class="p-3"><span class="text-emerald-600 font-semibold">Task</span></td>
         <td class="p-3"><code class="text-xs">wit_create_work_item</code></td>
         <td class="p-3"><code class="text-xs">&lt;fix description&gt;</code></td>
@@ -411,8 +411,8 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
   <PipelineBlock
     label="Development Lifecycle ADO Writes"
     steps={[
-      { title: 'DoR Check', subtitle: 'Comment', command: '/dx-req-dor', color: '#f59e0b' },
-      { title: 'Dev Plan', subtitle: 'Comment', command: '/dx-req-share', color: '#0891b2' },
+      { title: 'DoR Check', subtitle: 'Comment', command: '/dx-req (DoR phase)', color: '#f59e0b' },
+      { title: 'Dev Plan', subtitle: 'Comment', command: '/dx-req', color: '#0891b2' },
       { title: 'RE Agent', subtitle: 'Comment + Tasks', command: '/dx-agent-re', color: '#8b5cf6' },
       { title: 'Estimation', subtitle: 'Comment + Updates', command: '/dx-estimate', color: '#d97706' },
       { title: 'Task Split', subtitle: 'Tasks + Estimates', command: '/dx-req-tasks', color: '#059669' },
@@ -436,13 +436,13 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
     <tbody>
       <tr class="border-t border-gray-200">
         <td class="p-3">Requirements</td>
-        <td class="p-3"><code>/dx-req-dor</code></td>
+        <td class="p-3"><code>/dx-req (DoR phase)</code></td>
         <td class="p-3">Comment</td>
         <td class="p-3">Story</td>
       </tr>
       <tr class="border-t border-gray-200">
         <td class="p-3">Requirements</td>
-        <td class="p-3"><code>/dx-req-share</code></td>
+        <td class="p-3"><code>/dx-req</code> (share)</td>
         <td class="p-3">Comment</td>
         <td class="p-3">Story</td>
       </tr>
@@ -484,7 +484,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
       </tr>
       <tr class="border-t border-gray-200">
         <td class="p-3">Quality</td>
-        <td class="p-3"><code>/dx-req-dod-fix</code></td>
+        <td class="p-3"><code>/dx-req-dod</code> (fix)</td>
         <td class="p-3">Tasks</td>
         <td class="p-3">Story children</td>
       </tr>

--- a/website/src/pages/workflows/dor-dod.mdx
+++ b/website/src/pages/workflows/dor-dod.mdx
@@ -28,7 +28,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:clipboard-text" iconColor="bg-brand-700" title="Definition of Ready (DoR)">
       Validates that a user story has all the information needed to begin implementation. Checks title, description, acceptance criteria, design links, dialog fields, and more.
-      <CommandBlock>/dx-req-dor</CommandBlock>
+      <CommandBlock>/dx-req</CommandBlock>
     </ContentCard>
     <ContentCard icon="mdi:clipboard-check" iconColor="bg-emerald-600" title="Definition of Done (DoD)">
       Validates that actual deliverables (code, tests, PR, build) meet completion criteria. Works the same whether the story was implemented manually or via the AI workflow.
@@ -68,7 +68,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 <Section>
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:numeric-1-circle" iconColor="bg-brand-700" title="Agent Posts">
-      <code>/dx-req-dor</code> evaluates the story against wiki criteria and posts a <code>[DoRAgent]</code> comment with interactive checkboxes. Passing items are pre-checked, failing items are unchecked.
+      <code>/dx-req</code> evaluates the story against wiki criteria and posts a <code>[DoRAgent]</code> comment with interactive checkboxes. Passing items are pre-checked, failing items are unchecked.
     </ContentCard>
     <ContentCard icon="mdi:numeric-2-circle" iconColor="bg-cyan" title="BA Updates">
       The BA reads the comment, updates the story with missing data, and checks the corresponding checkboxes in the ADO comment.
@@ -125,8 +125,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
       </ul>
     </ContentCard>
     <ContentCard icon="mdi:auto-fix" iconColor="bg-cyan" title="Auto-Fix">
-      <code>/dx-req-dod-fix</code> reads <code>dod.md</code> failures and auto-fixes what is possible -- creates missing files, updates statuses, and fixes formatting issues.
-      <CommandBlock>/dx-req-dod-fix</CommandBlock>
+      <code>/dx-req-dod</code> also auto-fixes what is possible -- creates missing files, updates statuses, and fixes formatting issues.
+      <CommandBlock>/dx-req-dod</CommandBlock>
     </ContentCard>
   </div>
 
@@ -200,11 +200,11 @@ import CommandBlock from '../../components/CommandBlock.astro';
       Triggered by Lambda webhooks when work items are updated. Posts DoR results as comments and can transition work item state based on pass/fail.
     </ContentCard>
     <ContentCard icon="mdi:robot" iconColor="bg-cyan" title="Automated DoD">
-      Triggered when PRs are created or updated. Validates deliverables and posts results. <code>/dx-req-dod-fix</code> can auto-remediate failures.
+      Triggered when PRs are created or updated. Validates deliverables and posts results. <code>/dx-req-dod</code> can auto-remediate failures.
     </ContentCard>
   </div>
 
   <HighlightBox severity="info" title="Same Criteria, Two Modes">
-    Both the interactive skills (<code>/dx-req-dor</code>, <code>/dx-req-dod</code>) and the automation pipelines read from the same wiki pages. Updating the wiki changes behavior for both local development and automated pipelines.
+    Both the interactive skills (<code>/dx-req</code>, <code>/dx-req-dod</code>) and the automation pipelines read from the same wiki pages. Updating the wiki changes behavior for both local development and automated pipelines.
   </HighlightBox>
 </Section>

--- a/website/src/pages/workflows/local.mdx
+++ b/website/src/pages/workflows/local.mdx
@@ -58,7 +58,7 @@ export const base = import.meta.env.BASE_URL;
       { title: "Phase 2b", subtitle: "Planning", command: "/dx-plan", color: "#d97706" },
       { title: "Phase 3", subtitle: "Execution", command: "/dx-step-*", color: "#059669" },
       { title: "Phase 4", subtitle: "Build + Review", command: "/dx-step-verify", color: "#f59e0b" },
-      { title: "Phase 5", subtitle: "Commit & Push", command: "/dx-step-commit", color: "#ec4899" },
+      { title: "Phase 5", subtitle: "Commit & Push", command: "/dx-pr-commit", color: "#ec4899" },
       { title: "Phase 6", subtitle: "Pull Request", command: "/dx-pr", color: "#3b82f6" },
       { title: "Phase 6.5", subtitle: "Editorial Guide", command: "/aem-demo", color: "#6366f1" },
       { title: "Phase 7", subtitle: "Feature Documentation", command: "/dx-doc-gen", color: "#14b8a6" },
@@ -79,29 +79,16 @@ export const base = import.meta.env.BASE_URL;
     label="One Command"
     command="/dx-req-all <ID or JIRA-KEY>"
     steps={[
-      { title: "Fetch", subtitle: "Pull work item (ADO/Jira)", command: "/dx-req-fetch" },
-      { title: "DoR", subtitle: "Validate readiness", command: "/dx-req-dor", color: "#f59e0b" },
-      { title: "Explain", subtitle: "Dev requirements", command: "/dx-req-explain", color: "#8b5cf6" },
-      { title: "Research", subtitle: "Codebase search", command: "/dx-req-research", color: "#059669" },
-      { title: "Share", subtitle: "Post summary to ADO/Jira", command: "/dx-req-share", color: "#0891b2" },
+      { title: "Requirements", subtitle: "Full pipeline (fetch, DoR, explain, research, share)", command: "/dx-req" },
     ]}
   />
 
-  <div class="grid md:grid-cols-3 gap-4 mt-4">
-    <ContentCard icon="mdi:download" iconColor="bg-brand-700" title="/dx-req-fetch" tags={[{label: "raw-story.md", color: "primary"}]}>
-      Pulls the work item (ADO or Jira) -- description, acceptance criteria, attachments. Creates a spec directory and saves the raw story.
+  <div class="grid md:grid-cols-2 gap-4 mt-4">
+    <ContentCard icon="mdi:download" iconColor="bg-brand-700" title="/dx-req" tags={[{label: "All spec files", color: "primary"}]}>
+      Full requirements pipeline in one skill: fetches the work item (ADO or Jira), validates DoR, distills developer requirements, researches the codebase, and generates a team summary. Produces raw-story.md, dor-report.md, explain.md, research.md, and share-plan.md.
     </ContentCard>
-    <ContentCard icon="mdi:clipboard-check" iconColor="bg-amber-500" title="/dx-req-dor" tags={[{label: "dor-report.md", color: "warning"}]}>
-      Validates against the Definition of Ready checklist. Posts an interactive checkbox comment to the ADO work item or Jira issue.
-    </ContentCard>
-    <ContentCard icon="mdi:lightbulb" iconColor="bg-cyan" title="/dx-req-explain" tags={[{label: "explain.md", color: "secondary"}]}>
-      Distills the story into developer-focused requirements -- what to build, not how. Clarifies ambiguities and flags missing context.
-    </ContentCard>
-    <ContentCard icon="mdi:magnify" iconColor="bg-emerald-600" title="/dx-req-research" tags={[{label: "research.md", color: "success"}]}>
-      Searches the codebase with parallel AI agents to find relevant files, existing patterns, reusable utilities, and related components.
-    </ContentCard>
-    <ContentCard icon="mdi:chat" iconColor="bg-cyan-dark" title="/dx-req-share" tags={[{label: "share-plan.md", color: "info"}]}>
-      Non-technical summary for the team -- paste into Teams. Covers what is being built, the approach, scope, and estimated impact.
+    <ContentCard icon="mdi:clipboard-check" iconColor="bg-amber-500" title="/dx-req-all" tags={[{label: "Coordinator", color: "warning"}]}>
+      Coordinator that invokes /dx-req. Use this for the full orchestrated pipeline with run logging and metrics.
     </ContentCard>
   </div>
 
@@ -165,8 +152,7 @@ export const base = import.meta.env.BASE_URL;
     command="/dx-step-all"
     steps={[
       { title: "Execute", subtitle: "Run plan step", command: "/dx-step <n>", color: "#059669" },
-      { title: "Fix", subtitle: "Targeted correction", command: "/dx-step-fix", color: "#f59e0b" },
-      { title: "Heal", subtitle: "Root cause analysis", command: "/dx-step-heal", color: "#ef4444" },
+      { title: "Fix", subtitle: "Targeted correction + escalation", command: "/dx-step-fix", color: "#f59e0b" },
     ]}
   />
 
@@ -175,9 +161,9 @@ export const base = import.meta.env.BASE_URL;
       <strong>Single targeted fix.</strong> When a test or review fails, this skill applies a focused correction
       to the specific problem. If the same fix fails twice, it escalates to heal.
     </ContentCard>
-    <ContentCard icon="mdi:hospital" iconColor="bg-red-500" title="/dx-step-heal">
-      <strong>Root cause analysis.</strong> When targeted fixes fail, heal investigates the root cause,
-      potentially restructures the approach, and creates new corrective steps in the plan.
+    <ContentCard icon="mdi:hospital" iconColor="bg-red-500" title="/dx-step-fix (escalation)">
+      <strong>Root cause analysis.</strong> When targeted fixes fail repeatedly, dx-step-fix escalates to root cause analysis,
+      potentially restructuring the approach and creating new corrective steps in the plan.
     </ContentCard>
   </div>
 
@@ -263,7 +249,7 @@ export const base = import.meta.env.BASE_URL;
   <div class="mt-4">
     <HighlightBox severity="warning" title="Review-Fix Loop">
       The code review phase runs up to <strong>3 cycles</strong> of review, fix, rebuild, re-review. If issues
-      persist after 3 cycles, it escalates to <code>/dx-step-heal</code>. If heal also fails, the pipeline
+      persist after 3 cycles, it escalates to <code>/dx-step-fix</code> for root cause analysis. If that also fails, the pipeline
       <strong> stops</strong> and asks for human input.
     </HighlightBox>
   </div>
@@ -283,9 +269,9 @@ export const base = import.meta.env.BASE_URL;
       Detects WCAG violations, generates remediation suggestions, and can auto-fix
       common issues like missing alt text and ARIA attributes.
     </ContentCard>
-    <ContentCard icon="mdi:clipboard-check-outline" iconColor="bg-emerald-600" title="Definition of Done" tags={[{label: "/dx-req-dod", color: "success"}, {label: "/dx-req-dod-fix", color: "success"}]}>
-      <code>/dx-req-dod</code> validates your work against the story's acceptance criteria and posts
-      a checklist to ADO. <code>/dx-req-dod-fix</code> auto-fixes failing items and re-checks.
+    <ContentCard icon="mdi:clipboard-check-outline" iconColor="bg-emerald-600" title="Definition of Done" tags={[{label: "/dx-req-dod", color: "success"}]}>
+      <code>/dx-req-dod</code> validates your work against the story's acceptance criteria, posts
+      a checklist to ADO, and auto-fixes failing items where possible.
     </ContentCard>
     <ContentCard icon="mdi:timer" iconColor="bg-amber-500" title="/dx-estimate" tags={[{label: "Estimation", color: "warning"}]}>
       Analyzes a story and produces structured estimation: hours per task, story points,
@@ -305,7 +291,7 @@ export const base = import.meta.env.BASE_URL;
   <PipelineBlock
     label="No orchestrator — run individually"
     steps={[
-      { title: "Commit", subtitle: "Stage & push", command: "/dx-step-commit", color: "#ec4899" },
+      { title: "Commit", subtitle: "Stage & push", command: "/dx-pr-commit", color: "#ec4899" },
       { title: "Pull Request", subtitle: "Create PR", command: "/dx-pr", color: "#3b82f6" },
       { title: "Editorial Guide", subtitle: "Dialog screenshots", command: "/aem-demo", color: "#6366f1" },
       { title: "Feature Docs", subtitle: "Wiki + authoring guide", command: "/dx-doc-gen", color: "#14b8a6" },
@@ -357,29 +343,9 @@ export const base = import.meta.env.BASE_URL;
         <td class="p-3 text-[#4a4a5a]">Full requirements pipeline (fetch + DoR + explain + research + share)</td>
       </tr>
       <tr>
-        <td class="p-3"><code>/dx-req-fetch &lt;id&gt;</code></td>
+        <td class="p-3"><code>/dx-req &lt;id&gt;</code></td>
         <td class="p-3">Requirements</td>
-        <td class="p-3 text-[#4a4a5a]">Pull work item (ADO or Jira)</td>
-      </tr>
-      <tr>
-        <td class="p-3"><code>/dx-req-dor</code></td>
-        <td class="p-3">Requirements</td>
-        <td class="p-3 text-[#4a4a5a]">Definition of Ready validation only</td>
-      </tr>
-      <tr>
-        <td class="p-3"><code>/dx-req-explain</code></td>
-        <td class="p-3">Requirements</td>
-        <td class="p-3 text-[#4a4a5a]">Developer requirements summary only</td>
-      </tr>
-      <tr>
-        <td class="p-3"><code>/dx-req-research</code></td>
-        <td class="p-3">Requirements</td>
-        <td class="p-3 text-[#4a4a5a]">Codebase research only</td>
-      </tr>
-      <tr>
-        <td class="p-3"><code>/dx-req-share</code></td>
-        <td class="p-3">Requirements</td>
-        <td class="p-3 text-[#4a4a5a]">Team summary only</td>
+        <td class="p-3 text-[#4a4a5a]">Full requirements pipeline (fetch, DoR, explain, research, share)</td>
       </tr>
       <tr>
         <td class="p-3"><code>/dx-req-import</code></td>
@@ -395,11 +361,6 @@ export const base = import.meta.env.BASE_URL;
         <td class="p-3"><code>/dx-req-dod</code></td>
         <td class="p-3">Quality</td>
         <td class="p-3 text-[#4a4a5a]">Validate work against acceptance criteria, post checklist to ADO/Jira</td>
-      </tr>
-      <tr>
-        <td class="p-3"><code>/dx-req-dod-fix</code></td>
-        <td class="p-3">Quality</td>
-        <td class="p-3 text-[#4a4a5a]">Auto-fix failing DoD items and re-check</td>
       </tr>
       <tr>
         <td class="p-3"><code>/dx-estimate</code></td>
@@ -496,11 +457,11 @@ export const base = import.meta.env.BASE_URL;
   <div class="border border-gray-200 rounded p-5 bg-white font-mono text-sm">
     <span class="block text-[0.7rem] uppercase tracking-wider text-gray-400 font-medium mb-3">Directory structure</span>
     <div class="border-b border-gray-50 py-1"><span class="font-semibold text-cyan-dark">.ai/specs/&lt;id&gt;-&lt;slug&gt;/</span></div>
-    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">raw-story.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req-fetch</code></span></div>
-    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">dor-report.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req-dor</code></span></div>
-    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">explain.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req-explain</code></span></div>
-    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">research.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req-research</code></span></div>
-    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">share-plan.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req-share</code></span></div>
+    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">raw-story.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req</code></span></div>
+    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">dor-report.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req</code></span></div>
+    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">explain.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req</code></span></div>
+    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">research.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req</code></span></div>
+    <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">share-plan.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-req</code></span></div>
     <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">implement.md</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-plan</code></span></div>
     <div class="border-b border-gray-50 py-1 pl-6"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="font-semibold text-cyan-dark">prototype/</span><span class="text-gray-400 text-xs ml-auto float-right">&larr; <code class="text-gray-400">/dx-figma-prototype</code></span></div>
     <div class="border-b border-gray-50 py-1 pl-12"><span class="text-gray-400 mr-1">&boxur;&HorizontalLine;&HorizontalLine; </span><span class="text-brand-700">index.html</span></div>
@@ -531,7 +492,7 @@ export const base = import.meta.env.BASE_URL;
       AI-powered code review on a teammate's PR -- architecture, correctness, accessibility, performance.
       Posts structured comments with inline code patches that can be applied directly.
     </ContentCard>
-    <ContentCard icon="mdi:comment-check" iconColor="bg-emerald-600" title="Handling Feedback" tags={[{label: "/dx-pr-answer", color: "success"}, {label: "/dx-pr-fix", color: "success"}]}>
+    <ContentCard icon="mdi:comment-check" iconColor="bg-emerald-600" title="Handling Feedback" tags={[{label: "/dx-pr-answer", color: "success"}]}>
       When reviewers leave comments on your PR, AI reads them, applies fixes, and posts replies --
       resolving feedback in minutes instead of days.
     </ContentCard>


### PR DESCRIPTION
## Summary

- Update 39 website files with stale skill references from the skill simplification refactor (PR #35)
- Replace deleted skill names (dx-req-fetch → dx-req, dx-step-test/review/commit → dx-step, etc.)
- Update skill counts (78 → 69 total, 55 → 43 dx-core)
- Update plugin count (3 → 4, +dx-hub)
- Remove dx-step-executor agent references

This commit was created during PR #35 but pushed after the merge — cherry-picked to a new branch.

## Test plan

- [x] `grep` for all deleted skill names returns zero matches in website/
- [x] `grep` for old counts (78/55/74/53 skills) returns zero matches in website/