### PR TITLE
fix: update init templates to use /dx-req instead of /dx-req-all

### DIFF
--- a/plugins/dx-aem/templates/agents/AEMTicket.agent.md.template
+++ b/plugins/dx-aem/templates/agents/AEMTicket.agent.md.template
@@ -158,7 +158,7 @@ Dispatch agents simultaneously:
 If the user says yes:
 1. Create directory `.ai/specs/<id>-<slug>/`
 2. Write to `.ai/specs/<id>-<slug>/ticket-research.md`
-3. Suggest: `/dx-req-all <id>` to generate the full spec pipeline
+3. Suggest: `/dx-req <id>` to generate the full spec pipeline
 
 ## Rules
 

--- a/plugins/dx-core/templates/README.md.template
+++ b/plugins/dx-core/templates/README.md.template
@@ -12,7 +12,7 @@
 ## Quick Start
 
 ```
-/dx-req-all <ID>    # Fetch work item (ADO/Jira), explain, research codebase
+/dx-req <ID>    # Fetch work item (ADO/Jira), explain, research codebase
 /dx-plan            # Generate step-by-step implementation plan
 /dx-step-all        # Execute all steps (test + review + commit loop)
 /dx-step-build      # Build & deploy

--- a/plugins/dx-core/templates/docs/architecture.md.template
+++ b/plugins/dx-core/templates/docs/architecture.md.template
@@ -41,7 +41,7 @@
           |          Developer's Machine         |
           |                                      |
           |  Claude Code CLI  or  VS Code        |
-          |  /dx-req-all         @DxPRReview     |
+          |  /dx-req         @DxPRReview     |
           |  /dx-plan            @DxCodeReview   |
           |  /dx-step-all        @DxCommit       |
           |                                      |
@@ -57,7 +57,7 @@
 The developer runs commands. The AI assists.
 
 ```
-/dx-req-all <ID>  -->  skill reads config.yaml
+/dx-req <ID>  -->  skill reads config.yaml
                        skill fetches ADO work item
                        skill researches codebase (parallel agents)
                        skill writes .ai/specs/<id>-<slug>/raw-story.md, explain.md, research.md

--- a/plugins/dx-core/templates/docs/dx-dev-local-flow.md.template
+++ b/plugins/dx-core/templates/docs/dx-dev-local-flow.md.template
@@ -142,9 +142,9 @@ flowchart TD
 
 ---
 
-## Requirements Flow (/dx-req-all)
+## Requirements Flow (/dx-req)
 
-**Developer types:** `/dx-req-all <ADO-Story-ID>` (or individual skills: `/dx-req`, `/dx-req (dor)`, etc.)
+**Developer types:** `/dx-req <ADO-Story-ID>` (or individual skills: `/dx-req`, `/dx-req (dor)`, etc.)
 
 Chains 5 skills sequentially via `subagent` agents. Each step must complete before the next starts.
 
@@ -207,7 +207,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    subgraph INPUTS["Input Files (created by /dx-req-all + /dx-figma-*)"]
+    subgraph INPUTS["Input Files (created by /dx-req + /dx-figma-*)"]
         EXP["explain.md (required)"]
         RES["research.md (recommended)"]
         RAW["raw-story.md (reference)"]

--- a/plugins/dx-core/templates/docs/local-workflow.md.template
+++ b/plugins/dx-core/templates/docs/local-workflow.md.template
@@ -7,7 +7,7 @@ All commands run in Claude Code (terminal) or as `@Agent` in VS Code Copilot cha
 ## Quick Start
 
 ```
-/dx-req-all <ID>    # Fetch ADO story, explain, research codebase
+/dx-req <ID>    # Fetch ADO story, explain, research codebase
 /dx-plan            # Generate step-by-step implementation plan
 /dx-step-all        # Execute all steps (test + review + commit loop)
 /dx-step-build      # Build & deploy
@@ -21,7 +21,7 @@ All commands run in Claude Code (terminal) or as `@Agent` in VS Code Copilot cha
 
 | Command | What it does | Output |
 |---------|-------------|--------|
-| `/dx-req-all <ID>` | Full pipeline: fetch, dor, explain, research, share approach | All spec files + ADO comments |
+| `/dx-req <ID>` | Full pipeline: fetch, dor, explain, research, share approach | All spec files + ADO comments |
 | `/dx-req <ID>` | Full requirements pipeline — fetch, DoR, explain, research, share (5 phases) | All spec files + ADO comments |
 | `/dx-req-dod` | Validate Definition of Done and auto-fix gaps — tests, PR, docs, build | `dod.md` + fixes |
 | `/dx-req-tasks <ID>` | Create child Task work items with hour estimates | ADO tasks |
@@ -103,13 +103,13 @@ All commands run in Claude Code (terminal) or as `@Agent` in VS Code Copilot cha
 
 **"Just give me the requirements, I'll code myself"**
 ```
-/dx-req-all <ID>
+/dx-req <ID>
 # Review .ai/specs/<id>-*/explain.md, then code manually
 ```
 
 **"Generate a plan, then execute it"**
 ```
-/dx-req-all <ID>
+/dx-req <ID>
 /dx-plan
 /dx-plan-validate
 /dx-step-all
@@ -150,12 +150,12 @@ Some tickets require changes in multiple repos. Run the workflow in each repo in
 
 ```
 # In first repo:
-/dx-req-all <ID>   # research.md lists other repos involved
+/dx-req <ID>   # research.md lists other repos involved
 /dx-plan           # plans only the changes for THIS repo
 /dx-step-all
 
 # Switch to second repo, run same workflow
-/dx-req-all <ID>
+/dx-req <ID>
 /dx-plan
 /dx-step-all
 ```
@@ -166,7 +166,7 @@ All skills also work in VS Code Copilot chat via `@AgentName`:
 
 | Agent | Same as | Handoffs to |
 |-------|---------|-------------|
-| `@DxReqAll` | `/dx-req-all` | `@DxPlanExecutor`, `@DxFigma` |
+| `@DxReqAll` | `/dx-req` | `@DxPlanExecutor`, `@DxFigma` |
 | `@DxStepAll` | `/dx-step-all` | `@DxCodeReview`, `@DxCommit` |
 | `@DxBugAll` | `/dx-bug-all` | `@DxCodeReview`, `@DxCommit` |
 | `@DxAgentAll` | `/dx-agent-all` | `@DxCodeReview`, `@DxCommit` |

--- a/plugins/dx-core/templates/docs/testing.md.template
+++ b/plugins/dx-core/templates/docs/testing.md.template
@@ -4,7 +4,7 @@
 
 | Flow | Command | Pass when |
 |------|---------|-----------|
-| Story workflow | `/dx-req-all <ID>` then `/dx-plan` then `/dx-agent-all` | Spec files created, steps executed, PR created |
+| Story workflow | `/dx-req <ID>` then `/dx-plan` then `/dx-agent-all` | Spec files created, steps executed, PR created |
 | Bug fix | `/dx-bug-all <ID>` | Triage + fix, no `[ALERT:CRITICAL]` |
 | PR review | `/dx-pr-review <PR>` then `/dx-pr-answer` | Review posted, answers drafted |
 | AEM verify | `/aem-snapshot <comp>` then `/aem-verify <comp>` | Before/after snapshots captured |


### PR DESCRIPTION
## Summary

- Replace all `/dx-req-all` references with `/dx-req` in init-time doc templates
- 6 template files, 15 occurrences

## Test plan

- [ ] `grep -r "dx-req-all" plugins/*/templates/` — zero matches after merge