### PR TITLE
refactor: delete deprecated dx-req-all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Four Claude Code plugins for AI-assisted Azure DevOps development workflows. There is no build system — plugins are pure Markdown (skills, agents, rules, templates) with shell helper scripts.
 
-- **dx-core** (`plugins/dx-core/`) — Platform-agnostic ADO/Jira workflow: requirements → planning → execution → review → PR. Works with any tech stack. 43 skills (`dx-*`), 6 agents. 15 Copilot agent templates (incl. coordinators).
+- **dx-core** (`plugins/dx-core/`) — Platform-agnostic ADO/Jira workflow: requirements → planning → execution → review → PR. Works with any tech stack. 42 skills (`dx-*`), 6 agents. 15 Copilot agent templates (incl. coordinators).
 - **dx-hub** (`plugins/dx-hub/`) — Multi-repo orchestration: hub init, config, status. 3 skills (`dx-hub-*`).
 - **dx-aem** (`plugins/dx-aem/`) — AEM-specific verification, QA, and demo capture. Includes AEM project knowledge (seed data). Requires dx. 12 skills (`aem-*`), 6 agents.
 - **dx-automation** (`plugins/dx-automation/`) — Autonomous AI agents (DoR checker, DoD checker, DoD fixer, PR reviewer, PR answerer, BugFix agent, QA agent, DevAgent, DOCAgent, Estimation) running 24/7 as ADO pipelines triggered by AWS Lambda webhooks. Requires dx. 11 skills (`auto-*`).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ From a local clone:
 
 Full-stack development workflow for Azure DevOps and Jira projects: requirements gathering, implementation planning, step-by-step execution with testing and review, code review, bug fixes, and PR management.
 
-**43 skills, 6 agents.** Works with any tech stack.
+**42 skills, 6 agents.** Works with any tech stack.
 
 ### [dx-hub](plugins/dx-hub/) — Multi-Repo Orchestration
 

