### PR TITLE
fix: demo wiki authoring section and wiki page dedup

### DIFF
--- a/plugins/dx-core/data/templates/wiki/wiki-page-aem.md.template
+++ b/plugins/dx-core/data/templates/wiki/wiki-page-aem.md.template
@@ -39,7 +39,8 @@ Include technique used and WHY chosen over alternatives. -->
 
 ### Configuration
 
-<!-- OMIT if none. New config values, env vars, feature flags, dialog fields. -->
+<!-- OMIT if none. Non-dialog config only: env vars, OSGi configs, feature flags.
+Dialog/component authoring changes go in the Authoring section below. -->
 
 ## QA Verification
 
@@ -65,19 +66,42 @@ If all components can be demoed on one page, one table is enough. -->
 <!-- If component only exists on production pages:
 "Component exists on production pages — no dedicated QA demo page." with page paths if known. -->
 
-## Dialog Changes
+## Authoring
 
-### What's New in the Dialog
+<!-- From authoring-guide.md. This is the CORE demo section — every action MUST have a clickable link.
+The presenter follows this to configure and demo the component live. -->
 
-<!-- NEW or CHANGED fields only from authoring-guide.md.
-Per field: what it does, conditional visibility. Skip unchanged. -->
+<!-- Repeat this block for EACH component that needs configuration.
+Component names MUST be real AEM component names (from authoring-guide.md or aem-after.md).
+Page URL MUST be a real AEM Author Edit URL where the component exists. -->
 
-### Dialog Screenshot
+### <Component Name>
+
+**Page:** [`<demo-page-path>`](<author-url-qa>/editor.html<demo-page-path>.html)
+**Component:** <Real AEM Component Name — must exist on the page above>
+
+Open the page, find **<Component Name>**, open the component dialog, and change:
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| <field name> | <new value or setting> | <conditional visibility, default, purpose> |
+
+<!-- Add all NEW or CHANGED fields from authoring-guide.md. Skip unchanged fields. -->
+
+#### Dialog Screenshot
 
 ![Dialog](<repo-relative-path>/demo/dialog-<component>.png)
 
 <!-- Screenshot location: .ai/specs/<id>-<slug>/demo/dialog-<component>.png
 Commit with: git add .ai/specs/<id>-<slug>/demo/dialog-*.png -->
+
+### Tips
+
+<!-- Conditional visibility, gotchas, recommendations from authoring-guide.md. -->
+
+### Existing Pages
+
+<!-- OMIT if none. Table from authoring-guide.md — other pages using this component. -->
 
 ## Frontend Preview
 
@@ -101,22 +125,6 @@ Commit with: git add .ai/specs/<id>-<slug>/demo/rendered-*.png -->
 
 <!-- If fe-verify screenshots exist in screenshots/ dir, use those instead:
 .ai/specs/<id>-<slug>/screenshots/component-rendered.png -->
-
-## Authoring Guide
-
-<!-- From authoring-guide.md. Written for content editors, not developers. -->
-
-### Existing Pages
-
-<!-- OMIT if none. Table from authoring-guide.md. -->
-
-### How to Configure
-
-<!-- Field descriptions from authoring-guide.md "How to Use". -->
-
-### Tips
-
-<!-- Conditional visibility, gotchas, recommendations. -->
 
 ## Files Changed
 

--- a/plugins/dx-core/skills/dx-doc-gen/SKILL.md
+++ b/plugins/dx-core/skills/dx-doc-gen/SKILL.md
@@ -64,7 +64,9 @@ Create `$SPEC_DIR/docs/` directory if it doesn't exist.
 
 ### 5a. Template — With Authoring Guide (AEM projects)
 
-If `demo/authoring-guide.md` exists, read `.ai/templates/wiki/wiki-page-aem.md.template` and follow that structure exactly. The template is structured as a **demo walkthrough** — sections are ordered to match a typical demo presentation flow (story → design → implementation → QA page → dialog → frontend → Figma comparison → authoring guide).
+If `demo/authoring-guide.md` exists, read `.ai/templates/wiki/wiki-page-aem.md.template` and follow that structure exactly. The template is structured as a **demo walkthrough** — sections are ordered to match a typical demo presentation flow (story → design → implementation → QA page → authoring/dialog → frontend → Figma comparison).
+
+**Authoring section is the core of the demo page.** It merges what was previously split across Configuration, Dialog Changes, and Authoring Guide into one presenter-friendly section. Every action MUST have a clickable link — the AEM Author Edit URL where the component exists, the real component name, and a field-by-field table of what to change. The presenter should be able to follow this section to configure and demo the component live without searching for anything.
 
 **Screenshot references — repo-relative paths:** ADO wiki does not support binary upload via current MCP tools. All screenshot references MUST use repo-relative paths so they can be committed and linked from the ADO wiki.
 
