### PR TITLE
fix(website): correct AEM MCP setup docs

### DIFF
--- a/plugins/dx-aem/skills/aem-init/SKILL.md
+++ b/plugins/dx-aem/skills/aem-init/SKILL.md
@@ -423,17 +423,26 @@ echo "$AEM_INSTANCES"
    Alternative: add to .claude/settings.local.json under "env" (Claude Code only, not Copilot CLI).
    ```
 
-3. **Also update `.claude/settings.local.json`** if it exists — add the `AEM_INSTANCES` key as a placeholder so users have a reference of the expected format. Do NOT overwrite existing values:
+3. **Also update `.claude/settings.local.json`** — add the `AEM_INSTANCES` key as a placeholder. Do NOT overwrite existing values:
+
+   a. **If file exists:** Merge `AEM_INSTANCES` into the existing `"env"` object.
+
+   b. **If file does not exist:** Create it with both base dx env vars and AEM env vars:
 
    ```json
    {
      "env": {
+       "QA_BASIC_AUTH_USER": "",
+       "QA_BASIC_AUTH_PASS": "",
+       "QA_BASIC_AUTH_FALLBACK_USER": "",
+       "QA_BASIC_AUTH_FALLBACK_PASS": "",
+       "AXE_API_KEY": "",
        "AEM_INSTANCES": "local:http://localhost:4502:admin:admin"
      }
    }
    ```
 
-   Report: "Added AEM_INSTANCES placeholder to `.claude/settings.local.json`. Preferred: set in shell profile for both Claude Code and Copilot CLI."
+   Report: "Updated `.claude/settings.local.json` with AEM_INSTANCES. Preferred: set in shell profile for both Claude Code and Copilot CLI."
 
 ## 12. Summary
 

--- a/plugins/dx-aem/skills/aem-init/SKILL.md
+++ b/plugins/dx-aem/skills/aem-init/SKILL.md
@@ -399,38 +399,41 @@ For `qa-basic-auth`: the rule now reads credentials from env vars first (`QA_BAS
 
 **On re-run:** Compare existing file against template. If identical: skip. If template changed and user hasn't customized: update silently. If user customized: show diff, ask.
 
-### 11a. Update Local Secrets File with AEM Env Vars
+### 11a. Check AEM Environment Variable
 
-Read `.claude/settings.local.json` (created by `/dx-init` step 5i).
+Check if `AEM_INSTANCES` is already set in the shell environment:
 
-1. **If it exists:** Parse the JSON and merge these AEM-specific env var keys into the `"env"` object (empty string value). Do NOT overwrite existing values — only add keys that are missing:
+```bash
+echo "$AEM_INSTANCES"
+```
+
+1. **If set:** Report: "AEM_INSTANCES detected in shell environment — AEM MCP will use it." Skip to step 12.
+
+2. **If not set:** Print setup instructions:
+
+   ```
+   AEM MCP requires the AEM_INSTANCES environment variable.
+   Add to your shell profile (~/.bashrc or ~/.zshrc):
+
+     export AEM_INSTANCES="local:http://localhost:4502:admin:admin"
+
+   Format: name:url:user:pass (comma-separated for multiple instances).
+   Then restart your terminal or run: source ~/.zshrc
+
+   Alternative: add to .claude/settings.local.json under "env" (Claude Code only, not Copilot CLI).
+   ```
+
+3. **Also update `.claude/settings.local.json`** if it exists — add the `AEM_INSTANCES` key as a placeholder so users have a reference of the expected format. Do NOT overwrite existing values:
 
    ```json
    {
      "env": {
-       "AEM_INSTANCES": "local:http://localhost:4502:admin:admin,qa:https://qa-author.example.com:USER:PASS"
+       "AEM_INSTANCES": "local:http://localhost:4502:admin:admin"
      }
    }
    ```
 
-   Report: "Added AEM_INSTANCES to `.claude/settings.local.json` — fill in your QA credentials" (or "AEM env vars already present" if key exists).
-
-2. **If it does not exist:** Create it with both the base dx env vars and the AEM env vars:
-
-   ```json
-   {
-     "env": {
-       "QA_BASIC_AUTH_USER": "",
-       "QA_BASIC_AUTH_PASS": "",
-       "QA_BASIC_AUTH_FALLBACK_USER": "",
-       "QA_BASIC_AUTH_FALLBACK_PASS": "",
-       "AXE_API_KEY": "",
-       "AEM_INSTANCES": "local:http://localhost:4502:admin:admin,qa:https://qa-author.example.com:USER:PASS"
-     }
-   }
-   ```
-
-   Report: "Created `.claude/settings.local.json` with AEM env vars — add your credentials before using QA/AEM skills."
+   Report: "Added AEM_INSTANCES placeholder to `.claude/settings.local.json`. Preferred: set in shell profile for both Claude Code and Copilot CLI."
 
 ## 12. Summary
 

--- a/plugins/dx-core/shared/env-vars.md
+++ b/plugins/dx-core/shared/env-vars.md
@@ -1,6 +1,9 @@
 # Environment Variables
 
