### PR TITLE
feat(website): add Why This Exists intro block to home page

### DIFF
--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -43,6 +43,41 @@ export const base = import.meta.env.BASE_URL;
 </Section>
 
 <SectionHeading
+  badge="Why"
+  title="Why This Exists"
+  bg="alt"
+/>
+<Section>
+  <p class="text-sm text-gray-600 leading-relaxed">
+    AI coding assistants are powerful, but without structure they produce inconsistent results. You end up re-explaining your project, your conventions, and your workflow every session.
+  </p>
+  <p class="text-sm text-gray-600 leading-relaxed mt-3">
+    KAI is a structured development workflow built as a plugin system. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into <strong>skills</strong> that orchestrate multi-agent pipelines. A single command like <code>/dx-req</code> pulls the ticket from ADO/Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
+  </p>
+
+  <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+    <ContentCard icon="mdi:cog" iconColor="bg-brand-700" title="Config-Driven" horizontal>
+      Your build commands, branch names, and conventions live in one config file. Every skill reads it. No hardcoded values, no repeated instructions.
+    </ContentCard>
+    <ContentCard icon="mdi:file-document" iconColor="bg-cyan" title="Persistent Memory" horizontal>
+      Each skill writes structured output to local files. The next skill picks it up automatically. Sessions can end and resume without losing context.
+    </ContentCard>
+    <ContentCard icon="mdi:earth" iconColor="bg-amber-500" title="Multi-Source Context" horizontal>
+      Skills don't just read source code. They pull ADO/Jira tickets, Figma designs, AEM content, and browser screenshots through MCP integrations.
+    </ContentCard>
+    <ContentCard icon="mdi:lightning-bolt" iconColor="bg-red-500" title="Autonomous Mode" horizontal>
+      The same skills that run locally also run unattended as ADO pipeline agents, triggered by webhooks. Tag a ticket, get a verified bugfix with a PR.
+    </ContentCard>
+    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-emerald-600" title="Dual-IDE" horizontal>
+      Same 69 skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
+    </ContentCard>
+    <ContentCard icon="mdi:star" iconColor="bg-cyan-dark" title="Superpowers Integration" horizontal>
+      6 skills optionally invoke <a href="https://github.com/obra/superpowers" class="text-brand-700">superpowers</a> methodology (brainstorming, TDD, debugging, verification) when installed.
+    </ContentCard>
+  </div>
+</Section>
+
+<SectionHeading
   badge="Get Started"
   badgeColor="success"
   title="Ready to Try?"


### PR DESCRIPTION
## Summary

Add the "Why This Exists" intro section to the home page (matching the README). Placed between stat counters and "Get Started" block.

Includes: two intro paragraphs + 6 "what makes it different" cards (Config-Driven, Persistent Memory, Multi-Source Context, Autonomous Mode, Dual-IDE, Superpowers).

Cherry-picked from `fix/setup-restructure` — commit was pushed after PR #43 merged.

## Test plan

- [ ] Home page shows "Why This Exists" section between stats and "Get Started"