### PR TITLE
refactor(website): reorder main nav, rename Pricing to Costs

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -16,20 +16,20 @@ function url(path: string): string {
 
 const navItems = [
   { label: 'Home', path: '/' },
-  { label: 'Learn', path: '/learn/intro/' },
+  { label: 'Setup', path: '/setup/claude-code/' },
   { label: 'Workflows', path: '/workflows/local/' },
   { label: 'Reference', path: '/reference/skills/' },
   { label: 'Architecture', path: '/architecture/overview/' },
-  { label: 'Contributing', path: '/contributing/authoring/' },
-  { label: 'Setup', path: '/setup/claude-code/' },
-  { label: 'Pricing', path: '/pricing/' },
+  { label: 'Learn', path: '/learn/intro/' },
   { label: 'Demo', path: '/demo/' },
+  { label: 'Costs', path: '/costs/' },
+  { label: 'Contributing', path: '/contributing/authoring/' },
 ];
 
 function isActive(item: any): boolean {
   const fullPath = url(item.path);
   if (item.path === '/') return currentPath === fullPath;
-  if (item.path === '/pricing/') return currentPath === fullPath;
+  if (item.path === '/costs/') return currentPath === fullPath;
   const section = url(item.path.split('/').slice(0, 2).join('/') + '/');
   return currentPath.startsWith(section);
 }

--- a/website/src/pages/costs.mdx
+++ b/website/src/pages/costs.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../layouts/BaseLayout.astro
-title: Pricing
+title: Costs
 ---
 
 import PageHero from '../components/PageHero.astro';

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -457,8 +457,8 @@ export const base = import.meta.env.BASE_URL;
     <a href={`${base}/architecture/overview/`} class="no-underline">
       <ContentCard icon="mdi:sitemap" iconColor="bg-brand-700" title="Architecture">Plugin system, config, conventions, subagents, model tiers, MCP integration.</ContentCard>
     </a>
-    <a href={`${base}/pricing/`} class="no-underline">
-      <ContentCard icon="mdi:currency-usd" iconColor="bg-brand-700" title="Pricing">Two pricing models, per-operation costs, safety controls, cost optimization.</ContentCard>
+    <a href={`${base}/costs/`} class="no-underline">
+      <ContentCard icon="mdi:currency-usd" iconColor="bg-brand-700" title="Costs">Two pricing models, per-operation costs, safety controls, cost optimization.</ContentCard>
     </a>
     <a href={`${base}/demo/`} class="no-underline">
       <ContentCard icon="mdi:rocket-launch" iconColor="bg-brand-700" title="Demo">Platform capabilities, Figma deep dive, and key commands for live demos.</ContentCard>


### PR DESCRIPTION
## Summary

- Reorder main nav: Home → Setup → Workflows → Reference → Architecture → Learn → Demo → Costs → Contributing
- Rename Pricing → Costs (page file, title, nav label, index link)

## Test plan

- [ ] Nav renders in correct order
- [ ] `/costs/` loads (old `/pricing/` returns 404)
- [ ] Home page "Costs" card links to `/costs/`