--- a/docs/TODO-website-constants.md
+++ b/docs/TODO-website-constants.md
@@ -1,0 +1,49 @@
+# TODO: Extract Website Constants
+
+## Problem
+
+Skill/agent/plugin counts are hardcoded in 20+ places across website pages. Every version bump requires a grep-and-replace across all files.
+
+## Proposal
+
+Create `website/src/config/stats.ts`:
+
+```ts
+export const stats = {
+  totalSkills: 68,
+  dxCoreSkills: 42,
+  dxAemSkills: 12,
+  dxHubSkills: 3,
+  dxAutomationSkills: 11,
+  claudeAgents: 12,
+  copilotAgents: 25,
+  totalPlugins: 4,
+  autonomousAgents: 10,
+  mcpServers: 6,
+};
+```
+
+Import in `.mdx` pages:
+```mdx
+import { stats } from '../../config/stats';
+
+<div>{stats.totalSkills} skills</div>
+```
+
+## Other candidates for constants
+
+- Plugin names and descriptions (repeated in index, demo, learn/intro)
+- Figma demo URL (repeated in usage/index, demo/index)
+- GitHub repo URL
+- Website base URL patterns
+
+## Files to update (~15 pages)
+
+- index.mdx, demo/index.mdx, learn/intro.mdx, learn/skills.mdx, learn/tips.mdx
+- learn/cli-vs-chat.mdx, learn/agents.mdx, setup/copilot-cli.mdx
+- architecture/overview.mdx, reference/skills.mdx
+- 5 content/tips/*.md files
+
+## Priority
+
+Low — works fine with grep, but gets annoying on every refactor. Do it next time counts change.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,7 @@
 ### Layer 2: Skill Triggering Evals
 - [ ] Create `tests/` directory with bash test helpers (`run_claude`, `assert_contains`, `assert_order`)
 - [ ] Write trigger tests for key skills: does natural language prompt invoke the right skill?
-- [ ] Write explicit invocation tests: does `/dx-req-all 12345` trigger `dx-req-all`?
+- [ ] Write explicit invocation tests: does `/dx-req 12345` trigger `dx-req`?
 - [ ] Add `ANTHROPIC_API_KEY` as GitHub Actions secret
 - [ ] Create `tests/run-evals.sh` runner with `--quick` (10 key skills) and `--full` (all 78) modes
 - [ ] CI workflow: run on release tags only (expensive, non-deterministic)
@@ -155,7 +155,7 @@ All skill directories were prefixed with their plugin abbreviation (`dx-init`, `
 
 ## Better visual separation in multi-step skill logs
 
-Coordinator skills (`dx-req-all`, `dx-step-all`, `dx-agent-all`, `dx-bug-all`) run many steps sequentially. In the terminal output, step boundaries blend together — it's hard to see where one step ends and the next begins.
+Coordinator skills (`dx-req`, `dx-step-all`, `dx-agent-all`, `dx-bug-all`) run many steps sequentially. In the terminal output, step boundaries blend together — it's hard to see where one step ends and the next begins.
 
 **Idea:** Print a long horizontal rule (`────────────────────────────────`) above and below each step title, e.g.:
 

--- a/docs/reference/agent-catalog.md
+++ b/docs/reference/agent-catalog.md
@@ -351,7 +351,7 @@ Systematic error diagnosis. Read-only — traces errors through code, identifies
 | Property | Value |
 |----------|-------|
 | **Template** | `plugins/dx-core/templates/agents/DxReqAll.agent.md.template` |
-| **Claude equivalent** | (skill: /dx-req-all) |
+| **Claude equivalent** | (skill: /dx-req) |
 | **Invoke** | `@DxReqAll <work-item-id>` |
 
 Full requirements pipeline coordinator. Invokes `/dx-req` which handles all 5 phases (fetch → dor → explain → research → share).

--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -228,7 +228,7 @@ Coordinator skills automatically create `.ai/learning/` to store run metrics and
 ```
 .ai/learning/
 ├── raw/
-│   ├── runs.jsonl       # Run records from dx-req-all, dx-step-all, dx-bug-all
+│   ├── runs.jsonl       # Run records from dx-req, dx-step-all, dx-bug-all
 │   ├── fixes.jsonl      # Fix patterns from dx-step-all
 │   └── bugs.jsonl       # Bug patterns from dx-bug-all
 └── fixes.md             # (future) Human-readable fix summary

--- a/docs/reference/skill-catalog.md
+++ b/docs/reference/skill-catalog.md
@@ -1,6 +1,6 @@
 # Skill Catalog
 
-## dx-core plugin — 43 skills
+## dx-core plugin — 42 skills
 
 ### Estimation — 1 skill
 
@@ -8,11 +8,10 @@
 |-------|-----------|----------|-------------|--------|
 | dx-estimate | `/dx-estimate` | `<work-item-id or URL>` | Analyze ADO/Jira User Story and produce structured estimation — hours/SP, implementation plan, AEM pages, open questions. Posts as ADO/Jira comment. | ADO/Jira comment |
 
-### Requirements (`dx-req-*`) — 5 skills
+### Requirements (`dx-req-*`) — 4 skills
 
 | Skill | Invocation | Argument | Description | Output |
 |-------|-----------|----------|-------------|--------|
-| dx-req-all | `/dx-req-all` | `<work-item-id>` | Full pipeline coordinator: invokes dx-req. Gates on DoR blocking questions. Logs run metrics to `.ai/learning/`. | All spec files + ADO comments |
 | dx-req | `/dx-req` | `<work-item-id>` | Full requirements pipeline — fetch ticket, validate DoR, distill requirements, research codebase, share summary (5 phases). Includes reference docs for each phase. | All spec files + ADO comments |
 | dx-req-tasks | `/dx-req-tasks` | `<work-item-id>` | Create child Task work items with hour estimates | ADO/Jira tasks |
 | dx-req-dod | `/dx-req-dod` | `<work-item-id>` | Check Definition of Done and auto-fix gaps — validates deliverables, auto-fixes what's possible, creates tasks for the rest | `dod.md` + fixes |
@@ -130,9 +129,9 @@ Coordinator skills are implemented as Copilot agents with `handoffs:` (see [agen
 ## Skill Dependencies
 
 ```
-dx-req-all ── dx-req (5 phases: fetch → dor → explain → research → share)
-                  ↓ GATE: blocks if DoR has blocking questions
-                  ↻ BA checks items in ADO → re-run reads checkbox state → re-validates
+dx-req (5 phases: fetch → dor → explain → research → share)
+       ↓ GATE: blocks if DoR has blocking questions
+       ↻ BA checks items in ADO → re-run reads checkbox state → re-validates
 
 dx-agent-all ─┬─ dx-agent-re
               ├─ dx-plan (needs explain + research from dx-req)

--- a/plugins/dx-automation/data/pipelines/cli/ado-cli-dor.yml
+++ b/plugins/dx-automation/data/pipelines/cli/ado-cli-dor.yml
@@ -7,7 +7,7 @@ resources:
       type: git
       name: {{ADO_PROJECT}}/{{ADO_REPO}}
       ref: development
-# Claude Agent SDK pipeline — DoR Check via /dx-req-all skill.
+# Claude Agent SDK pipeline — DoR Check via /dx-req skill.
 # Triggered by Lambda webhook on work item state change.
 
 parameters:
@@ -42,7 +42,7 @@ steps:
     workingDirectory: $(Build.SourcesDirectory)
 
   - bash: |
-      PROMPT="/dx-req-all ${{ parameters.workItemId }}"
+      PROMPT="/dx-req ${{ parameters.workItemId }}"
       if [ "${{ parameters.dryRun }}" = "True" ]; then
         PROMPT="$PROMPT (dry run — analyze only, do NOT post comments to ADO)"
       else

--- a/plugins/dx-core/README.md
+++ b/plugins/dx-core/README.md
@@ -13,7 +13,7 @@ A comprehensive development workflow plugin for Azure DevOps and Jira projects. 
 
 ```bash
 /dx-init                    # One-time project setup — generates .ai/config.yaml
-/dx-req-all 2416553         # Fetch work item (ADO/Jira), distill requirements, research codebase
+/dx-req 2416553             # Fetch work item (ADO/Jira), distill requirements, research codebase
 /dx-plan                    # Generate step-by-step implementation plan
 /dx-step-all                # Execute all steps autonomously (test + review + commit loop)
 /dx-step-build                   # Build & deploy, auto-fix errors
@@ -33,7 +33,6 @@ A comprehensive development workflow plugin for Azure DevOps and Jira projects. 
 
 | Skill | Description |
 |-------|-------------|
-| `/dx-req-all` | Full requirements pipeline: fetch → dor → explain → research → share |
 | `/dx-req` | Full requirements pipeline — fetch, validate DoR, distill, research, share (5 phases) |
 | `/dx-req-tasks` | Create child Task work items with hour estimates |
 | `/dx-req-dod` | Check Definition of Done compliance and auto-fix gaps — reviews PR, tasks, docs |

--- a/plugins/dx-core/shared/subagent-contract.md
+++ b/plugins/dx-core/shared/subagent-contract.md
@@ -1,6 +1,6 @@
 # Subagent Return Envelope Contract
 
-Every subagent dispatched by a coordinator skill (dx-agent-all, dx-req-all, dx-step-all) MUST structure its final response with a `## Result` block as the FIRST section.
+Every subagent dispatched by a coordinator skill (dx-agent-all, dx-req, dx-step-all) MUST structure its final response with a `## Result` block as the FIRST section.
 
 ## Mandatory Return Envelope
 

--- a/plugins/dx-core/skills/dx-doc-gen/SKILL.md
+++ b/plugins/dx-core/skills/dx-doc-gen/SKILL.md
@@ -228,7 +228,7 @@ If the sprint is `Unknown`, create the page under `DOC_ROOT_ID` directly with an
 
 - **"No spec files found — nothing to generate from"**
   **Cause:** The spec directory exists but contains no recognized files (explain.md, implement.md, etc.).
-  **Fix:** Run the requirements and planning pipeline first (`/dx-req-all <id>` or `/dx-plan <id>`). Even `raw-story.md` alone is enough for a basic page.
+  **Fix:** Run the requirements and planning pipeline first (`/dx-req <id>` or `/dx-plan <id>`). Even `raw-story.md` alone is enough for a basic page.
 
 - **"docs/wiki-page.md already up to date — skipping"**
   **Cause:** The wiki page was already generated and the source files haven't changed.

--- a/plugins/dx-core/skills/dx-req-all/SKILL.md
+++ b/plugins/dx-core/skills/dx-req-all/SKILL.md
@@ -1,9 +1,0 @@
----
-name: dx-req-all
-description: "[Deprecated — use /dx-req directly] Full requirements pipeline."
-argument-hint: "[ADO Work Item ID or Jira key]"
----
-
-This skill is deprecated. Invoke `/dx-req` instead, which runs the full pipeline (fetch, DoR, explain, research, share).
-
-If invoked, call: `Skill(/dx-req)` with the provided argument.

--- a/plugins/dx-core/skills/dx-step-all/SKILL.md
+++ b/plugins/dx-core/skills/dx-step-all/SKILL.md
@@ -256,7 +256,7 @@ After all steps are done:
 
 ### Cross-Repo Note:
 <If implement.md has "Other repos required", print:>
-> This plan covers **<current repo>** only. Switch to **<other repo(s)>** and run `/dx-req-all <id>` there to plan and execute those changes.
+> This plan covers **<current repo>** only. Switch to **<other repo(s)>** and run `/dx-req <id>` there to plan and execute those changes.
 <Otherwise omit this section.>
 
 ### Next steps:

--- a/plugins/dx-core/skills/dx-step/SKILL.md
+++ b/plugins/dx-core/skills/dx-step/SKILL.md
@@ -107,7 +107,7 @@ If a step has `**Status:** blocked`, skip it and find the next pending step. Pri
 
 1. Check if implement.md has an `**Other repos required:**` line. If so, print:
    ```
-   > Cross-repo: This plan covers <current repo> only. Switch to <other repo(s)> and run `/dx-req-all <id>` there.
+   > Cross-repo: This plan covers <current repo> only. Switch to <other repo(s)> and run `/dx-req <id>` there.
    ```
 2. Print: "All steps are done. Run `/dx-pr` to create a pull request."
 3. STOP.

--- a/plugins/dx-core/skills/dx-ticket-analyze/SKILL.md
+++ b/plugins/dx-core/skills/dx-ticket-analyze/SKILL.md
@@ -210,7 +210,7 @@ If pipeline artifacts exist:
 > Note: This spec dir already has pipeline artifacts. `/dx-req` will pick up your ticket-research.md and use the discovered file paths to accelerate its search.
 
 If no pipeline artifacts:
-> Tip: Run `/dx-req-all <id>` to generate the full spec pipeline. The research skill will use your ticket-research.md to skip redundant searches.
+> Tip: Run `/dx-req <id>` to generate the full spec pipeline. The research skill will use your ticket-research.md to skip redundant searches.
 
 ## Examples
 

--- a/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
+++ b/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
@@ -3,7 +3,7 @@ title: "Plugin = Skills + Agents + Hooks in a Box"
 category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Plugin","Bundle","Reusable"]
-overview: "A plugin bundles skills, agents, hooks, MCP configs, and rules into a single installable package. Install once, available in every project. Our four plugins (dx-core, dx-hub, dx-aem, dx-automation) contain 69 skills, 12 agents, and 4 hooks — all distributed from a single source."
+overview: "A plugin bundles skills, agents, hooks, MCP configs, and rules into a single installable package. Install once, available in every project. Our four plugins (dx-core, dx-hub, dx-aem, dx-automation) contain 68 skills, 12 agents, and 4 hooks — all distributed from a single source."
 codeLabel: "Plugin anatomy"
 screenshot: null
 week: 8
@@ -30,7 +30,7 @@ slackText: |
   5. *Updateable* — bump version, sync to all projects
   
   *Our setup:*
-  Four plugins, 69 skills, 12 agents, distributed to 4 consumer repos:
+  Four plugins, 68 skills, 12 agents, distributed to 4 consumer repos:
   • `dx-core` — universal development workflow
   • `dx-hub` — multi-repo hub orchestration
   • `dx-aem` — AEM-specific tools
@@ -48,7 +48,7 @@ dx-core/
 │   └── plugin.json    # manifest
 ├── .mcp.json          # MCP servers
 ├── hooks/hooks.json   # hooks
-├── skills/            # 43 skills
+├── skills/            # 42 skills
 ├── agents/            # 6 agents
 └── rules/             # path-scoped rules
 ```

--- a/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
+++ b/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
@@ -3,7 +3,7 @@ title: "Terminal Agents: Claude Code vs Copilot CLI"
 category: "Meet Your AI Tools"
 focus: "Claude Code · CLI"
 tags: ["Claude Code","Copilot CLI","Terminal"]
-overview: "Both Claude Code and Copilot CLI are terminal-native autonomous agents. Claude Code has 1M token context, worktree isolation, and persistent memory. Copilot CLI (GA Feb 2026) has /fleet for parallel subagents, multi-model support (Claude + GPT + Gemini), and cloud delegation. Same 69 skills run in both."
+overview: "Both Claude Code and Copilot CLI are terminal-native autonomous agents. Claude Code has 1M token context, worktree isolation, and persistent memory. Copilot CLI (GA Feb 2026) has /fleet for parallel subagents, multi-model support (Claude + GPT + Gemini), and cloud delegation. Same 68 skills run in both."
 codeLabel: "Two terminal agents"
 screenshot: null
 week: 1
@@ -12,7 +12,7 @@ order: 3
 slackText: |
   🤖 Agentic AI Tip #3 — Terminal Agents: Claude Code vs Copilot CLI
   
-  Both are terminal-native agents. Both run our 69 skills. But they have distinct superpowers:
+  Both are terminal-native agents. Both run our 68 skills. But they have distinct superpowers:
   
   *Claude Code:*
   • 1M token context (8x more than Copilot CLI)

--- a/website/src/content/tips/your-plugin-journey-zero-to-production.md
+++ b/website/src/content/tips/your-plugin-journey-zero-to-production.md
@@ -12,7 +12,7 @@ order: 51
 slackText: |
   🤖 Agentic AI Tip #51 — Your Plugin Journey: Zero to Production
   
-  You've made it to Day 50! Here's the meta-lesson from building 69 skills across 4 plugins.
+  You've made it to Day 50! Here's the meta-lesson from building 68 skills across 4 plugins.
   
   *Don't plan a plugin. Grow one.*
   

--- a/website/src/pages/architecture/cross-agent.mdx
+++ b/website/src/pages/architecture/cross-agent.mdx
@@ -190,7 +190,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <tbody>
       <tr class="border-t border-gray-200">
         <td class="p-3">DxReqAll</td>
-        <td class="p-3"><code>/dx-req-all</code></td>
+        <td class="p-3"><code>/dx-req</code></td>
         <td class="p-3">fetch &rarr; dor &rarr; explain &rarr; research &rarr; share</td>
       </tr>
       <tr class="border-t border-gray-200">

--- a/website/src/pages/architecture/hub.mdx
+++ b/website/src/pages/architecture/hub.mdx
@@ -282,7 +282,7 @@ repos:
 │ Ticket   │ Skill      │ Frontend   │ Backend    │ Started   │
 ├──────────┼────────────┼────────────┼────────────┼───────────┤
 │ 2416553  │ dx-bug-all │ ✓ done     │ ⏳ running │ 10:32     │
-│ 2435084  │ dx-req-all │ ✓ done     │ ✓ done     │ 09:15     │
+│ 2435084  │ dx-req │ ✓ done     │ ✓ done     │ 09:15     │
 │ 2448331  │ dx-bug-all │ ✗ failed   │ — skipped  │ yesterday │
 └──────────┴────────────┴────────────┴────────────┴───────────┘`}</CommandBlock>
 

--- a/website/src/pages/architecture/overview.mdx
+++ b/website/src/pages/architecture/overview.mdx
@@ -26,7 +26,7 @@ import HighlightBox from '../../components/HighlightBox.astro';
   <HighlightBox severity="info" title="Plugin Directory Structure">
     <CommandBlock>
 {`dx-aem-flow/dx/plugins/
-  dx-core/   43 skills, 6 agents -- ADO/Jira workflow (any stack)
+  dx-core/   42 skills, 6 agents -- ADO/Jira workflow (any stack)
   dx-hub/              3 skills -- multi-repo hub orchestration
   dx-aem/              12 skills, 6 agents -- AEM verification & QA
   dx-automation/       11 skills -- autonomous 24/7 agents`}
@@ -567,7 +567,7 @@ aem:
       icon="mdi:wrench"
       iconColor="bg-cyan"
       title="Claude Code"
-      tags={[{ label: '69 skills', color: 'secondary' }, { label: '13 agents', color: 'secondary' }]}
+      tags={[{ label: '68 skills', color: 'secondary' }, { label: '13 agents', color: 'secondary' }]}
     >
       Full plugin system with MCP servers, subagents, hooks, and shared libraries.
     </ContentCard>
@@ -576,9 +576,9 @@ aem:
       icon="mdi:monitor"
       iconColor="bg-brand-700"
       title="GitHub Copilot CLI"
-      tags={[{ label: '69 skills', color: 'primary' }, { label: '25 agents', color: 'primary' }]}
+      tags={[{ label: '68 skills', color: 'primary' }, { label: '25 agents', color: 'primary' }]}
     >
-      Same 69 skills auto-discovered from plugins. 25 Copilot agents with <code>allowed-tools</code> for auto-approval
+      Same 68 skills auto-discovered from plugins. 25 Copilot agents with <code>allowed-tools</code> for auto-approval
       and <code>handoffs:</code> for navigation.
     </ContentCard>
   </div>
@@ -842,7 +842,7 @@ aem:
       <li class="py-0.5"><strong>Persona system</strong> -- not in the guide; KAI's me.md makes AI output indistinguishable from human teammates</li>
       <li class="py-0.5"><strong>Hooks for LLM offloading</strong> -- the guide focuses on skill instructions; KAI uses shell hooks for deterministic work</li>
       <li class="py-0.5"><strong>24/7 autonomous agents</strong> -- the guide covers interactive use; KAI runs the same skills unattended on ADO pipelines</li>
-      <li class="py-0.5"><strong>Dual-IDE support</strong> -- same 69 skills + shared marketplace work in both Claude Code and GitHub Copilot CLI</li>
+      <li class="py-0.5"><strong>Dual-IDE support</strong> -- same 68 skills + shared marketplace work in both Claude Code and GitHub Copilot CLI</li>
     </ul>
   </HighlightBox>
 

--- a/website/src/pages/demo/index.mdx
+++ b/website/src/pages/demo/index.mdx
@@ -388,7 +388,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     </div>
     <div class="border border-brand-700 rounded-lg p-5 bg-white h-full">
       <h3 class="text-base font-semibold text-brand-900 mb-1">Layer 2: Local Workflow (Claude Code + Copilot CLI)</h3>
-      <p class="text-sm text-gray-500">69 skills on both IDEs -- requirements, planning, execution, review, PR</p>
+      <p class="text-sm text-gray-500">68 skills on both IDEs -- requirements, planning, execution, review, PR</p>
     </div>
     <div class="border border-emerald-600 rounded-lg p-5 bg-white h-full">
       <h3 class="text-base font-semibold text-brand-900 mb-1">Layer 1: Foundation</h3>
@@ -398,7 +398,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
   <div class="grid md:grid-cols-3 gap-4 mt-6">
     <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="Plugin System" horizontal>
-      4 plugins, each independently installable. dx-core (43 skills, 6 agents),
+      4 plugins, each independently installable. dx-core (42 skills, 6 agents),
       dx-hub (3 skills), dx-aem (12 skills, 6 agents), dx-automation (11 skills, 10 pipeline agents).
     </ContentCard>
     <ContentCard icon="mdi:earth" iconColor="bg-cyan-dark" title="Live MCP Integrations" horizontal>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -141,7 +141,7 @@ export const base = import.meta.env.BASE_URL;
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:file-document-outline" iconColor="bg-brand-700" title="Requirements" tags={[{ label: '/dx-req-all', color: 'primary' }]}>
+    <ContentCard icon="mdi:file-document-outline" iconColor="bg-brand-700" title="Requirements" tags={[{ label: '/dx-req', color: 'primary' }]}>
       Fetch ticket (ADO or Jira), validate DoR, distill dev requirements, research codebase, generate team summary. Hours to minutes.
     </ContentCard>
     <ContentCard icon="mdi:pencil-ruler" iconColor="bg-cyan" title="Design-to-Code" tags={[{ label: '/dx-figma-all', color: 'secondary' }]}>

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -20,7 +20,7 @@ export const base = import.meta.env.BASE_URL;
 <Section>
   <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 text-center">
     <div>
-      <div class="text-4xl font-extrabold text-cyan">69</div>
+      <div class="text-4xl font-extrabold text-cyan">68</div>
       <div class="text-sm text-gray-500">Skills</div>
     </div>
     <div>
@@ -69,7 +69,7 @@ export const base = import.meta.env.BASE_URL;
       The same skills that run locally also run unattended as ADO pipeline agents, triggered by webhooks. Tag a ticket, get a verified bugfix with a PR.
     </ContentCard>
     <ContentCard icon="mdi:hammer-wrench" iconColor="bg-emerald-600" title="Dual-IDE" horizontal>
-      Same 69 skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
+      Same 68 skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
     </ContentCard>
     <ContentCard icon="mdi:star" iconColor="bg-cyan-dark" title="Superpowers Integration" horizontal>
       6 skills optionally invoke <a href="https://github.com/obra/superpowers" class="text-brand-700">superpowers</a> methodology (brainstorming, TDD, debugging, verification) when installed.
@@ -171,7 +171,7 @@ export const base = import.meta.env.BASE_URL;
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:wrench" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '43 skills' }, { label: '6 agents', color: 'secondary' }]}>
+    <ContentCard icon="mdi:wrench" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '42 skills' }, { label: '6 agents', color: 'secondary' }]}>
       Full development lifecycle -- requirements, planning, execution, review, PR, accessibility, documentation. Works with any stack.
     </ContentCard>
     <ContentCard icon="mdi:cube-outline" iconColor="bg-amber-500" title="dx-aem" tags={[{ label: '12 skills', color: 'warning' }, { label: '6 agents', color: 'secondary' }]}>
@@ -201,7 +201,7 @@ export const base = import.meta.env.BASE_URL;
       Coordinators invoke skills directly via Skill() calls. No intermediary agent needed. Self-healing with 3 layers: fix, heal, retry loop.
     </ContentCard>
     <ContentCard icon="mdi:hammer-wrench" iconColor="bg-brand-700" title="Dual-IDE Support" horizontal>
-      Same 69 skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
+      Same 68 skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
     </ContentCard>
     <ContentCard icon="mdi:target" iconColor="bg-cyan" title="Model Tier Strategy" horizontal>
       Opus for deep code review. Sonnet for execution. Haiku for simple lookups. Cost scales with complexity, not volume.

--- a/website/src/pages/learn/cli-vs-chat.mdx
+++ b/website/src/pages/learn/cli-vs-chat.mdx
@@ -194,7 +194,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   badge="Skills"
   badgeColor="info"
   title="VS Code Chat -- Skill Compatibility"
-  subtitle="38 of 69 skills work. 17 need context:fork or agent: dispatch (Claude Code-only features)."
+  subtitle="38 of 68 skills work. 17 need context:fork or agent: dispatch (Claude Code-only features)."
   bg="primary"
 />
 <Section>
@@ -308,14 +308,14 @@ import CommandBlock from '../../components/CommandBlock.astro';
 />
 <Section>
   <HighlightBox severity="info" title="Key Insight">
-    Claude Code and Copilot CLI are <strong>nearly identical in capability</strong> -- both are terminal-based, both run the same 69 skills, both load plugins and MCP servers.
+    Claude Code and Copilot CLI are <strong>nearly identical in capability</strong> -- both are terminal-based, both run the same 68 skills, both load plugins and MCP servers.
     The real difference is between <strong>terminal CLIs</strong> (Claude Code + Copilot CLI) and <strong>VS Code Chat</strong> (IDE-integrated, visual, different file discovery).
   </HighlightBox>
 
   <div class="grid md:grid-cols-3 gap-4 mt-4">
     <ContentCard icon="mdi:console" iconColor="bg-cyan" title="Terminal CLIs (Claude Code / Copilot CLI)" tags={[{ label: 'Full power', color: 'secondary' }]}>
       <ul class="mt-2 list-none p-0 text-sm space-y-1">
-        <li><strong>All 69 skills</strong> via /dx-&#42; commands</li>
+        <li><strong>All 68 skills</strong> via /dx-&#42; commands</li>
         <li>Full plugin system (hooks, MCP, agents)</li>
         <li>Subagent orchestration</li>
         <li>CI/CD pipeline automation (headless -p mode)</li>

--- a/website/src/pages/learn/cli-vs-chat.mdx
+++ b/website/src/pages/learn/cli-vs-chat.mdx
@@ -215,7 +215,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       <code>disable-model-invocation</code> (coordinator pattern).
       VS Code Chat ignores these fields -- skills load but can't orchestrate subagents.
 
-      <strong>Coordinators:</strong> <code>dx-agent-all</code>, <code>dx-req-all</code>,
+      <strong>Coordinators:</strong> <code>dx-agent-all</code>, <code>dx-req</code>,
       <code>dx-step-all</code>, <code>dx-bug-all</code>, <code>dx-figma-all</code>
 
       <strong>AEM (need inspector agent):</strong> <code>aem-snapshot</code>, <code>aem-verify</code>,
@@ -341,7 +341,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     </ContentCard>
     <ContentCard icon="mdi:swap-horizontal" iconColor="bg-emerald-600" title="Use Together" tags={[{ label: 'Recommended', color: 'success' }]}>
       <ul class="mt-2 list-none p-0 text-sm space-y-1">
-        <li><strong>CLI</strong> for structured workflows (/dx-req-all → /dx-plan → /dx-step-all)</li>
+        <li><strong>CLI</strong> for structured workflows (/dx-req → /dx-plan → /dx-step-all)</li>
         <li><strong>Chat</strong> for "fix this function", "explain this file"</li>
         <li><strong>CLI</strong> for PR review, ticket analysis, AEM verification</li>
         <li><strong>Chat</strong> for visual diff review and inline edits</li>

--- a/website/src/pages/learn/intro.mdx
+++ b/website/src/pages/learn/intro.mdx
@@ -192,7 +192,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       icon="mdi:puzzle"
       iconColor="bg-brand-700"
       title="dx-core"
-      tags={[{ label: '43 skills', color: 'primary' }, { label: '6 agents', color: 'primary' }]}
+      tags={[{ label: '42 skills', color: 'primary' }, { label: '6 agents', color: 'primary' }]}
     >
       Core development workflow -- requirements, planning, execution, review, bug fix.
       Works with any tech stack.

--- a/website/src/pages/learn/skills.mdx
+++ b/website/src/pages/learn/skills.mdx
@@ -108,7 +108,7 @@ a step-by-step implementation plan.
   badge="Categories"
   badgeColor="warning"
   title="Skill Categories in KAI"
-  subtitle="69 skills organized by workflow phase."
+  subtitle="68 skills organized by workflow phase."
   bg="alt"
 />
 <Section>

--- a/website/src/pages/learn/tips.mdx
+++ b/website/src/pages/learn/tips.mdx
@@ -13,7 +13,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
 <PageHero
   title="Tips & Best Practices"
-  subtitle="Practical advice from building 69 skills and running 10 autonomous agents"
+  subtitle="Practical advice from building 68 skills and running 10 autonomous agents"
 />
 
 <SectionHeading

--- a/website/src/pages/reference/agents.mdx
+++ b/website/src/pages/reference/agents.mdx
@@ -229,7 +229,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <tr><td class="p-3"><code>@DxPRFix</code></td><td class="p-3">/dx-pr-answer</td><td class="p-3">Applies agree-will-fix PR review changes.</td><td class="p-3">DxPRAnswer, DxCommit</td></tr>
         <tr><td class="p-3"><code>@DxCommit</code></td><td class="p-3">/dx-pr-commit</td><td class="p-3">Smart commit with conventional message. Optionally creates ADO pull request.</td><td class="p-3">DxPRReview, DxCodeReview</td></tr>
         <tr><td class="p-3"><code>@DxDebug</code></td><td class="p-3">--</td><td class="p-3">Systematic error diagnosis. Read-only -- traces errors, identifies root causes.</td><td class="p-3">DxPlanExecutor, DxCodeReview</td></tr>
-        <tr><td class="p-3"><code>@DxReqAll</code></td><td class="p-3">/dx-req-all</td><td class="p-3">Full requirements pipeline coordinator.</td><td class="p-3">DxPlanExecutor, DxTicket</td></tr>
+        <tr><td class="p-3"><code>@DxReqAll</code></td><td class="p-3">/dx-req</td><td class="p-3">Full requirements pipeline coordinator.</td><td class="p-3">DxPlanExecutor, DxTicket</td></tr>
         <tr><td class="p-3"><code>@DxStepAll</code></td><td class="p-3">/dx-step-all</td><td class="p-3">Execution loop coordinator.</td><td class="p-3">DxCodeReview, DxCommit, DxDebug</td></tr>
         <tr><td class="p-3"><code>@DxBugAll</code></td><td class="p-3">/dx-bug-all</td><td class="p-3">Full bug workflow coordinator.</td><td class="p-3">DxCodeReview, DxCommit</td></tr>
         <tr><td class="p-3"><code>@DxAgentAll</code></td><td class="p-3">/dx-agent-all</td><td class="p-3">End-to-end delivery coordinator.</td><td class="p-3">DxCodeReview, DxCommit, DxDebug</td></tr>

--- a/website/src/pages/reference/commands.mdx
+++ b/website/src/pages/reference/commands.mdx
@@ -95,7 +95,6 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Output</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>/dx-req-all</code></td><td class="p-3"><code>&lt;id&gt;</code></td><td class="p-3">Full pipeline coordinator: invokes dx-req</td><td class="p-3"><code>specs/&lt;id&gt;-&#42;/</code></td></tr>
         <tr><td class="p-3"><code>/dx-req</code></td><td class="p-3"><code>&lt;id&gt;</code></td><td class="p-3">Full requirements pipeline (fetch, DoR, explain, research, share)</td><td class="p-3">All spec files + ADO comments</td></tr>
         <tr><td class="p-3"><code>/dx-req-tasks</code></td><td class="p-3"><code>&lt;id&gt;</code></td><td class="p-3">Create child Task work items with estimates</td><td class="p-3">ADO/Jira tasks</td></tr>
         <tr><td class="p-3"><code>/dx-req-import</code></td><td class="p-3"><code>&lt;path&gt;</code></td><td class="p-3">Validate external requirements document</td><td class="p-3"><code>explain.md</code></td></tr>
@@ -471,7 +470,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:source-branch" iconColor="bg-brand-700" title="How It Works">
       <ol class="text-sm list-decimal list-inside space-y-1 mt-2">
-        <li>Requirements phase (<code>/dx-req-all</code>) discovers which repos need work</li>
+        <li>Requirements phase (<code>/dx-req</code>) discovers which repos need work</li>
         <li><code>research.md</code> and <code>explain.md</code> list the repos involved</li>
         <li>Plan and execution only cover the <strong>current repo</strong></li>
         <li>Switch to the other repo and run the same workflow there</li>
@@ -487,12 +486,12 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
   <CommandBlock label="Manual cross-repo workflow">
 {`# In backend repo:
-/dx-req-all 2416553
+/dx-req 2416553
 /dx-plan
 /dx-step-all
 
 # In frontend repo (same ticket, plans FE steps only):
-/dx-req-all 2416553
+/dx-req 2416553
 /dx-plan
 /dx-step-all`}
   </CommandBlock>

--- a/website/src/pages/reference/coordinators.mdx
+++ b/website/src/pages/reference/coordinators.mdx
@@ -37,7 +37,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Model Strategy</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>dx-req-all</code></td><td class="p-3">4 steps</td><td class="p-3">Requirements gathering</td><td class="p-3">Sonnet + Opus (checklist)</td></tr>
+        <tr><td class="p-3"><code>dx-req</code></td><td class="p-3">4 steps</td><td class="p-3">Requirements gathering</td><td class="p-3">Sonnet + Opus (checklist)</td></tr>
         <tr><td class="p-3"><code>dx-step-all</code></td><td class="p-3">N steps (dynamic)</td><td class="p-3">Plan execution loop</td><td class="p-3">Sonnet + Opus (fix/heal) + Haiku (test/commit)</td></tr>
         <tr><td class="p-3"><code>dx-bug-all</code></td><td class="p-3">3 steps</td><td class="p-3">Bug triage, verify, fix</td><td class="p-3">Sonnet + Opus (fix planning)</td></tr>
         <tr><td class="p-3"><code>dx-agent-all</code></td><td class="p-3">12 phases (max 13)</td><td class="p-3">Full story to PR pipeline</td><td class="p-3">All tiers</td></tr>
@@ -92,20 +92,20 @@ import CommandBlock from '../../components/CommandBlock.astro';
 </Section>
 
 {/* ════════════════════════════════════════════════════════════════════════ */}