-All secrets and sensitive credentials are stored as environment variables in `.claude/settings.local.json` (auto-gitignored, per-project). Claude Code loads these into the session automatically.
+All secrets and sensitive credentials are stored as environment variables. Two options (either works for Claude Code, shell is required for Copilot CLI):
+
+1. **Shell profile** (`~/.bashrc` or `~/.zshrc`) — `export VAR=value`. Works for both Claude Code and Copilot CLI. Best for machine-wide settings like `AEM_INSTANCES`.
+2. **`.claude/settings.local.json`** — `"env": { "VAR": "value" }`. Auto-gitignored, per-project. Best for project-specific secrets like QA auth credentials. Claude Code only (Copilot CLI does not read this file).
 
 ## How to Resolve Credentials
 

--- a/plugins/dx-core/skills/dx-init/SKILL.md
+++ b/plugins/dx-core/skills/dx-init/SKILL.md
@@ -432,7 +432,16 @@ If `tracker.provider` is `jira`, also include Jira/Confluence tokens in the plac
 
 Report: "Created `.claude/settings.local.json` — add your credentials before using QA/accessibility skills."
 
-> **Note:** AEM-specific env vars (`AEM_USER`, `AEM_PASS`) are added by `/aem-init` if the project is AEM.
+Print env var guidance:
+```
+Environment variables can be set in two ways (either works for Claude Code):
+  1. Shell profile (~/.bashrc or ~/.zshrc) — required for Copilot CLI compatibility
+  2. .claude/settings.local.json "env" block — Claude Code only, per-project
+
+Recommendation: use shell exports for machine-wide vars, settings.local.json for project-specific secrets.
+```
+
+> **Note:** AEM-specific env vars (`AEM_INSTANCES`) are added by `/aem-init` if the project is AEM.
 
 **On re-run:** If the file exists, check for missing env var keys from the template above. If new keys were added by a plugin update, merge them in (empty string value) without overwriting existing values.
 

--- a/website/src/pages/setup/claude-code.mdx
+++ b/website/src/pages/setup/claude-code.mdx
@@ -116,21 +116,18 @@ import CommandBlock from '../../components/CommandBlock.astro';
   </HighlightBox>
 
   <HighlightBox severity="warning" title="AEM MCP -- Manual Configuration Required">
-    AEM MCP requires <code>AEM_INSTANCES</code> to be set in <strong>two places</strong>:
-    <ol class="mt-2 text-sm">
-      <li><code>{"~"}/.bashrc</code> or <code>{"~"}/.zshrc</code> -- for Claude Code CLI and Copilot CLI</li>
-      <li><code>.claude/settings.local.json</code> -- for Claude Code session env</li>
-    </ol>
-    <p class="text-xs text-gray-500 mt-2">Why both? Copilot CLI does not read <code>settings.local.json</code> -- it only inherits shell environment variables.</p>
+    AEM MCP requires the <code>AEM_INSTANCES</code> environment variable. Add it to your shell profile -- both Claude Code and Copilot CLI inherit shell environment variables.
   </HighlightBox>
 
-  <CommandBlock label="~/.bashrc or ~/.zshrc">{`export AEM_INSTANCES='[{"name":"local","url":"http://localhost:4502","auth":"admin:admin"}]'`}</CommandBlock>
+  <CommandBlock label="~/.bashrc or ~/.zshrc">{`export AEM_INSTANCES="local:http://localhost:4502:admin:admin"
 
-  <CommandBlock label=".claude/settings.local.json">{`{
-  "env": {
-    "AEM_INSTANCES": "[{\\"name\\":\\"local\\",\\"url\\":\\"http://localhost:4502\\",\\"auth\\":\\"admin:admin\\"}]"
-  }
-}`}</CommandBlock>
+# Multiple instances (comma-separated):
+# export AEM_INSTANCES="local:http://localhost:4502:admin:admin,qa:https://qa-author.example.com:USER:PASS"`}</CommandBlock>
+
+  <HighlightBox severity="info" title="Format">
+    Colon-delimited: <code>name:url:user:pass</code>. Multiple instances separated by commas.
+    Alternatively, you can set this in <code>.claude/settings.local.json</code> under <code>"env"</code> instead of your shell profile.
+  </HighlightBox>
 
   <HighlightBox severity="info" title="Chrome DevTools MCP">
     Chrome DevTools MCP auto-launches a Chrome instance via stdio. No manual setup required -- just ensure Chrome is installed.


### PR DESCRIPTION
## Summary

- Shell export alone is sufficient — both Claude Code and Copilot CLI inherit shell env vars
- `settings.local.json` is an optional alternative, not a required second location
- Fix `AEM_INSTANCES` format from JSON array to colon-delimited string (`name:url:user:pass`) matching the canonical format in `aem-init` and `env-vars.md`

## Test plan

- [x] Format matches `plugins/dx-aem/skills/aem-init/SKILL.md` and `plugins/dx-core/shared/env-vars.md`
- [ ] Verify page renders correctly