@@ -267,7 +269,7 @@ If the sprint is `Unknown`, create the page under `DOC_ROOT_ID` directly with an
 
 1. `/dx-doc-gen 2416553` — Reads spec files, generates `docs/wiki-page.md` with Summary, What Changed and Why, Usage, Files Changed. Standard template.
 
-2. `/dx-doc-gen 2416553` (AEM project with authoring guide) — Detects `demo/authoring-guide.md`. Uses AEM template: Summary → Design Reference → What Changed and Why → QA Verification → Dialog Changes → Frontend Preview → Figma Comparison → Authoring Guide → Files Changed. Screenshots use repo-relative paths.
+2. `/dx-doc-gen 2416553` (AEM project with authoring guide) — Detects `demo/authoring-guide.md`. Uses AEM template: Summary → Design Reference → What Changed and Why → QA Verification → Authoring (page URL + component + field table + dialog screenshot) → Frontend Preview → Figma Comparison → Files Changed. Screenshots use repo-relative paths.
 
 3. `/dx-doc-gen 2416553` (pipeline mode) — `PIPELINE_MODE=true` triggers wiki posting. Creates the sprint subfolder (`Sprint 42`) in the ADO wiki if it doesn't exist, then creates the wiki page at the configured doc root path. Summary includes `git add` command for committing screenshots.
 
@@ -302,4 +304,5 @@ If the sprint is `Unknown`, create the page under `DOC_ROOT_ID` directly with an
 - **QA pages are mandatory** — for AEM projects, QA Author Edit + Preview URLs are required. This is the deliverable. Preview uses `wcmmode=disabled` for FE demo.
 - **Multi-component = multi-page** — if several components are affected and need different pages, provide QA URL tables for each page
 - **Don't list every file** — group by area (FE/BE/Config) with short descriptions. The PR has the diff; the wiki explains what and why.
-- **Demo walkthrough order** — AEM template sections follow a demo presentation flow: story → design → implementation → QA → dialog → frontend → Figma comparison → authoring guide → files
+- **Demo walkthrough order** — AEM template sections follow a demo presentation flow: story → design → implementation → QA → authoring (page URL + component + fields + dialog screenshot) → frontend → Figma comparison → files
+- **Authoring = presenter runbook** — every action in the Authoring section MUST have a clickable AEM Author Edit URL and the real component name. The presenter should never have to search for anything — all links, component names, and field values are explicit.

--- a/plugins/dx-core/skills/dx-doc-retro/SKILL.md
+++ b/plugins/dx-core/skills/dx-doc-retro/SKILL.md
@@ -286,6 +286,7 @@ mcp__atlassian__confluence_update_page
 - **PR descriptions are gold** — they often contain the best implementation summary. Prioritize them over story descriptions.
 - **AEM pages are mandatory** — for AEM projects, QA Author Edit + Preview URLs are required. This is the deliverable the customer sees.
 - **Use the right template** — AEM projects get the demo walkthrough template (`wiki-page-aem.md.template`), non-AEM get the standard template.
+- **Authoring = presenter runbook** — every action in the Authoring section MUST have a clickable AEM Author Edit URL, the real component name, and a field-by-field table. The presenter should never have to search for anything.
 - **Don't list every file** — group by area (FE/BE/Config) with short descriptions. The PR has the diff; the wiki explains what and why.
 - **Multi-component = multi-page** — if several components are affected, provide QA page URLs for each (unless they all fit on one page).
 - **Don't fabricate** — if you can't determine a technique or pattern, say what was changed without guessing how.


### PR DESCRIPTION
## Summary
- **Unified Authoring section** — merged Configuration/Dialog Changes/Authoring Guide into single presenter-friendly section with clickable AEM Author Edit URLs, real component names, and field-by-field tables
- **Wiki page deduplication** — doc-gen and doc-retro search for existing pages by work-item ID prefix before creating, preventing duplicates when slug differs
- **QA pages mandatory** — AEM wiki pages must include Author Edit + Preview URLs
- **Page selection rule** — new demo pages only for new components; updates reuse existing pages
- **ADO comment trimming** — shorter, structured work item comments
- **Bug verify qa mode** — post-merge QA verification flow
- **DoR re-validation** — re-validates when story content changes
- **Stale task cleanup** — coordinators clean up stale tasks on restart

## Test plan
- [ ] Run `/dx-doc-gen <id>` — verify Authoring section has clickable page URL, real component name, field table
- [ ] Run `/dx-doc-gen` on story with existing wiki page (different slug) — should update, not create duplicate
- [ ] Run `/dx-doc-retro <id>` — same dedup and authoring format
- [ ] Verify AEM wiki pages include QA Author Edit + Preview URLs
- [ ] Run `/dx-doc-gen` on non-AEM project — standard template, no Authoring section