-{/* dx-req-all                                                              */}
+{/* dx-req                                                              */}
 {/* ════════════════════════════════════════════════════════════════════════ */}
 
 <SectionHeading
   badge="Coordinator"
   badgeColor="primary"
-  title="dx-req-all"
+  title="dx-req"
   subtitle="Requirements gathering pipeline -- 4 steps"
   bg="alt"
 />
 <Section>
   <PipelineBlock
     label="Requirements Pipeline"
-    command="/dx-req-all <work-item-id>"
+    command="/dx-req <work-item-id>"
     steps={[
       { title: 'requirements', subtitle: 'Full pipeline (fetch, DoR, explain, research, share)', command: '/dx-req' },
     ]}
@@ -202,7 +202,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     command="/dx-agent-all <work-item-id>"
     description="Interactive by default -- pauses after requirements. Add 'autonomous' to skip pauses."
     steps={[
-      { title: 'Phase 1', subtitle: 'Requirements', command: 'dx-req-all' },
+      { title: 'Phase 1', subtitle: 'Requirements', command: 'dx-req' },
       { title: 'Phase 1.5', subtitle: 'Figma extract', command: 'dx-figma-extract' },
       { title: 'Phase 2', subtitle: 'Figma prototype', command: 'dx-figma-prototype' },
       { title: 'Phase 2b', subtitle: 'Planning', command: 'dx-plan' },
@@ -230,7 +230,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 />
 <Section>
   <div class="space-y-4">
-    <ContentCard icon="mdi:clipboard-text" iconColor="bg-brand-700" title="Phase 1: Requirements (dx-req-all)">
+    <ContentCard icon="mdi:clipboard-text" iconColor="bg-brand-700" title="Phase 1: Requirements (dx-req)">
       Subagent runs the full requirements pipeline: fetch, dor, explain, research, share.
       <strong>Interactive:</strong> Pauses for human review of dor-report.md and explain.md.
       <strong>Autonomous:</strong> Continues immediately.
@@ -374,7 +374,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
     <table class="w-full text-sm border-collapse bg-white rounded overflow-hidden">
       <thead><tr class="bg-brand-100">
         <th class="text-left p-3 font-semibold text-brand-900">Phase</th>
-        <th class="text-left p-3 font-semibold text-brand-900">dx-req-all</th>
+        <th class="text-left p-3 font-semibold text-brand-900">dx-req</th>
         <th class="text-left p-3 font-semibold text-brand-900">dx-step-all</th>
         <th class="text-left p-3 font-semibold text-brand-900">dx-bug-all</th>
         <th class="text-left p-3 font-semibold text-brand-900">dx-agent-all</th>
@@ -418,7 +418,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Autonomous</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>dx-req-all</code></td><td class="p-3">No pauses</td><td class="p-3">No pauses</td></tr>
+        <tr><td class="p-3"><code>dx-req</code></td><td class="p-3">No pauses</td><td class="p-3">No pauses</td></tr>
         <tr><td class="p-3"><code>dx-step-all</code></td><td class="p-3">No pauses</td><td class="p-3">No pauses</td></tr>
         <tr><td class="p-3"><code>dx-bug-all</code></td><td class="p-3">No pauses</td><td class="p-3">No pauses</td></tr>
         <tr><td class="p-3"><code>dx-agent-all</code></td><td class="p-3">Pause after requirements, auto-continue after planning</td><td class="p-3">Straight through</td></tr>

--- a/website/src/pages/reference/skills.mdx
+++ b/website/src/pages/reference/skills.mdx
@@ -14,7 +14,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
 <PageHero
   title="Skill Catalog"
-  subtitle="All slash commands across the four plugins -- 69 skills total"
+  subtitle="All slash commands across the four plugins -- 68 skills total"
 />
 
 <SectionHeading
@@ -25,7 +25,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 />
 <Section>
   <div class="grid md:grid-cols-3 gap-4">
-    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '43 skills', color: 'primary' }]}>
+    <ContentCard icon="mdi:puzzle" iconColor="bg-brand-700" title="dx-core" tags={[{ label: '42 skills', color: 'primary' }]}>
       Platform-agnostic ADO/Jira workflow: requirements, planning, execution, review, PR, bug fix, documentation, and utility.
     </ContentCard>
     <ContentCard icon="mdi:web" iconColor="bg-cyan-dark" title="dx-aem" tags={[{ label: '12 skills', color: 'secondary' }]}>

