### PR TITLE
refactor(website): move seed data guide from contributing to setup

### DIFF
--- a/website/src/layouts/SidebarLayout.astro
+++ b/website/src/layouts/SidebarLayout.astro
@@ -60,12 +60,12 @@ const sidebars: Record<string, { label: string; path: string }[]> = {
   contributing: [
     { label: 'Authoring Guide', path: '/contributing/authoring/' },
     { label: 'Technical Reference', path: '/contributing/technical-ref/' },
-    { label: 'Seed Data', path: '/contributing/seed-data/' },
     { label: 'Wiki Format', path: '/contributing/wiki-format/' },
   ],
   setup: [
     { label: 'Claude Code', path: '/setup/claude-code/' },
     { label: 'Copilot CLI', path: '/setup/copilot-cli/' },
+    { label: 'Seed Data', path: '/setup/seed-data/' },
     { label: 'Scaffold', path: '/setup/scaffold/' },
   ],
   demo: [

--- a/website/src/pages/setup/seed-data.mdx
+++ b/website/src/pages/setup/seed-data.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/SidebarLayout.astro
 title: Seed Data
-sidebar: contributing
+sidebar: setup
 ---
 
 import PageHero from '../../components/PageHero.astro';


### PR DESCRIPTION
## Summary

- Move `contributing/seed-data.mdx` → `setup/seed-data.mdx`
- Update sidebar: remove from Contributing, add to Setup (after Copilot CLI, before Scaffold)
- Seed data is project setup guidance for users, not plugin contribution docs

## Test plan

- [ ] `/setup/seed-data/` loads correctly
- [ ] `/contributing/seed-data/` returns 404
- [ ] Setup sidebar shows Seed Data link
- [ ] Contributing sidebar no longer shows Seed Data