--- a/website/src/pages/reference/skills.mdx
+++ b/website/src/pages/reference/skills.mdx
@@ -81,7 +81,6 @@ import CommandBlock from '../../components/CommandBlock.astro';
         <th class="text-left p-3 font-semibold text-brand-900">Output</th>
       </tr></thead>
       <tbody class="divide-y divide-gray-100">
-        <tr><td class="p-3"><code>/dx-req-all</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Coordinator: invokes /dx-req. Gates on DoR blocking questions. Logs run metrics.</td><td class="p-3">All spec files + ADO comments</td></tr>
         <tr><td class="p-3"><code>/dx-req</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Full requirements pipeline: fetch work item, validate DoR, distill dev requirements, research codebase, generate team summary. Posts interactive checkbox comment to ADO/Jira (idempotent).</td><td class="p-3">All spec files + ADO comments</td></tr>
         <tr><td class="p-3"><code>/dx-req-tasks</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Create child Task work items with hour estimates.</td><td class="p-3">ADO/Jira tasks</td></tr>
         <tr><td class="p-3"><code>/dx-req-dod</code></td><td class="p-3"><code>&lt;work-item-id&gt;</code></td><td class="p-3">Check Definition of Done against ADO/Jira wiki checklist -- validates actual deliverables: PR, tests, build, docs, child tasks. Auto-fixes what is possible, creates tasks for the rest.</td><td class="p-3"><code>dod.md</code></td></tr>
@@ -468,11 +467,10 @@ import CommandBlock from '../../components/CommandBlock.astro';
   bg="alt"
 />
 <Section>
-  <ContentCard icon="mdi:source-branch" iconColor="bg-brand-700" title="dx-req-all chain">
-    <code class="text-xs block mt-2 whitespace-pre-wrap bg-gray-50 p-3 rounded">{`dx-req-all
-  └─ dx-req (full pipeline: fetch → DoR → explain → research → share)
-       GATE: blocks if blocking questions exist
-       BA checks items → re-run reads state → re-validates`}</code>
+  <ContentCard icon="mdi:source-branch" iconColor="bg-brand-700" title="dx-req chain">
+    <code class="text-xs block mt-2 whitespace-pre-wrap bg-gray-50 p-3 rounded">{`dx-req (full pipeline: fetch → DoR → explain → research → share)
+  GATE: blocks if blocking questions exist
+  BA checks items → re-run reads state → re-validates`}</code>
   </ContentCard>
 
   <ContentCard icon="mdi:source-branch" iconColor="bg-cyan-dark" title="dx-agent-all chain" class="mt-4">

--- a/website/src/pages/setup/copilot-cli.mdx
+++ b/website/src/pages/setup/copilot-cli.mdx
@@ -134,7 +134,7 @@ export JIRA_USER_EMAIL="you@example.com"`}</CommandBlock>
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4">Skills</td><td class="py-2 px-4">69 skills, same commands</td><td class="py-2 px-4"></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4">Skills</td><td class="py-2 px-4">68 skills, same commands</td><td class="py-2 px-4"></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">Marketplace</td><td class="py-2 px-4">Same git URL</td><td class="py-2 px-4"></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">Rules</td><td class="py-2 px-4">Same .claude/rules/ files</td><td class="py-2 px-4">Dual frontmatter (paths: + applyTo:)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">Agents</td><td class="py-2 px-4"></td><td class="py-2 px-4">Claude: 12 subagents | Copilot: 25 @Agents</td></tr>

--- a/website/src/pages/usage/local.mdx
+++ b/website/src/pages/usage/local.mdx
@@ -21,7 +21,7 @@ export const base = import.meta.env.BASE_URL;
 
 <Section>
   <HighlightBox severity="info" title="How It Works">
-    Instead of writing complex prompts, you run **skills** -- short commands like <code>/dx-req-all</code> or <code>/dx-plan</code>.
+    Instead of writing complex prompts, you run **skills** -- short commands like <code>/dx-req</code> or <code>/dx-plan</code>.
     Each skill already knows what context to gather (tickets, codebase, config, prior specs -- not just source code),
     which subagents to spawn for parallel work, and what output format to produce.
 
@@ -77,7 +77,7 @@ export const base = import.meta.env.BASE_URL;
 <Section>
   <PipelineBlock
     label="One Command"
-    command="/dx-req-all <ID or JIRA-KEY>"
+    command="/dx-req <ID or JIRA-KEY>"
     steps={[
       { title: "Requirements", subtitle: "Full pipeline (fetch, DoR, explain, research, share)", command: "/dx-req" },
     ]}
@@ -87,7 +87,7 @@ export const base = import.meta.env.BASE_URL;
     <ContentCard icon="mdi:download" iconColor="bg-brand-700" title="/dx-req" tags={[{label: "All spec files", color: "primary"}]}>
       Full requirements pipeline in one skill: fetches the work item (ADO or Jira), validates DoR, distills developer requirements, researches the codebase, and generates a team summary. Produces raw-story.md, dor-report.md, explain.md, research.md, and share-plan.md.
     </ContentCard>
-    <ContentCard icon="mdi:clipboard-check" iconColor="bg-amber-500" title="/dx-req-all" tags={[{label: "Coordinator", color: "warning"}]}>
+    <ContentCard icon="mdi:clipboard-check" iconColor="bg-amber-500" title="/dx-req" tags={[{label: "Coordinator", color: "warning"}]}>
       Coordinator that invokes /dx-req. Use this for the full orchestrated pipeline with run logging and metrics.
     </ContentCard>
   </div>
@@ -338,7 +338,7 @@ export const base = import.meta.env.BASE_URL;
     </thead>
     <tbody class="divide-y divide-gray-100">
       <tr>
-        <td class="p-3"><code>/dx-req-all &lt;id&gt;</code></td>
+        <td class="p-3"><code>/dx-req &lt;id&gt;</code></td>
         <td class="p-3">Requirements</td>
         <td class="p-3 text-[#4a4a5a]">Full requirements pipeline (fetch + DoR + explain + research + share)</td>
       </tr>


### PR DESCRIPTION
## Summary

- Deleted `plugins/dx-core/skills/dx-req-all/SKILL.md` -- a thin coordinator wrapper that just invoked `/dx-req`
- Replaced all `dx-req-all` references with `dx-req` across 21 files (plugins, docs, website, pipeline YAML)
- Skill count drops from 43 to 42 in dx-core (69 to 68 total)
- Historical spec/plan files in `docs/superpowers/` left untouched

## Test plan

- [x] `scripts/validate-skills.sh` passes (68 skills, 0 errors)
- [ ] Grep confirms zero `dx-req-all` references outside historical spec files
- [ ] Website builds without errors
- [ ] `/dx-req <id>` still works end-to-end