### PR TITLE
feat: redesign tip pages for Slack sharing

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -14,6 +14,11 @@ const tips = defineCollection({
     weekLabel: z.string().optional(),
     order: z.number().optional(),
     slackText: z.string().optional(),
+    slackOneLiner: z.string().optional(),
+    keyPoints: z.array(z.string()).optional(),
+    keyPointsTitle: z.string().optional(),
+    actionItems: z.array(z.string()).optional(),
+    actionItemsTitle: z.string().optional(),
   }),
 });
 

--- a/website/src/content/tips/aem-mcp-query-content-from-ai.md
+++ b/website/src/content/tips/aem-mcp-query-content-from-ai.md
@@ -4,48 +4,31 @@ category: "Real-World Workflows"
 focus: "Claude Code"
 tags: ["AEM","JCR","MCP"]
 overview: "The AEM MCP server lets the AI query Adobe Experience Manager's content repository directly. Find components on pages, inspect dialog fields, search content trees, check page properties. No more switching between the AI terminal and AEM's CRXDE."
-codeLabel: "AEM MCP in action"
 screenshot: null
 week: 9
 weekLabel: "Agents — AI Personas"
 order: 42
-slackText: |
-  🤖 Agentic AI Tip #42 — AEM MCP: Query Content from AI
-  
-  If you work with Adobe Experience Manager, this MCP server is a game-changer.
-  
-  *What AEM MCP gives you:*
-  • `getNodeContent` — read any JCR node (component definitions, configs)
-  • `scanPageComponents` — list all components on a page
-  • `searchContent` — find content by query (pages, components, assets)
-  • `getPageProperties` — read page metadata
-  • `getComponents` — list available components for a template
-  
-  *Real workflows:*
-  "Find all pages that use the hero component" → AEM MCP searches JCR → returns page paths with author URLs.
-  
-  "What fields does the hero dialog have?" → AEM MCP reads the dialog definition → returns field names, types, and constraints.
-  
-  "Compare the component on local vs QA" → AEM MCP supports multi-instance. Query local:4502 and qa-author in the same session.
-  
-  *The fallback chain pattern:*
-  Our agent first tries an exact resourceType query. If that returns nothing, it falls back to a LIKE query. If that fails too, it uses explore subagents. Three levels of resilience, no human intervention.
-  
-  💡 Try it: If you have AEM running locally, add the AEM MCP server and ask the AI to list all components on your homepage.
-  
-  #AgenticAI #Day42
+slackOneLiner: "🤖 Tip #42 — AEM MCP gives the AI direct access to JCR — query components, inspect dialogs, search content, no CRXDE needed."
+keyPointsTitle: "What the AI Can Query"
+actionItemsTitle: "Setup and Tool Names"
+keyPoints:
+  - |
+    **Core tools**
+    - getNodeContent — read any JCR node
+    - scanPageComponents — list all components on a page
+    - searchContent — find pages/components/assets by query
+    - getPageProperties — page metadata
+    - getComponents — available components for a template
+  - "**Real workflow examples** — 'Find all pages using the hero component' returns page paths with author URLs. 'What fields does the hero dialog have?' returns field names, types, and constraints directly from the dialog definition."
+  - "**Multi-instance support** — Query local:4502 and qa-author in the same session. Compare component state across environments without switching browser tabs."
+  - "**Fallback chain pattern** — The agent first tries an exact resourceType query. If that returns nothing, it falls back to a LIKE query. If that fails too, it uses explore subagents. Three levels of resilience, no human intervention."
+actionItems:
+  - "**Try it** — If you have AEM running locally, add the AEM MCP server and ask the AI to list all components on your homepage"
+  - |
+    **Key MCP tool names to know**
+    - mcp__plugin_dx-aem_AEM__searchContent — find content by query
+    - mcp__plugin_dx-aem_AEM__getNodeContent — read any JCR node
+    - mcp__plugin_dx-aem_AEM__scanPageComponents — list components on a page
+  - "**Configure AEM_INSTANCES** — Environment variable supports multiple AEM instances (local, QA, staging) for cross-environment comparison"
+  - "**No more CRXDE tab-switching** — The AI reads JCR content directly while analyzing code. Component definitions, dialog configs, and content structures are all accessible from the terminal."
 ---
-
-```
-# Find pages using a component:
-mcp__plugin_dx-aem_AEM__searchContent
-  query: "hero" resourceType
-
-# Get component dialog fields:
-mcp__plugin_dx-aem_AEM__getNodeContent
-  path: "/apps/brand-a/components/hero"
-
-# List all components on a page:
-mcp__plugin_dx-aem_AEM__scanPageComponents
-  path: "/content/brand-a/gb/en"
-```

--- a/website/src/content/tips/agent-model-tiering-cost-vs-quality.md
+++ b/website/src/content/tips/agent-model-tiering-cost-vs-quality.md
@@ -4,41 +4,24 @@ category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Opus","Sonnet","Haiku","Cost"]
 overview: "Every agent gets exactly the model it needs — no more, no less. Our code reviewer uses Opus ($15/M tokens) because judgment quality matters. Our PR reviewer uses Sonnet ($3/M tokens) for implementation. Our file resolver uses Haiku ($0.25/M tokens) for speed. Wrong tier = wasted money or poor quality."
-codeLabel: "Our model distribution"
 screenshot: null
 week: 5
 weekLabel: "Skills — Recipe Book"
 order: 23
-slackText: |
-  🤖 Agentic AI Tip #23 — Agent Model Tiering: Cost vs Quality
-  
-  We run 12 agents across 4 plugins. Only ONE uses Opus. Here's why.
-  
-  *Opus ($15/M tokens) — 1 agent:*
-  `dx-code-reviewer` — Reviews code with confidence scoring. Needs deep reasoning to distinguish real bugs from style preferences. Worth the cost because a bad review wastes more human time than the tokens cost.
-  
-  *Sonnet ($3/M tokens) — 7 agents:*
-  `dx-pr-reviewer`, `aem-inspector`, `aem-editorial-guide-capture`, etc. — These need good judgment AND they need to take actions (read files, run commands, edit code). Sonnet is the sweet spot.
-  
-  *Haiku ($0.25/M tokens) — 4 agents:*
-  `dx-file-resolver`, `dx-doc-searcher`, `aem-file-resolver`, `aem-page-finder` — Pure lookups. "Find files matching this pattern." No reasoning needed, just fast execution.
-  
-  *The math:*
-  If a pipeline spawns all 12 agents, using Opus for all of them costs ~60x more than our tiered approach. For a team running 50 pipelines/day, that's the difference between $500/month and $30,000/month.
-  
-  💡 Try it: Review your agent definitions. Is any agent using a model tier higher than it needs?
-  
-  #AgenticAI #Day23
+slackOneLiner: "🤖 Tip #23 — We run 12 agents but only ONE uses Opus — model tiering cuts costs by 60x without sacrificing quality where it matters."
+keyPointsTitle: "Three Tiers, Three Roles"
+actionItemsTitle: "The Cost Math"
+keyPoints:
+  - "**Opus ($15/M tokens)** — 1 agent — `dx-code-reviewer` reviews code with confidence scoring. Needs deep reasoning to distinguish real bugs from style preferences. Worth the cost because a bad review wastes more human time than the tokens cost."
+  - "**Sonnet ($3/M tokens)** — 7 agents — `dx-pr-reviewer`, `aem-inspector`, `aem-editorial-guide-capture`, etc. Need good judgment AND they take actions (read files, run commands, edit code). Sonnet is the sweet spot for execution."
+  - "**Haiku ($0.25/M tokens)** — 4 agents — `dx-file-resolver`, `dx-doc-searcher`, `aem-file-resolver`, `aem-page-finder`. Pure lookups. 'Find files matching this pattern.' No reasoning needed, just fast execution."
+actionItems:
+  - "**The math** — Using Opus for all 12 agents costs ~60x more than our tiered approach. For a team running 50 pipelines/day, that's the difference between $500/month and $30,000/month."
+  - |
+    **Use this tiering guide**
+    - Opus — deep reasoning, judgment calls, confidence scoring
+    - Sonnet — implementation, actions, file editing, running commands
+    - Haiku — lookups, file search, pattern matching, simple queries
+  - "**Start cheap, upgrade when needed** — Begin with Haiku for new agents and upgrade only when quality isn't sufficient. It's easier to move up than to justify staying expensive."
+  - "**Review your agents** — Check if any agent is using a model tier higher than it needs. A file-finder on Sonnet is burning 12x what it should cost."
 ---
-
-```
-# 12 agents across 4 plugins:
-# Opus (1):  dx-code-reviewer
-# Sonnet (7): dx-pr-reviewer,
-#   aem-inspector, aem-editorial-guide-capture,
-#   aem-bug-executor, aem-fe-verifier,
-#   dx-figma-markup, dx-figma-styles
-# Haiku (4):  dx-file-resolver,
-#   dx-doc-searcher, aem-file-resolver,
-#   aem-page-finder
-```

--- a/website/src/content/tips/allowed-tools-kill-the-permission-spam.md
+++ b/website/src/content/tips/allowed-tools-kill-the-permission-spam.md
@@ -4,55 +4,24 @@ category: "Skills — Recipe Book"
 focus: "Copilot CLI"
 tags: ["Permissions","allowed-tools","Automation"]
 overview: 'Without allowed-tools in your skill frontmatter, Copilot CLI asks for permission before every single tool call. "Can I read this file? Can I run this command? Can I edit this?" It makes automation impossible. Add allowed-tools and the listed tools run automatically.'
-codeLabel: "Before vs after"
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
 order: 14
-slackText: |
-  🤖 Agentic AI Tip #14 — allowed-tools: Kill the Permission Spam
-  
-  If you've used Copilot CLI and felt like you were clicking "Yes" every 3 seconds, this tip is for you.
-  
-  By default, Copilot CLI asks permission before every tool call:
-  "May I read this file?" → Yes
-  "May I run this command?" → Yes
-  "May I edit this file?" → Yes
-  
-  For a skill that reads 5 files, runs a build, and edits 3 files, that's *13 permission prompts*. It completely breaks the flow.
-  
-  *The fix:* Add `allowed-tools` to your skill's frontmatter:
-  ```yaml
-  ---
-  allowed-tools: [read, edit, bash, grep, glob]
-  ---
-  ```
-  
-  Listed tools run automatically — no prompts. Unlisted tools still ask.
-  
-  *Be intentional about what you allow:*
-  • `read, grep, glob` — safe for research skills
-  • `+ edit, write` — for skills that modify code
-  • `+ bash` — for skills that run commands
-  • `+ mcp` — for skills that use MCP servers
-  
-  Claude Code has its own permission system (`acceptEdits` mode), but `allowed-tools` works in both tools.
-  
-  💡 Try it: Add `allowed-tools: [read, grep, glob]` to an existing skill and re-run it. Feel the difference.
-  
-  #AgenticAI #Day14
+slackOneLiner: "🤖 Tip #14 — Add allowed-tools to your skill frontmatter and stop clicking 'Yes' 13 times per skill run."
+keyPointsTitle: "The Problem and the Fix"
+actionItemsTitle: "Permission Levels by Skill Type"
+keyPoints:
+  - "**The problem** — By default, Copilot CLI asks permission before every tool call. A skill that reads 5 files, runs a build, and edits 3 files triggers 13 permission prompts. It completely breaks the flow."
+  - "**The fix** — Add allowed-tools to your skill's YAML frontmatter. Listed tools run automatically with no prompts. Unlisted tools still ask for permission — so you get automation where you want it and safety where you need it."
+  - "**Cross-tool compatibility** — Claude Code has its own permission system (acceptEdits mode), but allowed-tools works in both Claude Code and Copilot CLI. Adding it doesn't break anything."
+actionItems:
+  - |
+    **Choose the right permission level for each skill**
+    - Research only → allowed-tools: [read, grep, glob]
+    - Code modification → allowed-tools: [read, edit, write, grep, glob]
+    - Full automation → allowed-tools: [read, edit, write, bash, grep, glob]
+    - With MCP → add mcp to any of the above
+  - "**Be intentional** — read, grep, glob are safe for research skills. Add edit and write for skills that modify code. Add bash for skills that run commands. Add mcp for skills that use MCP servers."
+  - "**Try it now** — Add allowed-tools to an existing skill and re-run it. The difference is immediate — no more clicking 'Yes' for every operation."
 ---
-
-```
-# Without allowed-tools:
-# "May I read package.json?" [Y/n]
-# "May I run npm test?" [Y/n]
-# "May I edit src/index.js?" [Y/n]
-# 😤
-
-# With allowed-tools:
----
-allowed-tools: [read, edit, bash, grep]
----
-# Tools run automatically ✓
-```

--- a/website/src/content/tips/argument-hint-making-skills-discoverable.md
+++ b/website/src/content/tips/argument-hint-making-skills-discoverable.md
@@ -4,57 +4,27 @@ category: "Skills — Advanced"
 focus: "Claude Code · CLI"
 tags: ["argument-hint","Autocomplete","UX"]
 overview: 'When you type / in Claude Code, you see a list of skills. The argument-hint field tells users what to pass before they even read the docs. "/dx-req <ticket-id>" is instantly clear. Without it, users have to guess what the skill expects.'
-codeLabel: "UX difference"
 screenshot: null
 week: 4
 weekLabel: "Context — The Secret Sauce"
 order: 17
-slackText: |
-  🤖 Agentic AI Tip #17 — argument-hint: Making Skills Discoverable
-  
-  Small UX detail that makes a big difference: `argument-hint`.
-  
-  When you type `/` in Claude Code or Copilot CLI, you see a list of available skills. Without `argument-hint`, you see:
-  ```
-  /fetch-ticket
-  ```
-  "What do I pass to this? A URL? An ID? A name?"
-  
-  With `argument-hint: "<ticket-id>"`, you see:
-  ```
-  /fetch-ticket <ticket-id>
-  ```
-  Instantly clear.
-  
-  *Best practices for argument-hint:*
-  • Use angle brackets for required args: `"<ticket-id>"`
-  • Use square brackets for optional: `"[--verbose]"`
-  • Be specific: `"<ADO-work-item-id>"` not `"<id>"`
-  • Match what users actually type: `"<component-name>"` not `"<ComponentNameInPascalCase>"`
-  
-  *Why this matters more than you think:*
-  A skill that nobody knows how to invoke is a skill that nobody uses. discoverability = adoption. The 10 seconds you spend on argument-hint saves every user 30 seconds of confusion.
-  
-  💡 Try it: Add `argument-hint` to all your custom skills. Check the autocomplete in Claude Code — it looks much more professional.
-  
-  #AgenticAI #Day17
+slackOneLiner: "🤖 Tip #17 — Add argument-hint to every skill. Without it users see `/fetch-ticket` and wonder what to pass. With it they see `/fetch-ticket <ticket-id>` — instantly clear."
+keyPointsTitle: "Why Hints Matter"
+actionItemsTitle: "Hint Formatting Guide"
+keyPoints:
+  - "**Without argument-hint** — Users see `/fetch-ticket` and have to guess: a URL? An ID? A name? Confusion kills adoption."
+  - "**With argument-hint** — Users see `/fetch-ticket <ticket-id>` in autocomplete. Instantly clear what to pass, zero guesswork."
+  - "**Discoverability equals adoption** — A skill nobody knows how to invoke is a skill nobody uses. The 10 seconds you spend on argument-hint saves every user 30 seconds of confusion."
+  - "**Match what users actually type** — Use `\"<component-name>\"` not `\"<ComponentNameInPascalCase>\"`. The hint should reflect real usage patterns, not internal naming conventions."
+  - "**Compound hints work too** — Skills with multiple arguments: `\"<ticket-id> [--verbose]\"`. Show the full invocation pattern in one glance."
+actionItems:
+  - |
+    Follow these conventions for hint text
+    - Required args use angle brackets: `"<ticket-id>"`
+    - Optional args use square brackets: `"[--verbose]"`
+    - Be specific: `"<ADO-work-item-id>"` not `"<id>"`
+    - Match real usage: `"<component-name>"` not `"<ComponentNameInPascalCase>"`
+  - "**Audit existing skills** — Grep your skills directory for files missing argument-hint and add it to every one"
+  - "**Verify in autocomplete** — After adding hints, type `/` in Claude Code and check that your hints render correctly and read naturally"
+  - "**Use the hint as documentation** — A well-written argument-hint replaces the need for a README. Users see `<ticket-id>` and immediately know what to pass."
 ---
-
-```
----
-# Without argument-hint
-name: fetch-ticket
-description: Fetch a work item
----
-# User sees: /fetch-ticket
-# "What do I pass?"
-
----
-# With argument-hint
-name: fetch-ticket
-description: Fetch a work item
-argument-hint: "<ticket-id>"
----
-# User sees: /fetch-ticket <ticket-id>
-# Instantly clear!
-```

--- a/website/src/content/tips/ask-the-right-question.md
+++ b/website/src/content/tips/ask-the-right-question.md
@@ -4,45 +4,29 @@ category: "Meet Your AI Tools"
 focus: "All Tools"
 tags: ["Prompting","Specificity","Context"]
 overview: 'The difference between a useful AI response and a useless one is almost always in the prompt. "Fix this" gives you generic suggestions. "Fix the null pointer in handleSubmit when user.email is undefined on line 47" gives you working code. Specificity beats cleverness.'
-codeLabel: "Prompt comparison"
 screenshot: null
 week: 1
 weekLabel: "Meet Your AI Tools"
 order: 5
-slackText: |
-  🤖 Agentic AI Tip #5 — Ask the Right Question
-  
-  The #1 skill that separates effective AI users from frustrated ones: specificity.
-  
-  *Bad prompts:*
-  • "Fix this bug"
-  • "Make it faster"
-  • "Refactor the code"
-  
-  *Good prompts:*
-  • "Fix the null pointer in handleSubmit (login.js:47) when user.email is undefined — add a null check before the API call"
-  • "The user list page loads in 3s. Profile the component renders, identify unnecessary re-renders, and memoize the expensive computations"
-  • "Refactor the auth middleware to extract the JWT validation into a separate utility — we need it in the WebSocket handler too"
-  
-  The pattern: *what + where + why + how.*
-  
-  What's broken/needed, where in the code, why it matters, and what approach you're thinking. You don't need all four every time, but the more context you give, the better the response.
-  
-  One more trick: include error messages verbatim. Copy-paste the stack trace. AI is remarkably good at parsing error output.
-  
-  💡 Try it: Next time you get a bad response, re-ask with the file path, line number, and expected behavior.
-  
-  #AgenticAI #Day5
+slackOneLiner: "🤖 Tip #5 — The #1 skill separating effective AI users from frustrated ones is specificity. Say what, where, why, and how."
+keyPointsTitle: "The What/Where/Why/How Pattern"
+keyPoints:
+  - "Specificity is everything — 'Fix this bug' gets generic suggestions, 'Fix the null pointer in handleSubmit (login.js:47) when user.email is undefined' gets working code."
+  - |
+    The pattern — four elements that transform prompts
+    - What — what's broken or what you need
+    - Where — file path, line number, component name
+    - Why — user impact, dependency, urgency
+    - How — suggested fix direction or approach
+  - "Include error messages verbatim — copy-paste the stack trace. AI is remarkably good at parsing error output."
+  - "You don't need all four elements every time — but the more context you give, the better the response."
+actionItemsTitle: "Bad Prompts vs Good Prompts"
+actionItems:
+  - |
+    Side-by-side comparison
+    - 'Fix this bug' → 'Fix the null pointer in handleSubmit (login.js:47) when user.email is undefined — add a null check before the API call'
+    - 'Make it faster' → 'The user list page loads in 3s. Profile the component renders, identify unnecessary re-renders, and memoize the expensive computations'
+    - 'Refactor the code' → 'Refactor the auth middleware to extract JWT validation into a separate utility — we need it in the WebSocket handler too'
+  - "Next time you get a bad AI response, re-ask with the file path, line number, and expected behavior — compare the difference"
+  - "Always copy-paste error messages and stack traces verbatim into your prompt instead of paraphrasing them"
 ---
-
-```
-# Bad prompt
-"Fix the bug"
-
-# Good prompt
-"In src/auth/login.js line 47,
- handleSubmit throws when user.email
- is undefined. Add a null check before
- the API call and show a validation
- error to the user."
-```

--- a/website/src/content/tips/bug-triage-ticket-to-root-cause.md
+++ b/website/src/content/tips/bug-triage-ticket-to-root-cause.md
@@ -4,58 +4,28 @@ category: "Real-World Workflows"
 focus: "Claude Code"
 tags: ["Bug","Triage","Visual Verification"]
 overview: "Our bug flow: /dx-bug-triage fetches the bug ticket and finds the affected component in code. /dx-bug-verify opens Chrome, follows repro steps, and takes screenshots to confirm the bug. /dx-bug-fix implements the fix and verifies it works. Three skills, zero tab-switching."
-codeLabel: "Bug triage pipeline"
 screenshot: null
 week: 9
 weekLabel: "Agents — AI Personas"
 order: 45
-slackText: |
-  🤖 Agentic AI Tip #45 — Bug Triage: Ticket to Root Cause
-  
-  Bug fixing is 80% investigation, 20% coding. AI excels at the investigation part.
-  
-  *Step 1: Triage (/dx-bug-triage)*
-  • Fetches the bug ticket from ADO
-  • Reads repro steps, expected vs actual behavior
-  • Searches codebase for affected components
-  • Saves root cause hypothesis to `triage.md`
-  
-  *Step 2: Verify (/dx-bug-verify)*
-  • Opens Chrome DevTools MCP
-  • Navigates to the repro URL
-  • Follows the repro steps (click, fill, navigate)
-  • Takes screenshots at each step
-  • Confirms: "Yes, the bug reproduces" or "Cannot reproduce"
-  
-  *Step 3: Fix (/dx-bug-fix)*
-  • Reads the triage findings
-  • Implements the fix
-  • Re-runs verification in Chrome
-  • Screenshots the fixed state
-  • Before/after comparison
-  
-  *Why visual verification matters:*
-  "The hero component overlaps the nav on mobile" — you can't verify this by reading code. You need to see it. Chrome DevTools MCP makes the AI see what the user sees.
-  
-  💡 Try it: Pick a UI bug from your backlog. Run `/dx-bug-triage <id>` and read the triage output. Even if you fix it manually, the investigation saves time.
-  
-  #AgenticAI #Day45
+slackOneLiner: "🤖 Tip #45 — Bug fixing is 80% investigation — let AI triage the ticket, visually verify the bug in Chrome, then fix and re-verify."
+keyPointsTitle: "The Three-Step Bug Flow"
+actionItemsTitle: "When to Use Each Step"
+keyPoints:
+  - "**Step 1 — Triage** (/dx-bug-triage) — Fetches the bug ticket from ADO, reads repro steps and expected vs actual behavior, searches the codebase for affected components, and saves a root cause hypothesis to triage.md."
+  - "**Step 2 — Verify** (/dx-bug-verify) — Opens Chrome DevTools MCP, navigates to the repro URL, follows repro steps (click, fill, navigate), takes screenshots at each step, and confirms whether the bug reproduces."
+  - "**Step 3 — Fix** (/dx-bug-fix) — Reads the triage findings, implements the fix, re-runs verification in Chrome, screenshots the fixed state, and produces a before/after comparison."
+  - "**Visual verification matters** — 'The hero component overlaps the nav on mobile' can't be verified by reading code. Chrome DevTools MCP makes the AI see what the user sees."
+actionItems:
+  - |
+    **Pick the right skill for your situation**
+    - /dx-bug-triage — investigation only, safe to run anytime
+    - /dx-bug-verify — confirms reproduction, still read-only
+    - /dx-bug-fix — implements changes, use on a feature branch
+  - "**Even partial use saves time** — Pick a UI bug, run /dx-bug-triage <id>, and read the investigation output. Even if you fix it manually, the automated triage saves significant investigation time."
+  - |
+    **Prerequisites**
+    - Chrome DevTools MCP must be configured for the visual verify and fix steps
+    - Bug ticket needs repro steps and expected vs actual behavior for best results
+    - Run on a feature branch when using /dx-bug-fix
 ---
-
-```
-# Bug workflow:
-/dx-bug-triage 54321
-# → Fetches bug from ADO
-# → Finds affected component
-# → Saves root cause hypothesis
-
-/dx-bug-verify
-# → Opens Chrome DevTools
-# → Follows repro steps
-# → Screenshots the bug
-
-/dx-bug-fix
-# → Implements the fix
-# → Re-verifies in Chrome
-# → Screenshots the fixed state
-```

--- a/website/src/content/tips/chaining-skills-building-pipelines.md
+++ b/website/src/content/tips/chaining-skills-building-pipelines.md
@@ -4,46 +4,24 @@ category: "Skills — Advanced"
 focus: "Claude Code"
 tags: ["Pipeline","Chaining","Workflow"]
 overview: "Individual skills are building blocks. The real power comes from chaining them into pipelines. req → plan → execute → verify → PR. Each step reads the previous step's output. You can run the full pipeline or any individual step."
-codeLabel: "Complete pipeline"
 screenshot: null
 week: 4
 weekLabel: "Context — The Secret Sauce"
 order: 20
-slackText: |
-  🤖 Agentic AI Tip #20 — Chaining Skills: Building Pipelines
-  
-  Individual skills are useful. Chained skills are transformative.
-  
-  Here's a real pipeline that takes a ticket from ADO to a pull request:
-
-  ```
-  /dx-req 12345           → full requirements pipeline (fetch, DoR, explain, research, share)
-  /dx-plan                → generates implementation plan
-  /dx-step                → executes step 1
-  /dx-step                → executes step 2...
-  /dx-step-verify         → 6-phase verification
-  /dx-pr                  → creates the pull request
-  ```
-
-  *Key insight:* You don't have to run the full pipeline. Each skill is independent:
-  • Want to code manually? Skip `/dx-step`, just use `/dx-plan` as a guide
-  • Already coded? Jump straight to `/dx-step-verify`
-  
-  This modularity is intentional. The pipeline is a *suggestion*, not a requirement. Use what helps, skip what doesn't.
-  
-  *The coordinator version:* `/dx-agent-all` runs the entire pipeline as a single command using the coordinator pattern. Great for simple stories. Use individual steps for complex ones.
-  
-  💡 Try it: Pick a small ticket and run the first three skills: fetch, explain, research. Review each output before moving forward.
-  
-  #AgenticAI #Day20
+slackOneLiner: "🤖 Tip #20 — Individual skills are useful. Chained into pipelines — req, plan, step, verify, PR — they're transformative."
+keyPointsTitle: "The Pipeline Flow"
+actionItemsTitle: "Choose Your Workflow"
+keyPoints:
+  - "**A real pipeline** — `/dx-req 12345` (full requirements) → `/dx-plan` (implementation plan) → `/dx-step` (execute step 1, 2, ...) → `/dx-step-verify` (6-phase verification) → `/dx-pr` (creates the pull request). Ticket to PR in one flow."
+  - "**Modularity is intentional** — Each skill is independent. Want to code manually? Skip `/dx-step`, use `/dx-plan` as a guide. Already coded? Jump straight to `/dx-step-verify`. The pipeline is a suggestion, not a requirement."
+  - "**File convention enables chaining** — Each skill writes to `.ai/specs/<id>/` and the next skill reads from the same location. No data passing needed, no APIs, no coupling between skills."
+actionItems:
+  - "**Start with three skills** — Pick a small ticket and run `/dx-req <id>`, then review the output before running `/dx-plan`, then `/dx-step`. Get comfortable with the flow before automating."
+  - |
+    Choose your workflow style
+    - **Full automation** → `/dx-agent-all` for simple stories
+    - **Guided** → Run each skill individually, review between steps
+    - **Hybrid** → Use AI for requirements and planning, code manually, then `/dx-step-verify` and `/dx-pr`
+  - "**The coordinator shortcut** — `/dx-agent-all` runs the entire pipeline as a single command using the coordinator pattern. Great for simple stories. Use individual steps for complex ones where you want to review each output."
+  - "**Review early, save time** — Check each output in `.ai/specs/` before moving to the next step. Catching issues early saves re-work later."
 ---
-
-```
-# Full pipeline for a feature:
-/dx-req 12345     # full requirements pipeline
-/dx-plan
-/dx-step          # execute step 1
-/dx-step          # execute step 2
-/dx-step-verify
-/dx-pr
-```

--- a/website/src/content/tips/claude-md-your-projects-brain.md
+++ b/website/src/content/tips/claude-md-your-projects-brain.md
@@ -4,51 +4,31 @@ category: "Context — The Secret Sauce"
 focus: "Claude Code"
 tags: ["CLAUDE.md","Project Config","Auto-loaded"]
 overview: "CLAUDE.md sits at your project root and gets loaded into every Claude Code session automatically. It contains build commands, conventions, gotchas, and architecture decisions. This single file has more impact on AI quality than any prompt engineering technique."
-codeLabel: "CLAUDE.md example"
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 7
-slackText: |
-  🤖 Agentic AI Tip #7 — CLAUDE.md: Your Project's Brain
-  
-  This is the single highest-ROI file you can create for AI-assisted development.
-  
-  `CLAUDE.md` lives at your project root and is automatically loaded into every Claude Code session. Think of it as your project's operating manual — but for AI.
-  
-  *What to put in it:*
-  • *Build commands* — so AI can compile and test without guessing
-  • *Project structure* — which directories contain what
-  • *Naming conventions* — how you name files, components, branches
-  • *Architecture patterns* — the decisions behind your code
-  • *Gotchas* — things that trip up newcomers (and AI)
-  
-  *What NOT to put:*
-  • Things derivable from code (function signatures, imports)
-  • Git history (use git log)
-  • Temporary notes (use tasks instead)
-  
-  *Why it matters:*
-  Without CLAUDE.md, every AI session starts from zero — the AI guesses your conventions and gets them wrong. With it, the AI behaves like a team member who's read the onboarding docs.
-  
-  The file compounds in value. Every gotcha you add saves time in every future session.
-  
-  💡 Try it: Create a CLAUDE.md with your project's build command and one naming convention. Watch the difference in AI responses.
-  
-  #AgenticAI #Day7
+slackOneLiner: "🤖 Tip #7 — CLAUDE.md is the single highest-ROI file you can create for AI-assisted development. It's your project's operating manual for AI."
+keyPointsTitle: "What Goes In It"
+keyPoints:
+  - "CLAUDE.md lives at your project root and is automatically loaded into every Claude Code session — think of it as your project's operating manual for AI."
+  - |
+    What to put in it
+    - Build commands — so AI can compile and test without guessing
+    - Project structure — which directories contain what
+    - Naming conventions — how you name files, components, branches
+    - Architecture patterns — the decisions behind your code
+    - Gotchas — things that trip up newcomers (and AI)
+  - |
+    What NOT to put in it
+    - Things derivable from code (function signatures, imports)
+    - Git history (use git log)
+    - Temporary notes (use tasks instead)
+  - "The file compounds in value — every gotcha you add saves time in every future session across every team member."
+actionItemsTitle: "Why It Changes Everything"
+actionItems:
+  - "Without CLAUDE.md, every AI session starts from zero — the AI guesses your conventions and gets them wrong. With it, the AI behaves like a team member who's read the onboarding docs."
+  - "Create a CLAUDE.md at your project root with your build command and one naming convention — watch the difference in AI responses"
+  - "Add your project's top 3 gotchas — the things that trip up newcomers are exactly what trips up AI"
+  - "Commit CLAUDE.md to git so the entire team benefits from the same AI context"
 ---
-
-```
-# CLAUDE.md structure
-## Commands
-npm run build    # frontend build
-mvn clean install # full deploy
-
-## Conventions
-- ESLint: Airbnb + Prettier
-- Branches: feature/*, bugfix/*
-- PR target: development (never main)
-
-## Architecture
-Custom Elements extending CustomComponent
-```

--- a/website/src/content/tips/consumer-sync-one-source-many-projects.md
+++ b/website/src/content/tips/consumer-sync-one-source-many-projects.md
@@ -4,59 +4,27 @@ category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Sync","Multi-Repo","Version"]
 overview: "We maintain plugins in one source repo and sync to 4 consumer projects. A sync script handles distribution. But version bumping requires updating 4 files — 3 plugin.json files + 1 marketplace.json. Forgetting one causes version mismatch nightmares."
-codeLabel: "Multi-repo sync"
 screenshot: null
 week: 9
 weekLabel: "Agents — AI Personas"
 order: 41
-slackText: |
-  🤖 Agentic AI Tip #41 — Consumer Sync: One Source, Many Projects
-  
-  Building a plugin is half the battle. Distributing it across multiple projects is the other half.
-  
-  *Our setup:*
-  • 4 plugins developed in one source location
-  • 4 consumer repos that use these plugins
-  • A sync script that handles distribution
-  
-  *The sync script handles:*
-  • Copying skills, agents, rules, hooks
-  • Respecting per-repo config differences
-  • Preserving local overrides
-  • Reporting what changed
-  
-  *The version bump trap:*
-  When bumping plugin versions, you must update 5 files:
-  1. `dx-core/plugin.json`
-  2. `dx-hub/plugin.json`
-  3. `dx-aem/plugin.json`
-  4. `dx-automation/plugin.json`
-  5. `.claude-plugin/marketplace.json` (consumer repo root)
-  
-  Miss #5 and the consumer repo thinks it has an old version. This causes "already up to date" messages when you try to reinstall.
-  
-  *Lessons learned:*
-  • Always read the consumer's local config before applying changes — branch names, paths, and feature flags vary per project
-  • Test sync on one consumer before syncing all four
-  • Diff the result after sync — catch accidental deletions
-  
-  💡 Try it: If you maintain a plugin used in multiple projects, write a checklist for version bumps. Include ALL files that need updating.
-  
-  #AgenticAI #Day41
+slackOneLiner: "🤖 Tip #41 — Distributing plugins across multiple projects requires a sync script and a version bump checklist — miss one file and you get 'already up to date' lies."
+keyPointsTitle: "The Distribution Challenge"
+actionItemsTitle: "The Sync Playbook"
+keyPoints:
+  - "**The challenge** — Building a plugin is half the battle. Distributing it across multiple projects is the other half. We maintain 4 plugins in one source repo, synced to 4 consumer repos."
+  - "**Sync script responsibilities** — Copies skills, agents, rules, and hooks. Respects per-repo config differences. Preserves local overrides. Reports what changed after each sync."
+  - "**The version bump trap** — When bumping plugin versions, you must update 5 files: dx-core/plugin.json, dx-hub/plugin.json, dx-aem/plugin.json, dx-automation/plugin.json, AND .claude-plugin/marketplace.json in the consumer repo root. Miss the marketplace.json and the consumer thinks it has an old version."
+  - "**Lessons learned** — Always read the consumer's local config before applying changes (branch names, paths, feature flags vary per project). Test sync on one consumer before syncing all four."
+actionItems:
+  - |
+    **Version bump checklist**
+    - Update each plugin's plugin.json (version field)
+    - Update .claude-plugin/marketplace.json in each consumer repo
+    - Run sync script
+    - Diff the result to verify no accidental deletions
+    - Test `/plugin list` in a consumer to confirm version match
+  - "**Test before you ship** — Sync on one consumer project before distributing to all. Catch issues early with a single test target rather than debugging across four repos."
+  - "**Diff after every sync** — Review the diff to catch accidental deletions. A sync script that removes a file you customized locally is a silent breakage."
+  - "**Respect local overrides** — Each consumer may have different branch names, paths, and feature flags. Your sync script must read local config before applying changes, not blindly overwrite."
 ---
-
-```
-# Version lives in 5 files:
-# 1. dx-core/plugin.json
-# 2. dx-hub/plugin.json
-# 3. dx-aem/plugin.json
-# 4. dx-automation/plugin.json
-# 5. .claude-plugin/marketplace.json
-
-# Sync to consumers:
-./scripts/sync-consumers.sh
-# → Customer-Brand-A
-# → Customer-Brand-B
-# → Platform-Core
-# → AEM-Platform-Core
-```

--- a/website/src/content/tips/context-window-why-ai-forgets.md
+++ b/website/src/content/tips/context-window-why-ai-forgets.md
@@ -4,39 +4,35 @@ category: "Context — The Secret Sauce"
 focus: "All Tools"
 tags: ["1M Tokens","200K Tokens","Fresh Sessions"]
 overview: "AI models have a fixed context window — Opus holds 1M tokens, Sonnet 200K. When your conversation exceeds this, older messages get compressed or dropped. This is why long sessions degrade. Start fresh for new tasks. Don't try to do everything in one conversation."
-codeLabel: ""
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
 order: 11
-slackText: |
-  🤖 Agentic AI Tip #11 — Context Window: Why AI "Forgets"
-  
-  Ever notice the AI gets confused late in a long session? It's not a bug — it's a fundamental constraint.
-  
-  *Context windows:*
-  • Opus: ~1M tokens (~750K words)
-  • Sonnet: ~200K tokens (~150K words)
-  • GPT-4: ~128K tokens (~95K words)
-  
-  When your conversation fills the window, older messages get compressed or dropped. The AI literally can't see them anymore.
-  
-  *Symptoms of context overflow:*
-  • AI repeats work it already did
-  • AI "forgets" decisions you agreed on
-  • AI contradicts its earlier responses
-  • Code quality degrades as the session goes on
-  
-  *How to manage it:*
-  1. *Start fresh* for new tasks — don't chain unrelated work in one session
-  2. *Use subagents* for expensive operations — they get their own context
-  3. *Put conventions in CLAUDE.md* — re-loaded automatically, never forgotten
-  4. *Use the /compact command* in Claude Code — it summarizes and frees space (but loses nuance)
-  
-  The mental model: context window = short-term memory. CLAUDE.md = long-term memory. Write down what matters.
-  
-  💡 Try it: Check Claude Code's token usage display. Start a new session when you switch to a different task.
-  
-  #AgenticAI #Day11
+slackOneLiner: "🤖 Tip #11 — AI gets confused late in long sessions because it literally can't see older messages anymore. Start fresh for new tasks."
+keyPointsTitle: "How Context Windows Work"
+keyPoints:
+  - |
+    Context window sizes
+    - Opus: ~1M tokens (~750K words)
+    - Sonnet: ~200K tokens (~150K words)
+    - GPT-4: ~128K tokens (~95K words)
+  - "When your conversation fills the window, older messages get compressed or dropped — the AI literally can't see them anymore."
+  - |
+    Symptoms of context overflow
+    - AI repeats work it already did
+    - AI 'forgets' decisions you agreed on
+    - AI contradicts its earlier responses
+    - Code quality degrades as the session goes on
+  - "The mental model — context window = short-term memory. CLAUDE.md = long-term memory. Write down what matters."
+actionItemsTitle: "How to Manage It"
+actionItems:
+  - |
+    Prevention strategies
+    - Start fresh for new tasks — don't chain unrelated work in one session
+    - Use subagents for expensive operations — they get their own context
+    - Put conventions in CLAUDE.md — re-loaded automatically, never forgotten
+    - Use the /compact command in Claude Code — it summarizes and frees space (but loses nuance)
+  - "Check Claude Code's token usage display — start a new session when you switch to a different task"
+  - "Move important conventions and decisions into CLAUDE.md so they survive across sessions"
+  - "Use /compact when a session gets long but you're not ready to start fresh — it summarizes and frees space"
 ---
-

--- a/website/src/content/tips/figma-to-code-the-full-pipeline.md
+++ b/website/src/content/tips/figma-to-code-the-full-pipeline.md
@@ -4,56 +4,26 @@ category: "Real-World Workflows"
 focus: "Claude Code"
 tags: ["Figma","Design-to-Code","Pipeline"]
 overview: "Our Figma pipeline goes: Extract (read design, capture screenshot, extract tokens) → Prototype (generate standalone HTML/CSS) → Verify (screenshot prototype, compare against Figma reference). Three skills, three agents, zero manual copying of hex values."
-codeLabel: "Design-to-code"
 screenshot: null
 week: 9
 weekLabel: "Agents — AI Personas"
 order: 43
-slackText: |
-  🤖 Agentic AI Tip #43 — Figma-to-Code: The Full Pipeline
-  
-  Manually translating Figma designs into code is tedious and error-prone. Here's how we automated it.
-  
-  *Three-step pipeline:*
-  
-  *Step 1: Extract (/dx-figma-extract)*
-  • Reads the Figma design via MCP
-  • Captures a reference screenshot
-  • Extracts design tokens (colors, spacing, typography)
-  • Saves everything to `figma-extract.md`
-  
-  *Step 2: Prototype (/dx-figma-prototype)*
-  • Reads the extraction data
-  • Discovers project CSS conventions (variables, breakpoints)
-  • Generates standalone HTML/CSS prototype
-  • Maps Figma tokens to existing project variables (not raw hex!)
-  
-  *Step 3: Verify (/dx-figma-verify)*
-  • Opens the prototype in Chrome (via DevTools MCP)
-  • Takes a screenshot
-  • Compares against the Figma reference using vision
-  • Identifies visual differences
-  • Fixes them automatically and re-verifies
-  
-  *Key insight:* The prototype maps to your *project's* design tokens, not generic CSS. If Figma says `#36C0CF`, the prototype uses `var(--color-secondary)`. This makes the output actually usable.
-  
-  💡 Try it: If you have a Figma design URL, run `/dx-figma-extract <url>` and inspect the output in `.ai/specs/`.
-  
-  #AgenticAI #Day43
+slackOneLiner: "🤖 Tip #43 — Three-step Figma pipeline: extract tokens, generate a prototype mapped to project variables, then visually verify against the original."
+keyPointsTitle: "The Three-Step Pipeline"
+actionItemsTitle: "Why It Works"
+keyPoints:
+  - "**Step 1 — Extract** (/dx-figma-extract) — Reads the Figma design via MCP, captures a reference screenshot, extracts design tokens (colors, spacing, typography), and saves everything to figma-extract.md."
+  - "**Step 2 — Prototype** (/dx-figma-prototype) — Reads the extraction data, discovers project CSS conventions (variables, breakpoints), generates standalone HTML/CSS, and maps Figma tokens to existing project variables (not raw hex values)."
+  - "**Step 3 — Verify** (/dx-figma-verify) — Opens the prototype in Chrome via DevTools MCP, takes a screenshot, compares against the Figma reference using vision, identifies visual differences, fixes them automatically, and re-verifies."
+actionItems:
+  - "**Token mapping is the key insight** — The prototype maps to your project's design tokens, not generic CSS. If Figma says #36C0CF, the prototype uses var(--color-secondary). This makes the output actually usable in production code."
+  - |
+    **Zero manual copying** — Three skills, three agents, no tab-switching between Figma and code
+    - The entire pipeline runs from the terminal
+    - Each step's output feeds the next automatically
+  - |
+    **Getting started**
+    - Run /dx-figma-extract <figma-url> with a real Figma design URL and inspect the output in .ai/specs/
+    - Ensure Chrome DevTools MCP is configured — the verify step needs it to screenshot and compare
+    - Check your project's CSS variable conventions before running the prototype step — missing variable mappings fall back to raw values
 ---
-
-```
-# Full Figma pipeline:
-/dx-figma-extract <figma-url>
-# → Reads design, extracts tokens
-# → Saves figma-extract.md + screenshot
-
-/dx-figma-prototype
-# → Generates HTML/CSS prototype
-# → Maps tokens to project variables
-
-/dx-figma-verify
-# → Screenshots the prototype
-# → Compares against Figma reference
-# → Fixes visual differences
-```

--- a/website/src/content/tips/file-convention-over-data-passing.md
+++ b/website/src/content/tips/file-convention-over-data-passing.md
@@ -4,48 +4,26 @@ category: "Skills — Advanced"
 focus: "Claude Code"
 tags: ["Spec Directory","Convention","Decoupling"]
 overview: "Our skills don't pass data through APIs or return values. Instead, each skill writes output to a predictable file location (.ai/specs/<id>/). The next skill reads from the same location. This decouples skills completely — each can be tested and run independently."
-codeLabel: "File convention"
 screenshot: null
 week: 4
 weekLabel: "Context — The Secret Sauce"
 order: 19
-slackText: |
-  🤖 Agentic AI Tip #19 — File Convention Over Data Passing
-  
-  How do you pass data between AI skills that run in separate contexts? You don't.
-  
-  Instead, we use a *file convention*: each skill writes its output to a predictable location, and the next skill knows where to look.
-  
-  ```
-  .ai/specs/<ticket-id>-<slug>/
-  ├── raw-story.md      ← /dx-req writes this (Phase 1: fetch)
-  ├── explain.md        ← /dx-req writes this (Phase 3: explain)
-  ├── research.md       ← /dx-req writes this (Phase 4: research)
-  ├── implement.md      ← /dx-plan reads all above, writes this
-  └── figma-extract.md  ← /dx-figma-extract writes this
-  ```
-  
-  *Why this beats data passing:*
-  1. *Inspectable* — you can read any file to see what happened
-  2. *Resumable* — skip a step and re-run just what you need
-  3. *Testable* — each skill is independent
-  4. *Debuggable* — if step 3 fails, check step 2's output
-  
-  *No APIs, no return values, no coupling.* Skills find each other's output by convention. This is the same principle as Unix pipes — small tools, predictable I/O.
-  
-  💡 Try it: Run `/dx-req <id>` then look inside `.ai/specs/`. Read the files. You'll see exactly what the AI captured.
-  
-  #AgenticAI #Day19
+slackOneLiner: "🤖 Tip #19 — How do you pass data between AI skills in separate contexts? You don't. Use a file convention — each skill writes to a predictable location, the next knows where to look."
+keyPointsTitle: "The Design Pattern"
+actionItemsTitle: "See It in Action"
+keyPoints:
+  - "**The pattern** — Each skill writes its output to a predictable location (`.ai/specs/<ticket-id>-<slug>/`), and the next skill knows where to look. No APIs, no return values, no coupling."
+  - "**Same principle as Unix pipes** — Small tools, predictable I/O. Skills find each other's output by convention, not by API contracts or shared memory."
+  - "**Inspectable** — You can read any file to see exactly what happened. `raw-story.md` shows what was fetched, `explain.md` shows how it was interpreted, `implement.md` shows the plan."
+  - "**Testable and debuggable** — Each skill is fully independent. If step 3 fails, check step 2's output file. Mock any input by writing the expected file manually."
+actionItems:
+  - "**Try the flow** — Run `/dx-req <id>` then look inside `.ai/specs/` — read the files to see exactly what the AI captured at each phase."
+  - |
+    Understand the file flow
+    - `/dx-req` writes: raw-story.md, explain.md, research.md
+    - `/dx-plan` reads explain.md + research.md, writes: implement.md
+    - `/dx-figma-extract` writes: figma-extract.md
+    - Each skill is independent — test and run them in any order
+  - "**Resumable by design** — Skip a step and re-run just what you need. `/dx-plan` reads `explain.md` which is already there from `/dx-req`. No need to re-run the entire chain."
+  - "**Apply to custom skills** — When building your own skills, follow the same convention. Write output to `.ai/specs/<id>/` so other skills can chain from it."
 ---
-
-```
-# /dx-req writes all phases:
-.ai/specs/12345-login-bug/raw-story.md
-.ai/specs/12345-login-bug/explain.md
-.ai/specs/12345-login-bug/research.md
-
-# /dx-plan reads explain.md, writes:
-.ai/specs/12345-login-bug/implement.md
-
-# Each skill is independent!
-```

--- a/website/src/content/tips/four-instruction-files-claude-md-agents-md-and-mor.md
+++ b/website/src/content/tips/four-instruction-files-claude-md-agents-md-and-mor.md
@@ -4,50 +4,25 @@ category: "Context — The Secret Sauce"
 focus: "All Tools"
 tags: ["CLAUDE.md","AGENTS.md","copilot-instructions","Instructions"]
 overview: "Each tool reads different instruction files — and some read multiple. CLAUDE.md (Claude Code primary), AGENTS.md (Copilot coding agent, open format), .github/copilot-instructions.md (legacy Copilot), plus .github/instructions/*.instructions.md for path-scoped rules. Rules in .claude/rules/ can be shared via an env var."
-codeLabel: "Instruction file matrix"
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 8
-slackText: |
-  🤖 Agentic AI Tip #8 — Four Instruction Files: Who Reads What
-  
-  The instruction file landscape has expanded. Here's the current state:
-  
-  *CLAUDE.md* — Claude Code's primary file. Also read by Copilot coding agent (the cloud autonomous agent that works on GitHub issues). Supports @import for recursive includes.
-  
-  *AGENTS.md* — The new open format (Aug 2025). Read by Copilot CLI, VS Code Chat, and the coding agent. Placed at root or nested per-directory.
-  
-  *.github/copilot-instructions.md* — The original Copilot format. Still works. Repo-wide scope.
-  
-  *.github/instructions/*.instructions.md* — Path-scoped with `applyTo:` frontmatter. Like .claude/rules/ but for Copilot. Can exclude specific agents with `excludeAgent:`.
-  
-  *The sharing trick:*
-  Your `.claude/rules/` files can be read by Copilot CLI too! Set this env var:
-  ```
-  COPILOT_CUSTOM_INSTRUCTIONS_DIRS=".claude/rules"
-  ```
-  Now BOTH tools read the same rules. No duplication needed for conventions.
-  
-  *Still needed:*
-  Dual frontmatter (`paths:` + `applyTo:`) in rule files so path-matching works in both tools.
-  
-  💡 Try it: Check which instruction files your project has. Ensure each tool can find what it needs. Use the env var trick to share .claude/rules/.
-  
-  #AgenticAI #Day8
+slackOneLiner: "🤖 Tip #8 — Four instruction files exist across platforms. Know who reads what — and use the env var trick to share rules without duplication."
+keyPointsTitle: "Who Reads What"
+actionItemsTitle: "Cross-Platform Sharing"
+keyPoints:
+  - "**CLAUDE.md** — Claude Code's primary file. Also read by Copilot coding agent (the cloud autonomous agent that works on GitHub issues). Supports @import for recursive includes."
+  - "**AGENTS.md** — the new open format (Aug 2025). Read by Copilot CLI, VS Code Chat, and the coding agent. Placed at root or nested per-directory."
+  - "**.github/copilot-instructions.md** — the original Copilot format. Still works. Repo-wide scope."
+  - "**.github/instructions/*.instructions.md** — path-scoped with `applyTo:` frontmatter. Like .claude/rules/ but for Copilot. Can exclude specific agents with `excludeAgent:`."
+actionItems:
+  - |
+    The sharing trick — no duplication needed
+    - Set `COPILOT_CUSTOM_INSTRUCTIONS_DIRS=".claude/rules"` as an env var
+    - Now BOTH Claude Code and Copilot CLI read the same rules
+    - Still need dual frontmatter (`paths:` + `applyTo:`) for path-matching in both tools
+  - "Check which instruction files your project has — ensure each tool can find what it needs"
+  - "Set `COPILOT_CUSTOM_INSTRUCTIONS_DIRS=\".claude/rules\"` so Copilot CLI reads your existing Claude Code rules"
+  - "Use dual frontmatter (`paths:` for Claude Code + `applyTo:` for Copilot) in all rule files for cross-platform path-matching"
 ---
-
-```
-# Who reads what:
-CLAUDE.md              → Claude Code ✅
-                         Copilot coding agent ✅
-AGENTS.md              → Copilot CLI + Chat ✅
-                         Copilot coding agent ✅
-.github/copilot-       → Copilot CLI + Chat ✅
-  instructions.md
-.claude/rules/         → Claude Code ✅
-                         Copilot CLI ✅ (via env)
-
-# Share rules with Copilot CLI:
-COPILOT_CUSTOM_INSTRUCTIONS_DIRS=".claude/rules"
-```

--- a/website/src/content/tips/hook-matchers-precision-targeting.md
+++ b/website/src/content/tips/hook-matchers-precision-targeting.md
@@ -4,62 +4,37 @@ category: "Hooks — Guardrails"
 focus: "Claude Code"
 tags: ["Matchers","Wildcards","Patterns"]
 overview: 'Hook matchers let you target specific operations. "Bash" matches all Bash calls. "Bash(git commit*)" matches only git commits. "Bash(git push --force*)" matches only force pushes. Wildcards give you precision without false positives.'
-codeLabel: "Matcher precision"
 screenshot: null
 week: 8
 weekLabel: "Skills — Advanced"
 order: 36
-slackText: |
-  🤖 Agentic AI Tip #36 — Hook Matchers: Precision Targeting
-  
-  A hook that fires on every Bash command is useless — too noisy. A hook that fires on `git push --force` only is perfect.
-  
-  *Matcher syntax:*
-  
-  `"Bash"` — matches ALL Bash tool calls
-  → Too broad for most uses
-  
-  `"Bash(git commit*)"` — matches Bash calls starting with "git commit"
-  → Perfect for branch protection
-  
-  `"Bash(git push --force*)"` — matches only force pushes
-  → Precise, no false positives
-  
-  `"mcp__*figma*"` — matches any MCP tool with "figma" in the name
-  → Catches all Figma operations
-  
-  `"Edit"` — matches all Edit tool calls
-  → Good for file validation hooks
-  
-  *The wildcard rules:*
-  • `*` matches anything (including nothing)
-  • The pattern matches the tool name and optionally the arguments in parentheses
-  • No regex — just glob-style wildcards
-  
-  *A matcher for every risk level:*
-  • `Bash(rm -rf*)` — catch destructive deletions
-  • `Bash(git reset --hard*)` — catch history destruction
-  • `Write(*.env*)` — catch secret file creation
-  • `Bash(curl*|*wget*)` — catch network calls
-  
-  💡 Try it: List the 3 most dangerous commands for your project. Write a matcher for each. You now have a safety net.
-  
-  #AgenticAI #Day36
+slackOneLiner: "🤖 Tip #36 — Hook matchers give you precision targeting — match only `git push --force`, not every Bash call. Glob-style wildcards, no regex."
+keyPointsTitle: "Matcher Syntax"
+actionItemsTitle: "Matchers for Every Risk"
+keyPoints:
+  - |
+    Tool name plus optional argument pattern in parentheses
+    - `"Bash"` — matches ALL Bash tool calls (too broad for most uses)
+    - `"Bash(git commit*)"` — matches Bash calls starting with "git commit" (perfect for branch protection)
+    - `"Bash(git push --force*)"` — matches only force pushes (precise, no false positives)
+  - |
+    MCP and other tool matchers
+    - `"mcp__*figma*"` — matches any MCP tool with "figma" in the name
+    - `"Edit"` — matches all Edit tool calls (good for file validation)
+    - `"Write(*.env*)"` — catches secret file creation
+  - |
+    Wildcard rules
+    - `*` matches anything (including nothing)
+    - Pattern matches tool name and optionally arguments in parentheses
+    - No regex — just glob-style wildcards
+actionItems:
+  - |
+    A matcher for every risk level
+    - `Bash(rm -rf*)` — catch destructive deletions
+    - `Bash(git reset --hard*)` — catch history destruction
+    - `Write(*.env*)` — catch secret file creation
+    - `Bash(curl*|*wget*)` — catch network calls
+  - "List the 3 most dangerous commands for your project — write a matcher for each and you have a safety net"
+  - "Start specific, not broad — `Bash(git commit*)` is better than `Bash` because it avoids false positives on harmless commands"
+  - "Test matchers by asking the AI to run the matched command — verify the hook fires and the error message is clear"
 ---
-
-```
-# Match ALL Bash calls
-"matcher": "Bash"
-
-# Match only git commits
-"matcher": "Bash(git commit*)"
-
-# Match only force pushes
-"matcher": "Bash(git push --force*)"
-
-# Match any MCP tool with "figma"
-"matcher": "mcp__*figma*"
-
-# Match Edit tool (any file)
-"matcher": "Edit"
-```

--- a/website/src/content/tips/hooks-event-driven-automation.md
+++ b/website/src/content/tips/hooks-event-driven-automation.md
@@ -4,58 +4,26 @@ category: "Hooks — Guardrails"
 focus: "Claude Code"
 tags: ["Hooks","Events","Automation"]
 overview: "Hooks are code that runs when the AI does something. SessionStart fires when a session begins. PreToolUse fires before the AI calls a tool. PostToolUse fires after. Stop fires when the AI finishes. They're your guardrails — preventing mistakes, enriching results, validating actions."
-codeLabel: "Hook examples"
 screenshot: null
 week: 7
 weekLabel: "Skills — Advanced"
 order: 32
-slackText: |
-  🤖 Agentic AI Tip #32 — Hooks: Event-Driven Automation
-  
-  Hooks are the safety net you didn't know you needed.
-  
-  *What are hooks?*
-  Shell commands that run automatically when the AI takes specific actions. Think of them as git hooks, but for AI tool usage.
-  
-  *Four hook events:*
-  
-  *SessionStart* — fires once when AI session begins
-  → Check Node version, verify MCP connections, validate config
-  
-  *PreToolUse* — fires BEFORE a tool call
-  → Block dangerous operations, validate parameters
-  → Can REJECT the tool call (the AI can't proceed)
-  
-  *PostToolUse* — fires AFTER a tool call
-  → Cache results, validate outputs, log actions
-  
-  *Stop* — fires when the AI finishes
-  → Cleanup, reporting, notifications
-  
-  *Real examples from our project:*
-  • PreToolUse blocks `git commit` on protected branches (development, main)
-  • PostToolUse saves Figma screenshots to disk automatically
-  • PostToolUse validates plugin file edits (prevents YAML corruption)
-  
-  *The power:* Hooks are declarative safety. Instead of hoping the AI remembers not to commit on main, you *prevent* it structurally.
-  
-  💡 Try it: Look at your project's hooks (if any): `.claude/hooks/` or plugin `hooks.json`. If none exist, start with a branch protection hook.
-  
-  #AgenticAI #Day32
+slackOneLiner: "🤖 Tip #32 — Hooks are shell commands that fire on AI events — think git hooks, but for AI tool usage. Your structural safety net."
+keyPointsTitle: "Four Hook Events"
+actionItemsTitle: "When to Use Each"
+keyPoints:
+  - "Hooks are shell commands that run automatically when the AI takes specific actions — think git hooks, but for AI tool usage. Declarative safety that can't be overridden by context loss."
+  - "**SessionStart** — fires once when AI session begins. Check Node version, verify MCP connections, validate config files."
+  - "**PreToolUse** — fires BEFORE a tool call. Block dangerous operations, validate parameters. Can REJECT the tool call — the AI must find another approach."
+  - "**PostToolUse** — fires AFTER a tool call. Cache results, validate outputs, log actions. Cannot block — the action already happened."
+  - "**Stop** — fires when the AI finishes. Cleanup, reporting, notifications."
+actionItems:
+  - |
+    Real examples from our project
+    - PreToolUse blocks `git commit` on protected branches (development, main)
+    - PostToolUse saves Figma screenshots to disk automatically
+    - PostToolUse validates plugin file edits (prevents YAML corruption)
+  - "Look at your project's hooks: `.claude/hooks/` or plugin `hooks.json` — if none exist, start with a branch protection hook"
+  - "Start with PreToolUse for safety — it's the most valuable hook type because it prevents mistakes structurally instead of relying on AI instructions"
+  - "Remember the key difference — PreToolUse can block (exit 1), PostToolUse can only observe and enrich"
 ---
-
-```
-# hooks.json
-[
-  {
-    "event": "PreToolUse",
-    "matcher": "Bash(git commit*)",
-    "command": "./scripts/check-branch.sh"
-  },
-  {
-    "event": "PostToolUse",
-    "matcher": "Edit",
-    "command": "./scripts/validate-edit.sh"
-  }
-]
-```

--- a/website/src/content/tips/how-to-select-an-agent-three-uis-one-concept.md
+++ b/website/src/content/tips/how-to-select-an-agent-three-uis-one-concept.md
@@ -4,54 +4,24 @@ category: "Meet Your AI Tools"
 focus: "All Tools"
 tags: ["Agent Selection","/agents","Dropdown","Auto-Dispatch"]
 overview: "Each tool selects agents differently. VSCode Chat: dropdown menu at the bottom — pick an agent, it becomes your assistant. Copilot CLI: /agents command shows a numbered list — arrow keys to select. Claude Code: /agents lists all 34 agents with plugin prefix, model tier, and memory. But most of the time, you don't pick manually — skills auto-dispatch to the right agent."
-codeLabel: "Three selection methods"
 screenshot: "/images/tldr/agents-selection.png"
 week: 1
 weekLabel: "Meet Your AI Tools"
 order: 4
-slackText: |
-  🤖 Agentic AI Tip #4 — How to Select an Agent: Three UIs, One Concept
-  
-  You have dozens of agents available. How do you pick one? It depends on the tool.
-  
-  *VSCode Chat — dropdown menu:*
-  At the bottom of the Chat panel, click the agent name. A dropdown shows all available agents: DxPRReview, DxCodeReview, AEMComponent, etc. Pick one, and it becomes your active assistant with its own tools and persona. You'll also see "Configure Custom Agents..." to manage .agent.md files.
-  
-  *Copilot CLI — /agents command:*
-  Type `/agents` in the terminal. You get a numbered list of all agents — plugin agents AND .github/agents/ agents. Use arrow keys to navigate, Enter to select. The selected agent stays active for your session. You also see warnings if any .agent.md files have unsupported fields.
-  
-  *Claude Code — /agents command:*
-  Type `/agents` for the full inventory. Claude Code shows the richest info: agent name with plugin prefix (`dx-aem:aem-inspector`), model tier (`sonnet`), and memory type (`project memory`). You see all 34 agents across installed plugins.
-  
-  *But here's the real pattern:*
-  Most of the time, you don't manually select agents. *Skills auto-dispatch.* When you run `/dx-pr-review`, the skill automatically routes to the `dx-pr-reviewer` agent (Sonnet, with ADO MCP tools). The skill knows which agent is right for the job.
-  
-  Manual selection is for exploration. Auto-dispatch is for workflows.
-  
-  💡 Try it: Run `/agents` in both Claude Code and Copilot CLI. Compare the lists — Claude Code shows 13 plugin agents, Copilot shows 25 .github agents.
-  
-  #AgenticAI #Day4
+slackOneLiner: "🤖 Tip #4 — You have dozens of agents available across three tools, but most of the time skills auto-dispatch to the right one for you."
+keyPointsTitle: "Selection in Each Tool"
+keyPoints:
+  - "VSCode Chat — Dropdown menu at the bottom of the Chat panel. Click the agent name, pick from the list (DxPRReview, DxCodeReview, AEMComponent, etc.). Also shows 'Configure Custom Agents...' to manage .agent.md files."
+  - "Copilot CLI — Type `/agents` in the terminal. Get a numbered list of all agents (plugin agents AND .github/agents/ agents). Arrow keys to navigate, Enter to select. The selected agent stays active for your session."
+  - "Claude Code — Type `/agents` for the full inventory. Shows the richest info: agent name with plugin prefix (`dx-aem:aem-inspector`), model tier (`sonnet`), and memory type (`project memory`). All 34 agents across installed plugins visible at once."
+actionItemsTitle: "Auto-Dispatch vs Manual Selection"
+actionItems:
+  - "Auto-dispatch is the real pattern — Most of the time, you don't manually select agents. Skills auto-dispatch. Running `/dx-pr-review` automatically routes to the `dx-pr-reviewer` agent (Sonnet, with ADO MCP tools). The skill knows which agent is right for the job."
+  - "Manual selection is for exploration — Use `/agents` to discover what's available, learn agent capabilities, and experiment. For actual workflows, let skills handle the routing."
+  - "Run `/agents` in both Claude Code and Copilot CLI — compare the lists (Claude Code shows 13 plugin agents, Copilot shows 25 .github agents)"
+  - |
+    Know the selection method per tool
+    - VSCode Chat — dropdown at bottom of Chat panel
+    - Copilot CLI — `/agents` command, arrow keys + Enter
+    - Claude Code — `/agents` command, shows plugin prefix + model tier
 ---
-
-```
-# VSCode Chat — dropdown at bottom:
-# Click agent name → pick from list
-# Shows: DxPRReview, DxCodeReview...
-# "Configure Custom Agents..." link
-
-# Copilot CLI — /agents command:
-/agents
-# → numbered list, Enter to select
-# Shows plugin + .github agents
-
-# Claude Code — /agents command:
-/agents
-# → full list with details:
-# dx-aem:aem-inspector · sonnet
-# dx-core:dx-code-reviewer
-#   · opus · project memory
-
-# Auto-dispatch (most common):
-/dx-pr-review    # skill picks agent
-# → routes to dx-pr-reviewer agent
-```

--- a/website/src/content/tips/maxturns-the-agent-safety-net.md
+++ b/website/src/content/tips/maxturns-the-agent-safety-net.md
@@ -4,61 +4,26 @@ category: "Mastery"
 focus: "Claude Code"
 tags: ["maxTurns","Safety","Loops"]
 overview: "Agents can loop. An agent trying to fix a flaky test might retry indefinitely. maxTurns sets a hard cap on how many turns an agent can take before stopping. Set it lower for simple tasks (10-20) and higher for complex ones (50+). Without it, a stuck agent burns tokens forever."
-codeLabel: "maxTurns per agent"
 screenshot: null
 week: 10
 weekLabel: "Agents — AI Personas"
 order: 50
-slackText: |
-  🤖 Agentic AI Tip #50 — maxTurns: The Agent Safety Net
-  
-  Without maxTurns, a stuck agent loops forever, burning tokens into oblivion.
-  
-  *The scenario:*
-  Agent tries to fix a test. Test still fails. Agent tries again. Still fails. Tries a different approach. Fails. Reverts. Tries again... 200 turns later, you've spent $50 and the test still fails.
-  
-  *The fix:*
-  `maxTurns` in agent frontmatter sets a hard cap:
-  ```yaml
-  maxTurns: 15   # for simple lookups
-  maxTurns: 50   # for complex tasks
-  ```
-  
-  When the agent hits the limit, it stops and returns what it has — partial results are better than infinite loops.
-  
-  *How to set the right value:*
-  • File search/lookup: 10-15 turns
-  • Implementation with testing: 40-50 turns
-  • Code review: 30-50 turns
-  • Bug investigation: 30-40 turns
-  
-  *Pro tip:* If an agent frequently hits maxTurns, the task is too complex for one agent. Break it into smaller subtasks or add better instructions to guide the agent more efficiently.
-  
-  *For autonomous agents:*
-  maxTurns is especially critical. A Lambda-based agent without maxTurns could run for hours. We set conservative limits and handle partial completion gracefully.
-  
-  💡 Try it: Check your agent definitions for maxTurns. Any missing? Add them. Start conservative — you can always increase.
-  
-  #AgenticAI #Day50
+slackOneLiner: "🤖 Tip #50 — Set maxTurns on every agent to prevent infinite loops — a stuck agent without it burns tokens into oblivion."
+keyPointsTitle: "Why Agents Need Limits"
+actionItemsTitle: "Setting the Right Values"
+keyPoints:
+  - "**The problem** — Without maxTurns, a stuck agent loops forever. Agent tries to fix a test, fails, tries again, tries a different approach, reverts, retries... 200 turns later, you've spent $50 and the test still fails."
+  - "**The fix** — `maxTurns` in agent frontmatter sets a hard cap. When the agent hits the limit, it stops and returns what it has. Partial results are better than infinite loops."
+  - "**Frequent hits signal a problem** — If an agent frequently hits maxTurns, the task is too complex for one agent. Break it into smaller subtasks or add better instructions to guide the agent more efficiently."
+  - "**Critical for autonomous agents** — A Lambda-based agent without maxTurns could run for hours. Set conservative limits and handle partial completion gracefully."
+actionItems:
+  - |
+    **Right-sizing by agent type**
+    - Haiku lookup agents — maxTurns 10-15
+    - Sonnet implementation agents — maxTurns 40-50
+    - Opus review agents — maxTurns 30-50
+    - Autonomous pipeline agents — conservative limits (15-30)
+  - "**Start conservative** — Begin with lower values and increase only if agents consistently need more turns to complete their tasks. It's cheaper to bump a limit than to burn tokens on a runaway."
+  - "**Audit your agents** — Check every agent definition for missing maxTurns. Any agent without one is a potential runaway. Add limits to all of them."
+  - "**Handle partial completion** — Design your skills to accept partial results gracefully. A code review that covers 80% of files is better than one that loops forever trying to cover 100%."
 ---
-
-```
-# Agent definition:
----
-name: dx-file-resolver
-model: haiku
-maxTurns: 15    # simple lookup
----
-
----
-name: dx-pr-reviewer
-model: sonnet
-maxTurns: 50    # complex implementation
----
-
----
-name: dx-code-reviewer
-model: opus
-maxTurns: 50    # thorough review
----
-```

--- a/website/src/content/tips/mcp-secrets-two-different-approaches.md
+++ b/website/src/content/tips/mcp-secrets-two-different-approaches.md
@@ -4,54 +4,22 @@ category: "MCP — System Integration"
 focus: "Claude Code · CLI"
 tags: ["Secrets","Environment Variables","Config"]
 overview: "MCP servers often need API keys. Claude Code reads env vars from .claude/settings.local.json (gitignored). Copilot CLI does NOT read this file — it only sees shell environment variables from ~/.bashrc. Same secret, two different config locations."
-codeLabel: "Same secret, two configs"
 screenshot: null
 week: 6
 weekLabel: "Skills — Recipe Book"
 order: 30
-slackText: |
-  🤖 Agentic AI Tip #30 — MCP Secrets: Two Different Approaches
-  
-  MCP servers need API keys, passwords, and URLs. Where you put them depends on which AI tool you're using.
-  
-  *Claude Code:*
-  `.claude/settings.local.json` (per-project, gitignored):
-  ```json
-  { "env": { "AXE_API_KEY": "your-key" } }
-  ```
-  Clean, project-scoped, won't leak to git.
-  
-  *Copilot CLI:*
-  Only reads shell environment variables. Does NOT read `settings.local.json`.
-  ```bash
-  # In ~/.bashrc
-  export AXE_API_KEY="your-key"
-  ```
-  
-  *The common mistake:*
-  You configure secrets in `settings.local.json`, MCP works perfectly in Claude Code. Then you switch to Copilot CLI and MCP connections fail. No error tells you "I can't read settings.local.json" — the env var is just empty.
-  
-  *Best practice for teams using both tools:*
-  1. Put secrets in `~/.bashrc` (or `~/.zshrc`) — works for both tools
-  2. Optionally also add to `settings.local.json` for Claude Code's per-project isolation
-  
-  *Security reminder:* Never commit API keys. Both `settings.local.json` and `~/.bashrc` are outside git. Keep it that way.
-  
-  💡 Try it: Run `echo $AXE_API_KEY` in your terminal. If it's empty, your Copilot CLI MCP servers can't see it.
-  
-  #AgenticAI #Day30
+slackOneLiner: "🤖 Tip #30 — Same API key, two config locations: Claude Code reads settings.local.json, Copilot CLI only sees shell env vars."
+keyPointsTitle: "Where Each Tool Reads Secrets"
+actionItemsTitle: "Avoiding the Silent Failure"
+keyPoints:
+  - "**Claude Code** — Secrets go in .claude/settings.local.json (per-project, gitignored). Clean, project-scoped, won't leak to git. Format: { \"env\": { \"AXE_API_KEY\": \"your-key\" } }."
+  - "**Copilot CLI** — Only reads shell environment variables. Does NOT read settings.local.json. Secrets must be exported in ~/.bashrc or ~/.zshrc."
+  - "**The silent failure trap** — You configure secrets in settings.local.json, MCP works perfectly in Claude Code. Then you switch to Copilot CLI and MCP connections fail silently. No error tells you the env var is empty — it just doesn't work."
+actionItems:
+  - "**Quick diagnosis** — Run 'echo $AXE_API_KEY' in your terminal. If it's empty, your Copilot CLI MCP servers can't see it."
+  - |
+    **Cross-tool compatibility** — Set secrets in both locations
+    - ~/.bashrc or ~/.zshrc → export AXE_API_KEY="your-key"
+    - .claude/settings.local.json → { "env": { "AXE_API_KEY": "your-key" } }
+  - "**Security reminder** — Never commit API keys. Both settings.local.json and ~/.bashrc are outside git. Verify that settings.local.json is in your .gitignore."
 ---
-
-```
-# Claude Code — settings.local.json
-{
-  "env": {
-    "AXE_API_KEY": "your-key-here",
-    "AEM_INSTANCES": "http://admin:admin@localhost:4502"
-  }
-}
-
-# Copilot CLI — ~/.bashrc only!
-export AXE_API_KEY="your-key-here"
-export AEM_INSTANCES="http://..."
-```

--- a/website/src/content/tips/mcp-tool-naming-three-formats-one-gotcha.md
+++ b/website/src/content/tips/mcp-tool-naming-three-formats-one-gotcha.md
@@ -4,59 +4,31 @@ category: "MCP — System Integration"
 focus: "Claude Code"
 tags: ["Naming","Prefix","Cross-Platform"]
 overview: "MCP tool names differ by platform. Claude Code: mcp__plugin_dx-aem_AEM__getNodeContent (double underscore). Copilot: ado/wit_get_work_item (slash format). VSCode: same as Copilot. Plugin tools get an extra prefix. Get the format wrong = silent failure."
-codeLabel: "Three naming formats"
 screenshot: null
 week: 6
 weekLabel: "Skills — Recipe Book"
 order: 29
-slackText: |
-  🤖 Agentic AI Tip #29 — MCP Tool Naming: Three Formats, One Gotcha
-  
-  MCP tool names look different in each tool. This is the #1 debugging headache.
-  
-  *Claude Code format (double underscore):*
-  `mcp__plugin_<plugin>_<server>__<tool>`
-  • `mcp__plugin_dx-aem_AEM__getNodeContent`
-  • `mcp__ado__wit_get_work_item` (project-level, no plugin prefix)
-  
-  *Copilot CLI & VSCode format (slash):*
-  `'server/tool'`
-  • `'AEM/getNodeContent'`
-  • `'ado/wit_get_work_item'`
-  
-  *In .agent.md files:*
-  ```yaml
-  tools:
-    - read
-    - 'ado/wit_get_work_item'
-    - 'AEM/scanPageComponents'
-  ```
-  
-  *The cross-platform trap:*
-  Our agent templates need to work in both Claude Code and Copilot. The tools section must include both naming formats. Unrecognized names are silently ignored — so having both doesn't cause errors.
-  
-  *Debugging tip:*
-  • Claude Code: use `ToolSearch("+AEM")` to find the real prefixed name
-  • Copilot CLI: MCP tools appear as `server/tool` in tool lists
-  • If a tool "doesn't exist," check the format first
-  
-  💡 Try it: Compare the tool names in a Claude Code agent file vs a .github/agents/ file. Notice the different format.
-  
-  #AgenticAI #Day29
+slackOneLiner: "🤖 Tip #29 — MCP tool names look different in each platform — get the format wrong and tools silently fail to resolve."
+keyPointsTitle: "The Three Naming Formats"
+actionItemsTitle: "Cross-Platform Survival Guide"
+keyPoints:
+  - |
+    **Claude Code format (double underscore)**
+    - Pattern: mcp__plugin_<plugin>_<server>__<tool>
+    - Example: mcp__plugin_dx-aem_AEM__getNodeContent
+    - Project-level servers skip the plugin prefix: mcp__ado__wit_get_work_item
+  - |
+    **Copilot CLI and VSCode format (slash)**
+    - Pattern: server/tool
+    - Example: AEM/getNodeContent, ado/wit_get_work_item
+    - Same format for both platforms
+  - "**The gotcha** — Agent templates that need to work in both Claude Code and Copilot must include both naming formats in the tools section. Unrecognized names are silently ignored, so having both doesn't cause errors."
+actionItems:
+  - |
+    **Include both formats in cross-platform templates**
+    - Claude Code: mcp__plugin_dx-aem_AEM__getNodeContent
+    - Copilot CLI: AEM/getNodeContent
+  - "**Debugging in Claude Code** — Use ToolSearch(\"+AEM\") to find the real prefixed name. If a tool 'doesn't exist,' the naming format is the first thing to check."
+  - "**Debugging in Copilot CLI** — MCP tools appear as server/tool in tool lists. Compare against what your agent file references."
+  - "**Comparison test** — Look at a Claude Code agent file vs a .github/agents/ file side by side. The naming difference becomes immediately obvious."
 ---
-
-```
-# Claude Code format:
-mcp__plugin_dx-aem_AEM__getNodeContent
-mcp__ado__wit_get_work_item
-
-# Copilot CLI / VSCode format:
-'AEM/getNodeContent'
-'ado/wit_get_work_item'
-
-# In Copilot .agent.md tools:
-tools:
-  - read
-  - 'ado/wit_get_work_item'
-  - 'AEM/scanPageComponents'
-```

--- a/website/src/content/tips/mentions-and-agent-mode-context.md
+++ b/website/src/content/tips/mentions-and-agent-mode-context.md
@@ -4,55 +4,31 @@ category: "Context — The Secret Sauce"
 focus: "VSCode Chat"
 tags: ["@file","@workspace","#runSubagent","Agent Mode"]
 overview: "In VSCode Chat, @ mentions feed context: @workspace, @terminal, @vscode. In Agent mode, the AI also auto-discovers context — it reads files, searches code, and checks diagnostics on its own. New: #runSubagent creates context-isolated sub-tasks. In Copilot CLI, use #file and drag-and-drop for context."
-codeLabel: "Context feeding"
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 9
-slackText: |
-  🤖 Agentic AI Tip #9 — @ Mentions and Agent Mode Context
-  
-  How you feed context to AI depends on the mode and tool.
-  
-  *VSCode Chat — Ask/Plan mode (manual context):*
-  • `@workspace` — searches your codebase
-  • `@terminal` — includes terminal output
-  • `@vscode` — knows about editor settings and commands
-  • Drag & drop files into chat
-  • Select code → "Add to Chat"
-  
-  *VSCode Chat — Agent mode (auto-discovers):*
-  In Agent mode, the AI doesn't wait for you to feed context. It *actively searches* — reads files, runs searches, checks LSP diagnostics, even runs terminal commands. You just describe the task, it finds what it needs.
-  
-  *New: #runSubagent*
-  Creates a context-isolated sub-task within VSCode Chat. The subagent gets a fresh context, does its work, and returns results — similar to Claude Code's spawned agents.
-  
-  *Copilot CLI:*
-  • `#file:path/to/file.js` to include a file
-  • Drag & drop from file explorer
-  • CLI auto-reads relevant files in agentic mode
-  
-  *Claude Code:*
-  Automatically discovers context. Read, Grep, Glob tools let it explore the codebase. CLAUDE.md provides persistent project context.
-  
-  💡 Try it: In VSCode Agent mode, just describe what you want. Don't manually @ mention anything. Watch how the AI finds context on its own.
-  
-  #AgenticAI #Day9
+slackOneLiner: "🤖 Tip #9 — How you feed context to AI depends on the mode and tool. Agent mode auto-discovers; Ask/Plan mode needs @ mentions."
+keyPointsTitle: "How Each Tool Gets Context"
+keyPoints:
+  - |
+    VSCode Chat — Ask/Plan mode (manual context)
+    - @workspace — searches your codebase
+    - @terminal — includes terminal output
+    - @vscode — knows about editor settings and commands
+    - Drag & drop files into chat
+    - Select code → 'Add to Chat'
+  - "VSCode Chat — Agent mode (auto-discovers) — the AI doesn't wait for you to feed context. It actively searches, reads files, runs searches, checks LSP diagnostics, even runs terminal commands. Just describe the task."
+  - |
+    Copilot CLI context
+    - #file:path/to/file.js to include a specific file
+    - Drag & drop from file explorer
+    - CLI auto-reads relevant files in agentic mode
+  - "Claude Code — automatically discovers context via Read, Grep, Glob tools. CLAUDE.md provides persistent project context loaded into every session."
+actionItemsTitle: "Context Power Moves"
+actionItems:
+  - "#runSubagent — creates a context-isolated sub-task within VSCode Chat. The subagent gets a fresh context, does its work, and returns results — similar to Claude Code's spawned agents."
+  - "In VSCode Agent mode, just describe what you want without any @ mentions — watch how the AI finds context on its own"
+  - "Use #runSubagent for isolated research tasks that shouldn't pollute your main conversation context"
+  - "In Copilot CLI, use #file:path to explicitly include files when the auto-discovery misses something"
 ---
-
-```
-# VSCode Chat — @ mentions:
-@workspace "find Modal usages"
-@terminal "why did this fail?"
-@vscode "how to configure font size?"
-
-# Agent mode — auto-discovers context:
-"Fix the auth bug"
-→ AI reads files, checks LSP, runs tests
-
-# Sub-task with isolated context:
-#runSubagent "research the modal API"
-
-# Copilot CLI — context:
-#file:src/auth.js "explain this"
-```

--- a/website/src/content/tips/model-selection-more-models-than-you-think.md
+++ b/website/src/content/tips/model-selection-more-models-than-you-think.md
@@ -4,53 +4,35 @@ category: "Meet Your AI Tools"
 focus: "All Tools"
 tags: ["Opus $$$","Sonnet $$","Haiku $","Multi-Model"]
 overview: "Claude Code uses Anthropic models (Opus/Sonnet/Haiku). Copilot CLI and VSCode Chat support Claude, GPT, AND Gemini — switch mid-session with /model. Each model family has strengths. Copilot agents support model fallback chains: model: [claude-sonnet, gpt-4o] — if one fails, try the next."
-codeLabel: "Model options"
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 6
-slackText: |
-  🤖 Agentic AI Tip #6 — Model Selection: More Models Than You Think
-  
-  The model landscape is wider than you think — and *which tool you use* determines your options.
-  
-  *Claude Code — Anthropic models:*
-  • Opus ($$$): deep reasoning, architecture, code review (1M context)
-  • Sonnet ($$): everyday coding, PR review, implementation
-  • Haiku ($): fast lookups, file search, simple transforms
-  Switch with `/model` or `/fast` for Sonnet quick-mode.
-  
-  *Copilot CLI & VSCode Chat — multi-model:*
-  • Claude Sonnet 4.6, Claude Haiku 4.5
-  • GPT-4o, GPT-5.3-Codex
-  • Gemini 2.5 Pro, Gemini 3 Pro
-  Switch mid-session with `/model`. Each model family has strengths.
-  
-  *Copilot agent fallback chains:*
-  ```yaml
-  model: [claude-sonnet-4, gpt-4o]
-  ```
-  If Claude is down, fall back to GPT automatically. Claude Code doesn't support this.
-  
-  *The tiering principle still applies:*
-  Use the cheapest model that can do the job. Our 13 agents use 3 tiers: 1 Opus agent (code review), 8 Sonnet agents (execution), 4 Haiku agents (lookups). This saves 10x vs using Opus for everything.
-  
-  💡 Try it: In Copilot CLI, run `/model` to see all available models. Try the same prompt with Claude and GPT — compare the approaches.
-  
-  #AgenticAI #Day6
+slackOneLiner: "🤖 Tip #6 — Which tool you use determines your model options. Claude Code = Anthropic only. Copilot = Claude + GPT + Gemini. Tier wisely."
+keyPointsTitle: "The Model Landscape"
+keyPoints:
+  - "The model landscape is wider than you think — which tool you use determines your options."
+  - |
+    Claude Code — Anthropic models only
+    - Opus ($$$): deep reasoning, architecture, code review (1M context)
+    - Sonnet ($$): everyday coding, PR review, implementation
+    - Haiku ($): fast lookups, file search, simple transforms
+    - Switch with /model or /fast for Sonnet quick-mode
+  - |
+    Copilot CLI & VSCode Chat — multi-model
+    - Claude Sonnet 4.6, Claude Haiku 4.5
+    - GPT-4o, GPT-5.3-Codex
+    - Gemini 2.5 Pro, Gemini 3 Pro
+    - Switch mid-session with /model — each model family has strengths
+  - "Copilot agent fallback chains — specify `model: [claude-sonnet-4, gpt-4o]` in agent config. If Claude is down, fall back to GPT automatically. Claude Code doesn't support this."
+actionItemsTitle: "Tier Wisely, Save 10x"
+actionItems:
+  - "The tiering principle — use the cheapest model that can do the job. Our 13 agents use 3 tiers: 1 Opus agent (code review), 8 Sonnet agents (execution), 4 Haiku agents (lookups). This saves 10x vs using Opus for everything."
+  - |
+    Match model to task
+    - Deep reasoning/architecture → Opus
+    - Everyday coding/implementation → Sonnet
+    - Fast lookups/simple transforms → Haiku
+  - "In Copilot CLI, run /model to see all available models — try the same prompt with Claude and GPT to compare approaches"
+  - "Review your agent definitions and ensure each uses the cheapest model tier that produces good results"
 ---
-
-```
-# Claude Code — Anthropic only
-/model opus    # deep reasoning
-/model sonnet  # everyday coding
-/model haiku   # fast lookups
-
-# Copilot CLI — multi-model
-/model claude-sonnet-4
-/model gpt-4o
-/model gemini-2.5-pro
-
-# Copilot agent fallback chain:
-# model: [claude-sonnet, gpt-4o]
-```

--- a/website/src/content/tips/multi-provider-ado-jira.md
+++ b/website/src/content/tips/multi-provider-ado-jira.md
@@ -4,52 +4,24 @@ category: "Mastery"
 focus: "Claude Code"
 tags: ["ADO","Jira","Multi-Provider"]
 overview: "Our skills work with both Azure DevOps and Jira. A single config value — tracker.provider — switches the entire pipeline between ADO MCP calls and Jira MCP calls. Write skills once, deploy to any organization regardless of their project management tool."
-codeLabel: "Provider switch"
 screenshot: null
 week: 10
 weekLabel: "Agents — AI Personas"
 order: 49
-slackText: |
-  🤖 Agentic AI Tip #49 — Multi-Provider: ADO + Jira
-  
-  Some teams use Azure DevOps. Others use Jira. Our skills work with both.
-  
-  *How it works:*
-  One config value in `.ai/config.yaml`:
-  ```yaml
-  tracker:
-    provider: ado  # or "jira"
-  ```
-  
-  Skills check this value and route to the correct MCP backend:
-  • `ado` → `mcp__ado__wit_get_work_item`
-  • `jira` → `mcp__atlassian__get_issue`
-  
-  *Why this matters:*
-  Write the skill logic once. The business logic (requirements analysis, planning, implementation) is the same regardless of whether the ticket lives in ADO or Jira. Only the API calls differ.
-  
-  *The abstraction layer:*
-  Field names differ between providers. ADO calls it "Acceptance Criteria," Jira calls it "Description." Our `shared/provider-config.md` maps these fields so skills can reference generic names.
-  
-  *For teams considering this pattern:*
-  Start with one provider. Get the skills working perfectly. Then add the second provider as an abstraction layer. Don't try to build both at once.
-  
-  💡 Try it: Check your project's `.ai/config.yaml` for the `tracker.provider` value. If you switch orgs, just change this one line.
-  
-  #AgenticAI #Day49
+slackOneLiner: "🤖 Tip #49 — One config value (tracker.provider) switches the entire skill pipeline between ADO and Jira — write once, deploy anywhere."
+keyPointsTitle: "How the Abstraction Works"
+actionItemsTitle: "Provider Mapping Details"
+keyPoints:
+  - "**Single config switch** — One value in .ai/config.yaml (tracker.provider: ado or jira) routes all skills to the correct MCP backend. No code changes, no skill duplication."
+  - "**Business logic stays the same** — Requirements analysis, planning, and implementation logic is identical regardless of where the ticket lives. Only the API calls to fetch and update tickets differ between providers."
+  - "**Field name abstraction** — ADO calls it 'Acceptance Criteria,' Jira calls it 'Description.' The shared/provider-config.md file maps these fields so skills can reference generic names like 'acceptance criteria' everywhere."
+  - "**Practical adoption strategy** — Start with one provider and get all skills working perfectly. Then add the second provider as an abstraction layer. Don't try to build both at once."
+actionItems:
+  - |
+    **Provider mapping examples**
+    - ADO: mcp__ado__wit_get_work_item, mcp__ado__wit_update_work_item
+    - Jira: mcp__atlassian__get_issue, mcp__atlassian__update_issue
+  - "**Quick switch** — Check your .ai/config.yaml for the tracker.provider value. Changing this one line switches the entire pipeline."
+  - "**Customize field mappings** — Review shared/provider-config.md if your Jira instance uses custom field names that differ from the defaults"
+  - "**Test both paths** — After adding a second provider, run /dx-req <ticket-id> with each provider setting to verify field mapping works correctly"
 ---
-
-```
-# .ai/config.yaml
-tracker:
-  provider: ado  # or "jira"
-
-# Skills check the provider:
-# if ado → use mcp__ado__*
-# if jira → use mcp__atlassian__*
-
-# Same skill, different backend:
-/dx-req 12345
-# → ADO: mcp__ado__wit_get_work_item
-# → Jira: mcp__atlassian__get_issue
-```

--- a/website/src/content/tips/parallel-agents-three-ways-to-run-concurrent-work.md
+++ b/website/src/content/tips/parallel-agents-three-ways-to-run-concurrent-work.md
@@ -4,52 +4,25 @@ category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Parallel","/fleet","Concurrent"]
 overview: "Three approaches to parallel work: Claude Code spawns multiple Agent calls in one message. Copilot CLI has /fleet — run the same task across multiple subagents and converge results. VSCode Chat has #runSubagent for context-isolated sub-tasks. Each tool has its own parallelism model."
-codeLabel: "Three parallelism models"
 screenshot: null
 week: 5
 weekLabel: "Skills — Recipe Book"
 order: 25
-slackText: |
-  🤖 Agentic AI Tip #25 — Parallel Agents: Three Ways to Run Concurrent Work
-  
-  Each tool has its own approach to parallelism:
-  
-  *Claude Code — multiple Agent tool calls:*
-  Put multiple Agent calls in one message → they run concurrently. Each gets its own context. Our `/dx-step-verify` runs lint + secrets + architecture in parallel, cutting time by ~60%.
-  
-  *Copilot CLI — /fleet:*
-  `/fleet "review each module for security issues"`
-  Spawns N parallel subagents, one per subtask. Results converge back. Think MapReduce for code tasks. Great for code review across many modules.
-  
-  *VSCode Chat — #runSubagent:*
-  `#runSubagent "research the modal API"`
-  Creates a context-isolated sub-task. The subagent works independently, returns results to your main conversation. Your context stays clean.
-  
-  *When to use which:*
-  • Claude Code: best for heterogeneous tasks (lint agent + test agent + build agent — different tools, same time)
-  • /fleet: best for homogeneous tasks (same task across N targets)
-  • #runSubagent: best for delegation (one-off heavy research)
-  
-  *Don't parallelize:*
-  Dependent tasks — if step 2 needs step 1's output. Parallel agents can't see each other's work.
-  
-  💡 Try it: In Copilot CLI, try `/fleet "summarize each file in src/components/"` — watch the parallel magic.
-  
-  #AgenticAI #Day25
+slackOneLiner: "🤖 Tip #25 — Each tool has its own parallelism model: Claude Code uses multiple Agent calls, Copilot CLI uses /fleet, VSCode Chat uses #runSubagent."
+keyPointsTitle: "Three Parallelism Models"
+actionItemsTitle: "When to Use Which"
+keyPoints:
+  - "**Claude Code** — Multiple Agent tool calls in one message run concurrently, each with its own context. Our `/dx-step-verify` runs lint + secrets + architecture checks in parallel, cutting verification time by ~60%."
+  - "**Copilot CLI /fleet** — Spawns N parallel subagents, one per subtask. Results converge back. Think MapReduce for code tasks. Great for homogeneous work like code review across many modules."
+  - "**VSCode Chat #runSubagent** — Creates a context-isolated sub-task. The subagent works independently, returns results to your main conversation. Your context stays clean. Best for one-off heavy research or delegation."
+  - "**Don't parallelize dependent tasks** — If step 2 needs step 1's output, run them sequentially. Parallel agents can't see each other's work."
+actionItems:
+  - |
+    **Match the model to the task type**
+    - Heterogeneous (different tools) — Claude Code multiple Agent calls
+    - Homogeneous (same task, N targets) — Copilot CLI /fleet
+    - Delegation (one-off research) — VSCode Chat #runSubagent
+  - "**Try /fleet** — In Copilot CLI, run `/fleet \"summarize each file in src/components/\"` to see parallel agent execution in action."
+  - "**Look for parallel opportunities** — Check if any of your sequential skill steps could run in parallel. Independent verification checks (lint, secrets, architecture) are prime candidates."
+  - "**Keep dependencies sequential** — Map your skill steps as a dependency graph. Only parallelize steps with no data dependencies between them."
 ---
-
-```
-# Claude Code — multiple Agent calls:
-Agent → run linting
-Agent → run tests     # same message!
-Agent → run build     # same message!
-
-# Copilot CLI — /fleet:
-/fleet "review each module for
- security issues"
-→ spawns N parallel subagents
-→ converges results
-
-# VSCode Chat — #runSubagent:
-#runSubagent "research the auth API"
-```

--- a/website/src/content/tips/permission-modes-plan-vs-acceptedits.md
+++ b/website/src/content/tips/permission-modes-plan-vs-acceptedits.md
@@ -4,52 +4,29 @@ category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Permissions","plan","acceptEdits","Safety"]
 overview: "Agents have two permission modes. \"plan\" means read-only — the agent can explore but can't change anything. \"acceptEdits\" means the agent can modify files autonomously. Default is read-only. Choose explicitly based on trust level."
-codeLabel: "Permission modes"
 screenshot: null
 week: 6
 weekLabel: "Skills — Recipe Book"
 order: 26
-slackText: |
-  🤖 Agentic AI Tip #26 — Permission Modes: plan vs acceptEdits
-  
-  How much do you trust the agent? That's what permission modes answer.
-  
-  *plan (read-only):*
-  The agent can read files, search code, and analyze — but cannot modify anything. Perfect for:
-  • Code review (read and report, don't change)
-  • Research (explore codebase, don't touch)
-  • Analysis (understand architecture, don't refactor)
-  
-  *acceptEdits (autonomous):*
-  The agent can read AND write files, run commands, make changes. Needed for:
-  • Implementation (the whole point is to write code)
-  • Bug fixes (needs to edit the broken code)
-  • Automation (needs to run builds and tests)
-  
-  *Why this matters:*
-  An agent with `acceptEdits` running in your working directory can modify files you're actively editing. If something goes wrong, you're dealing with merge conflicts against AI changes.
-  
-  *Safety pattern:* Combine `acceptEdits` with `isolation: "worktree"` — the agent works on a copy of the repo, not your active files. If it messes up, just delete the worktree.
-  
-  *Our practice:* Only 1 agent out of 13 has `acceptEdits` — the step executor. All others are read-only.
-  
-  💡 Try it: Check your agent definitions. Any agent with `acceptEdits` that doesn't need it? Switch it to `plan`.
-  
-  #AgenticAI #Day26
+slackOneLiner: "🤖 Tip #26 — How much do you trust the agent? 'plan' = read-only exploration, 'acceptEdits' = autonomous file changes. Default to plan."
+keyPointsTitle: "Two Modes, Different Trust Levels"
+keyPoints:
+  - |
+    plan (read-only)
+    - The agent can read files, search code, and analyze — but cannot modify anything
+    - Perfect for code review (read and report), research (explore codebase), and analysis (understand architecture)
+  - |
+    acceptEdits (autonomous)
+    - The agent can read AND write files, run commands, make changes
+    - Needed for implementation (writing code), bug fixes (editing broken code), and automation (running builds and tests)
+  - "Risk with acceptEdits — an agent with acceptEdits running in your working directory can modify files you're actively editing. If something goes wrong, you're dealing with merge conflicts against AI changes."
+actionItemsTitle: "Safety Patterns in Practice"
+actionItems:
+  - "Safety pattern — combine acceptEdits with isolation: 'worktree'. The agent works on a copy of the repo, not your active files. If it messes up, just delete the worktree."
+  - "Our practice — only 1 agent out of 13 has acceptEdits (the step executor). All others are read-only. Default to plan unless the agent's job is to write code."
+  - "Check your agent definitions — any agent with acceptEdits that doesn't need it? Switch it to plan"
+  - |
+    Choose permission mode by agent role
+    - Reviewers, analyzers, searchers → plan
+    - Implementers, fixers, automators → acceptEdits + worktree
 ---
-
-```
-# Read-only agent (safe exploration)
----
-permissionMode: plan
----
-# Can: Read, Glob, Grep, Search
-# Cannot: Edit, Write, Bash
-
-# Autonomous agent (trusted executor)
----
-permissionMode: acceptEdits
----
-# Can: Read, Edit, Write, Bash
-# Full autonomy within its scope
-```

--- a/website/src/content/tips/plugin-mcp-registration.md
+++ b/website/src/content/tips/plugin-mcp-registration.md
@@ -4,57 +4,30 @@ category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Plugin MCP",".mcp.json","Prefix"]
 overview: "Plugins can register their own MCP servers via .mcp.json alongside plugin.json. These servers are scoped to the plugin and their tools get auto-prefixed: mcp__plugin_<plugin>_<server>__<tool>. This prevents name collisions between plugins."
-codeLabel: "Plugin MCP"
 screenshot: null
 week: 8
 weekLabel: "Skills — Advanced"
 order: 38
-slackText: |
-  🤖 Agentic AI Tip #38 — Plugin MCP Registration
-  
-  Plugins don't just bundle skills — they can bring their own MCP servers along.
-  
-  *How it works:*
-  Place a `.mcp.json` file alongside your `plugin.json`. The MCP servers defined there are automatically started when the plugin loads.
-  
-  *The auto-prefix:*
-  Plugin MCP tools get a prefix that prevents name collisions:
-  `mcp__plugin_<plugin-name>_<server-name>__<tool-name>`
-  
-  So the AEM server in the dx-aem plugin becomes:
-  `mcp__plugin_dx-aem_AEM__getNodeContent`
-  
-  Not: `mcp__AEM__getNodeContent` (that would be a project-level server)
-  
-  *Why this matters:*
-  Two plugins could both register a server named "api". Without prefixing, they'd collide. With prefixing, they coexist:
-  • `mcp__plugin_pluginA_api__call`
-  • `mcp__plugin_pluginB_api__call`
-  
-  *Our plugins register 4 MCP servers:*
-  • AEM (stdio) — JCR content queries
-  • Chrome DevTools (stdio) — browser automation
-  • Figma (HTTP) — design extraction
-  • axe (Docker) — accessibility testing
-  
-  💡 Try it: Check `.mcp.json` in your installed plugins. Match the server names to the prefixed tool names you see in Claude Code.
-  
-  #AgenticAI #Day38
+slackOneLiner: "🤖 Tip #38 — Plugin MCP servers get auto-prefixed tool names to prevent collisions — always use the full prefix in skills and agents."
+keyPointsTitle: "How Auto-Prefixing Works"
+actionItemsTitle: "Getting the Prefix Right"
+keyPoints:
+  - "**Registration** — Place a .mcp.json file alongside your plugin.json. The MCP servers defined there are automatically started when the plugin loads."
+  - "**Auto-prefix format** — Plugin MCP tools get the prefix `mcp__plugin_<plugin-name>_<server-name>__<tool-name>`, preventing name collisions between plugins."
+  - "**Why it matters** — Two plugins could both register a server named 'api'. Without prefixing they'd collide. With prefixing they coexist: `mcp__plugin_pluginA_api__call` vs `mcp__plugin_pluginB_api__call`."
+  - |
+    **Our plugin MCP servers**
+    - AEM (stdio) — JCR content queries and component inspection
+    - Chrome DevTools (stdio) — browser automation and screenshots
+    - Figma (HTTP) — design extraction and token mapping
+    - axe (Docker) — accessibility testing and compliance
+actionItems:
+  - |
+    **Always use the full prefix in skills and agents**
+    - Plugin server: `mcp__plugin_dx-aem_AEM__getNodeContent`
+    - Project-level server: `mcp__ado__getWorkItem`
+    - WRONG: `mcp__AEM__getNodeContent` (missing plugin prefix)
+  - "**The common mistake** — Using the shorthand `mcp__AEM__getNodeContent` instead of the full `mcp__plugin_dx-aem_AEM__getNodeContent`. The shorthand doesn't match the actual registered tool names, causing 'tool not found' failures."
+  - "**Copy, don't guess** — When writing skills that call MCP tools, copy the exact tool name from Claude Code's tool list. Never guess the prefix format."
+  - "**Verify your setup** — Check .mcp.json in your installed plugins and match the server names to the prefixed tool names you see in Claude Code."
 ---
-
-```
-# dx-aem/.mcp.json
-{
-  "mcpServers": {
-    "AEM": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["aem-mcp-server"]
-    }
-  }
-}
-
-# Tool name becomes:
-# mcp__plugin_dx-aem_AEM__getNodeContent
-# NOT: mcp__AEM__getNodeContent
-```

--- a/website/src/content/tips/plugin-settings-per-project-config.md
+++ b/website/src/content/tips/plugin-settings-per-project-config.md
@@ -4,59 +4,30 @@ category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Settings","Per-Project","local.md"]
 overview: "Plugins need different settings per project — different AEM URLs, different markets, different build commands. The pattern: .claude/plugin-name.local.md with YAML frontmatter. It's gitignored (per-project), loaded by the plugin, and separates config from code."
-codeLabel: "Per-project plugin config"
 screenshot: null
 week: 8
 weekLabel: "Skills — Advanced"
 order: 39
-slackText: |
-  🤖 Agentic AI Tip #39 — Plugin Settings: Per-Project Config
-  
-  A plugin that works the same way in every project isn't very useful. Real projects have different URLs, different markets, different conventions.
-  
-  *The pattern:*
-  `.claude/<plugin-name>.local.md` — a per-project config file with YAML frontmatter.
-  
-  ```yaml
-  ---
-  aem:
-    author-url: http://localhost:4502
-    author-url-qa: https://qa-author.example.com
-    active-markets: [gb, de, fr]
-  ---
-  ```
-  
-  *Why .local.md?*
-  • `.local` = gitignored (project-specific, not committed)
-  • `.md` = can include both structured YAML and free-text notes
-  • Plugin reads the YAML for settings, ignores the markdown
-  
-  *What goes in plugin settings:*
-  • Environment URLs (local, QA, staging)
-  • Market/locale scoping
-  • Feature flags
-  • API endpoints
-  • Credentials references (point to env vars, never store secrets)
-  
-  *What does NOT go here:*
-  • Secrets (use environment variables)
-  • Shared team conventions (use `.ai/config.yaml`)
-  • Temporary state (use spec directory files)
-  
-  💡 Try it: Check if your project has any `.claude/*.local.md` files. If you're using plugins, configure the per-project settings.
-  
-  #AgenticAI #Day39
+slackOneLiner: "🤖 Tip #39 — Use `.claude/<plugin-name>.local.md` for per-project plugin settings — gitignored YAML frontmatter that separates config from code."
+keyPointsTitle: "The Three Config Layers"
+actionItemsTitle: "What Goes Where"
+keyPoints:
+  - "**`.claude/<plugin-name>.local.md`** — Per-project config with YAML frontmatter. The plugin reads the YAML for settings and ignores the markdown body. `.local` means gitignored, `.md` means it can include free-text notes."
+  - "**`.ai/config.yaml`** — Shared team conventions that get committed. Build commands, branch names, project structure — everything the team agrees on."
+  - "**Spec directory files** — Temporary per-ticket state in `.ai/specs/<id>/`. Created during work, discarded after merge."
+  - "**Why three layers** — Team conventions are shared (config.yaml). Developer preferences are local (local.md). Ticket context is temporary (spec files). Each has a different lifecycle and audience."
+actionItems:
+  - |
+    **What goes in plugin settings (.local.md)**
+    - `aem.author-url` — http://localhost:4502
+    - `aem.author-url-qa` — https://qa-author.example.com
+    - `aem.active-markets` — [gb, de, fr]
+    - `aem.demo-parent-path` — /content/brand-a/gb/en
+  - |
+    **What does NOT go here**
+    - Secrets — use environment variables, never store directly
+    - Shared team conventions — use `.ai/config.yaml` instead
+    - Temporary state — use spec directory files
+  - "**Never store secrets directly** — Reference environment variables instead (e.g., `auth-token: $AEM_AUTH_TOKEN`). The .local.md file is gitignored but secrets still shouldn't be in plain text."
+  - "**Check your project** — Look for `.claude/*.local.md` files. If you're using plugins but don't have these, you may be missing per-project configuration."
 ---
-
-```
-# .claude/dx-aem.local.md
----
-aem:
-  author-url: http://localhost:4502
-  author-url-qa: https://qa-author.example.com
-  active-markets: [gb, de, fr]
-  demo-parent-path: /content/brand-a/gb/en
----
-
-Additional notes for this project...
-```

--- a/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
+++ b/website/src/content/tips/plugin-skills-agents-hooks-in-a-box.md
@@ -4,51 +4,38 @@ category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Plugin","Bundle","Reusable"]
 overview: "A plugin bundles skills, agents, hooks, MCP configs, and rules into a single installable package. Install once, available in every project. Our four plugins (dx-core, dx-hub, dx-aem, dx-automation) contain 69 skills, 12 agents, and 4 hooks — all distributed from a single source."
-codeLabel: "Plugin anatomy"
 screenshot: null
 week: 8
 weekLabel: "Skills — Advanced"
 order: 37
-slackText: |
-  🤖 Agentic AI Tip #37 — Plugin = Skills + Agents + Hooks in a Box
-  
-  Once you have a collection of skills, agents, and hooks that work together, the next step is packaging them as a plugin.
-  
-  *A plugin contains:*
-  • `plugin.json` — manifest (name, version, description)
-  • `skills/` — your skill collection
-  • `agents/` — your agent definitions
-  • `hooks/` — event-driven automation
-  • `.mcp.json` — MCP server registrations
-  • `rules/` — auto-loading conventions
-  
-  *Why plugin instead of just files?*
-  1. *Install once, use everywhere* — add to any project with one command
-  2. *Versioned* — track changes, roll back if needed
-  3. *Shared* — team uses the same skills without copy-pasting
-  4. *Encapsulated* — MCP servers, hooks, and rules bundled together
-  5. *Updateable* — bump version, sync to all projects
-  
-  *Our setup:*
-  Four plugins, 69 skills, 12 agents, distributed to 4 consumer repos:
-  • `dx-core` — universal development workflow
-  • `dx-hub` — multi-repo hub orchestration
-  • `dx-aem` — AEM-specific tools
-  • `dx-automation` — autonomous CI/CD agents
-  
-  💡 Try it: Look at an installed plugin's structure. Open plugin.json to see the manifest. Understand what's bundled.
-  
-  #AgenticAI #Day37
+slackOneLiner: "🤖 Tip #37 — A plugin bundles skills, agents, hooks, MCP configs, and rules into one installable package — install once, use everywhere."
+keyPointsTitle: "What's Inside a Plugin"
+actionItemsTitle: "Why Plugins Beat Loose Files"
+keyPoints:
+  - |
+    **plugin.json** — The manifest declaring name, version, and description
+    - The entry point that Claude Code and Copilot CLI both read
+    - Defines what the plugin contains and how to discover it
+  - |
+    **skills/** — Slash commands that automate workflows
+    - Each skill is a directory with a SKILL.md file
+    - Triggered by typing /skill-name in the terminal
+  - |
+    **agents/** — Specialized AI personas with model tiers
+    - Each agent has its own system prompt and tool access
+    - Can run in isolation with worktree support
+  - |
+    **hooks/** — Event-driven guardrails and automation
+    - Fire on specific events (pre-commit, post-save, etc.)
+    - Prevent mistakes before they happen
+  - |
+    **Supporting files** — MCP configs + rules + templates
+    - .mcp.json registers external tool connections
+    - rules/ loads conventions based on file paths
+actionItems:
+  - "**Install once, use everywhere** — Add to any project with one command. Versioned, shared across teams, and updateable by bumping a single version number."
+  - "**Encapsulation** — MCP servers, hooks, and rules are bundled together. No scattered config files across your project — everything lives in one installable package."
+  - "**Shared distribution** — The whole team uses the same skills without copy-pasting. Roll back if a new version breaks something. Everyone stays in sync."
+  - "**Our setup** — Four plugins (dx-core, dx-hub, dx-aem, dx-automation), 69 skills, 12 agents, distributed to 4 consumer repos from a single source."
+  - "**Start exploring** — Open an installed plugin's plugin.json to see the manifest, then browse skills/ and agents/ to understand what's available."
 ---
-
-```
-# Plugin structure:
-dx-core/
-├── .claude-plugin/
-│   └── plugin.json    # manifest
-├── .mcp.json          # MCP servers
-├── hooks/hooks.json   # hooks
-├── skills/            # 42 skills
-├── agents/            # 6 agents
-└── rules/             # path-scoped rules
-```

--- a/website/src/content/tips/plugins-install-once-use-everywhere.md
+++ b/website/src/content/tips/plugins-install-once-use-everywhere.md
@@ -4,83 +4,31 @@ category: "Plugins — Full Package"
 focus: "All Tools"
 tags: ["Plugins","Marketplace","Skills","Agents","MCP"]
 overview: "Plugins are installable bundles of skills, agents, rules, and MCP servers. One command adds them. They work in both Claude Code and Copilot CLI. Think of them like VS Code extensions — but for your terminal AI."
-codeLabel: "Install from a marketplace"
 screenshot: null
 week: 15
 weekLabel: "Plugins — Full Package"
 order: 52
-slackText: |
-  🤖 Agentic AI Tip #52 — Plugins: Install Once, Use Everywhere
-
-  Plugins are installable bundles of skills, agents, rules, and MCP servers. Think of them like VS Code extensions — but for your terminal AI.
-
-  *What's in a plugin:*
-  • Skills — slash commands (/dx-plan, /aem-verify)
-  • Agents — specialized AI personas (code reviewer, file resolver)
-  • Rules — convention templates (.claude/rules/)
-  • MCP servers — external tool connections (ADO, AEM, Figma)
-
-  *Install from a marketplace (GitHub repo):*
-  ```
-  /plugin marketplace add owner/repo
-  /plugin install plugin-name@marketplace
-  ```
-
-  *Works in both tools:*
-  • Claude Code — native plugin support, hooks, worktree isolation
-  • Copilot CLI — same skills + agents, reads same plugin format
-  • Install once, both tools discover it automatically
-
-  *Example marketplaces:*
-  • adobe/skills — AEM Edge Delivery skills (17 skills)
-  • Your own — any GitHub repo with .claude-plugin/marketplace.json
-
-  💡 Try it: Run `/plugin marketplace add adobe/skills` to browse Adobe's public skills. Then `/plugin list` to see what's installed.
-
-  #AgenticAI #Day52
+slackOneLiner: "🤖 Tip #52 — Plugins are installable bundles of skills, agents, rules, and MCP servers — like VS Code extensions for your terminal AI."
+keyPointsTitle: "What Plugins Give You"
+actionItemsTitle: "How to Install and Use"
+keyPoints:
+  - "**What's in a plugin** — Skills (slash commands like /dx-plan, /aem-verify), agents (specialized AI personas), rules (convention templates for .claude/rules/), and MCP servers (external tool connections to ADO, AEM, Figma)."
+  - "**Cross-platform** — Works in both Claude Code and Copilot CLI. Install once, both tools discover skills, agents, rules, and MCP servers automatically."
+  - "**No build step** — Plugins are pure Markdown + shell scripts. Install, init, use. No compilation or bundling needed."
+  - "**Auto-discovery** — After install, everything is automatic. Skills show up as /commands, agents are available for dispatch, rules load based on file paths, and MCP servers connect on their own."
+  - "**Public marketplaces** — Adobe publishes AEM Edge Delivery skills (17 skills). You can create your own marketplace in any GitHub repo."
+actionItems:
+  - "**Browse Adobe's skills** — Run `/plugin marketplace add adobe/skills` to register, then `/plugin list` to see what's available."
+  - |
+    **Install from a marketplace**
+    - `/plugin marketplace add owner/repo` — register a marketplace
+    - `/plugin list --marketplace` — browse available plugins
+    - `/plugin install plugin-name@marketplace` — install what you need
+    - `/plugin marketplace update marketplace-name` — update all installed plugins
+  - |
+    **Know the cross-platform differences**
+    - Agents — Claude Code uses plugin agents/, Copilot uses .github/agents/
+    - Rules — Claude Code uses native paths:, Copilot uses applyTo: env var
+    - Hooks — Claude Code supports 18 events + prompt, Copilot supports 8 events
+  - "**Start small** — Install one plugin, run its init skill, and explore the slash commands it adds to your terminal."
 ---
-
-```bash
-# Add a marketplace (GitHub repo or local path)
-/plugin marketplace add adobe/skills
-/plugin marketplace add owner/my-plugins
-
-# Browse available plugins
-/plugin list --marketplace
-
-# Install what you need
-/plugin install aem-eds@adobe-skills
-/plugin install dx-core@my-plugins
-
-# Update all installed plugins
-/plugin marketplace update my-plugins
-```
-
-*What's inside a plugin:*
-
-```
-my-plugin/
-├── .claude-plugin/plugin.json   # Manifest
-├── skills/                      # /slash commands
-├── agents/                      # AI personas
-├── rules/                       # Convention templates
-├── hooks/                       # Guardrails
-└── .mcp.json                    # MCP server config
-```
-
-After install, everything is auto-discovered. Skills show up as `/commands`, agents are available for dispatch, rules load based on file paths, and MCP servers connect automatically.
-
-*Both platforms, same plugins:*
-
-| Feature | Claude Code | Copilot CLI |
-|---------|------------|-------------|
-| Skills (/commands) | Native | Native |
-| Agents | Plugin agents/ | .github/agents/ |
-| Rules (.claude/rules/) | Native (paths:) | Via env var (applyTo:) |
-| MCP servers | .mcp.json | .mcp.json |
-| Hooks | 18 events + prompt | 8 events |
-| Marketplace | /plugin marketplace | /plugin marketplace |
-
-*No build step.* Plugins are pure Markdown + shell scripts. Install → init → use.
-
-💡 Try it: Run `/plugin marketplace add adobe/skills` to see a public marketplace. Then `/plugin list` to see what you get.

--- a/website/src/content/tips/plugins-install-once-use-everywhere.md
+++ b/website/src/content/tips/plugins-install-once-use-everywhere.md
@@ -5,8 +5,8 @@ focus: "All Tools"
 tags: ["Plugins","Marketplace","Skills","Agents","MCP"]
 overview: "Plugins are installable bundles of skills, agents, rules, and MCP servers. One command adds them. They work in both Claude Code and Copilot CLI. Think of them like VS Code extensions — but for your terminal AI."
 screenshot: null
-week: 15
-weekLabel: "Plugins — Full Package"
+week: 11
+weekLabel: "Plugins & Mastery"
 order: 52
 slackOneLiner: "🤖 Tip #52 — Plugins are installable bundles of skills, agents, rules, and MCP servers — like VS Code extensions for your terminal AI."
 keyPointsTitle: "What Plugins Give You"

--- a/website/src/content/tips/posttooluse-enrich-after-it-happens.md
+++ b/website/src/content/tips/posttooluse-enrich-after-it-happens.md
@@ -4,47 +4,21 @@ category: "Hooks — Guardrails"
 focus: "Claude Code"
 tags: ["PostToolUse","Cache","Validate"]
 overview: "PostToolUse hooks fire after a tool completes. They can't block — the action already happened — but they can cache results, validate outputs, log events, and trigger follow-up actions. Example: automatically save Figma screenshots to disk after every Figma API call."
-codeLabel: "PostToolUse patterns"
 screenshot: null
 week: 7
 weekLabel: "Skills — Advanced"
 order: 34
-slackText: |
-  🤖 Agentic AI Tip #34 — PostToolUse: Enrich After It Happens
-  
-  While PreToolUse prevents, PostToolUse enriches. It fires after a tool completes and is perfect for caching, validation, and logging.
-  
-  *Pattern 1: Auto-cache expensive results*
-  Every time the AI calls the Figma screenshot tool, a PostToolUse hook saves the image to disk. Next time you need it, it's already cached — no API call needed.
-  
-  *Pattern 2: Validate file edits*
-  After any Edit tool call to a plugin file (YAML, JSON, markdown), a hook checks the file is still valid. Catches YAML syntax errors, missing required fields, and accidental deletions.
-  
-  *Pattern 3: Log subagent completions*
-  After the Agent tool completes, a hook logs the agent name, model used, and duration. Useful for tracking cost and identifying slow agents.
-  
-  *What PostToolUse CANNOT do:*
-  It cannot block the tool call — the action already happened. If you need to prevent something, use PreToolUse.
-  
-  *Pro tip:* PostToolUse hooks get the tool result as context. Your script can inspect the output and take different actions based on success/failure.
-  
-  💡 Try it: Create a PostToolUse hook that logs every Bash command to a file. After a session, review what commands the AI ran.
-  
-  #AgenticAI #Day34
+slackOneLiner: "🤖 Tip #34 — PostToolUse hooks enrich after the fact — cache expensive results, validate outputs, log actions. Prevention is PreToolUse; enrichment is PostToolUse."
+keyPointsTitle: "What PostToolUse Can Do"
+actionItemsTitle: "Hooks to Build First"
+keyPoints:
+  - "**Auto-cache expensive results** — every time the AI calls the Figma screenshot tool, a PostToolUse hook saves the image to disk. Next time you need it, it's already cached — no API call needed."
+  - "**Validate file edits** — after any Edit tool call to a plugin file (YAML, JSON, markdown), a hook checks the file is still valid. Catches YAML syntax errors, missing required fields, and accidental deletions."
+  - "**Log subagent completions** — after the Agent tool completes, a hook logs the agent name, model used, and duration. Useful for tracking cost and identifying slow agents."
+actionItems:
+  - "**Cannot block, only observe** — the action already happened. If you need to prevent something, use PreToolUse instead."
+  - "**Gets tool result as context** — your script can inspect the output and take different actions based on success or failure."
+  - "Create a PostToolUse hook that logs every Bash command to a file — after a session, review what commands the AI ran"
+  - "Add a validation hook for Edit calls on config files (YAML, JSON) — catch corruption immediately instead of discovering it later"
+  - "Use the matcher to target specific tools — `Edit` for file validation, `mcp__*figma*` for Figma caching"
 ---
-
-```
-# Auto-cache Figma screenshots
-{
-  "event": "PostToolUse",
-  "matcher": "mcp__*figma*get_screenshot*",
-  "command": "./scripts/cache-figma.sh"
-}
-
-# Validate plugin file edits
-{
-  "event": "PostToolUse",
-  "matcher": "Edit",
-  "command": "./scripts/validate-edit.sh"
-}
-```

--- a/website/src/content/tips/pre-flight-validation-dont-burn-tokens.md
+++ b/website/src/content/tips/pre-flight-validation-dont-burn-tokens.md
@@ -4,53 +4,28 @@ category: "Real-World Workflows"
 focus: "Claude Code · CLI"
 tags: ["Pre-flight","Validation","Cost"]
 overview: "Before running multi-step pipelines, check that all inputs exist, MCP servers respond, and target branches exist. A 2-second check saves 15 minutes of token-burning failure. We learned this the hard way after pipelines failed at step 6 because the MCP server was down."
-codeLabel: "Pre-flight pattern"
 screenshot: null
 week: 10
 weekLabel: "Agents — AI Personas"
 order: 46
-slackText: |
-  🤖 Agentic AI Tip #46 — Pre-flight Validation: Don't Burn Tokens
-  
-  This lesson cost us real money: a 7-step pipeline that failed at step 6 because the AEM MCP server wasn't running.
-  
-  Steps 1-5 consumed tokens, generated files, and made progress. Step 6 needed AEM MCP and... connection refused. All that work, wasted.
-  
-  *The fix: pre-flight validation.*
-  
-  Before any multi-step pipeline, check:
-  1. *Do all required inputs exist?* (ticket ID, spec files, URLs)
-  2. *Are MCP servers responsive?* (make a lightweight call)
-  3. *Does the target branch exist?* (git verify)
-  4. *Is the environment correct?* (Node version, config files)
-  
-  *Implementation:*
-  We added pre-flight checks to every coordinator skill. Before dispatching any subagent, the coordinator runs a quick validation. If anything fails, it stops immediately with a clear error message.
-  
-  *The economics:*
-  Pre-flight check: ~$0.01 (one lightweight MCP call)
-  Failed pipeline: ~$2-5 (multiple agents, multiple tools, wasted output)
-  ROI: 200-500x
-  
-  *Rule of thumb:* If the pipeline has more than 3 steps, add pre-flight validation. The 2 seconds of checking save 15 minutes of failing.
-  
-  💡 Try it: Check your last few pipeline failures. How many could have been caught by a pre-flight check?
-  
-  #AgenticAI #Day46
+slackOneLiner: "🤖 Tip #46 — A 2-second pre-flight check saves 15 minutes of token-burning failure. Validate inputs, MCP servers, and branches before starting."
+keyPointsTitle: "The Problem & The Cost"
+actionItemsTitle: "What to Check & Where"
+keyPoints:
+  - "**The lesson that cost real money** — a 7-step pipeline failed at step 6 because the AEM MCP server wasn't running. Steps 1-5 consumed tokens, generated files, made progress. Step 6 hit 'connection refused.' All wasted."
+  - |
+    The economics — ROI of 200-500x
+    - Pre-flight check: ~$0.01 (one lightweight MCP call)
+    - Failed pipeline: ~$2-5 (multiple agents, tools, wasted output)
+  - "**Rule of thumb** — if the pipeline has more than 3 steps, add pre-flight validation. The 2 seconds of checking save 15 minutes of failing."
+actionItems:
+  - |
+    Pre-flight checklist — verify before any multi-step pipeline
+    - Do all required inputs exist? (ticket ID, spec files, URLs)
+    - Are MCP servers responsive? (make a lightweight call)
+    - Does the target branch exist? (git verify)
+    - Is the environment correct? (Node version, config files)
+  - "We added pre-flight checks to every coordinator skill — before dispatching any subagent, the coordinator runs a quick validation. If anything fails, it stops immediately with a clear error message."
+  - "Add a lightweight MCP call as the first step of any multi-step workflow — e.g., `getNodeContent path: /` for AEM"
+  - "Build pre-flight into coordinator skills, not individual steps — the coordinator validates once, then dispatches with confidence"
 ---
-
-```
-# Pre-flight checks:
-# 1. Do inputs exist?
-[ -f .ai/specs/12345/raw-story.md ]
-
-# 2. Is MCP reachable?
-mcp__plugin_dx-aem_AEM__getNodeContent
-  path: "/" # lightweight check
-
-# 3. Does the branch exist?
-git rev-parse --verify origin/development
-
-# All pass? → Start pipeline
-# Any fail? → Stop with clear message
-```

--- a/website/src/content/tips/pretooluse-block-before-it-happens.md
+++ b/website/src/content/tips/pretooluse-block-before-it-happens.md
@@ -4,51 +4,25 @@ category: "Hooks — Guardrails"
 focus: "Claude Code"
 tags: ["PreToolUse","Block","Safety"]
 overview: "PreToolUse hooks fire before the AI executes a tool call. If the hook exits with non-zero, the tool call is blocked. This is how you prevent dangerous operations: committing on protected branches, force-pushing, deleting production resources. Prevention beats recovery."
-codeLabel: "Branch protection"
 screenshot: null
 week: 7
 weekLabel: "Skills — Advanced"
 order: 33
-slackText: |
-  🤖 Agentic AI Tip #33 — PreToolUse: Block Before It Happens
-  
-  The most valuable type of hook: preventing mistakes before they happen.
-  
-  *How it works:*
-  When the AI is about to run a tool (like Bash with `git commit`), the PreToolUse hook fires first. If the hook exits with code 1, the tool call is *blocked*. The AI gets the error message and must find another approach.
-  
-  *Real example — branch protection:*
-  ```json
-  {
-    "event": "PreToolUse",
-    "matcher": "Bash(git commit*)",
-    "command": "./scripts/check-branch.sh"
-  }
-  ```
-  
-  The script checks the current branch. If it's `main`, `master`, `development`, or `develop`, it blocks the commit with a clear message.
-  
-  *Why a hook instead of just telling the AI "don't commit on main"?*
-  Because instructions get forgotten in long sessions. Context windows compress. Conventions drift. But hooks are *structural* — they can't be overridden by context loss.
-  
-  *Other PreToolUse patterns:*
-  • Block `git push --force` to any branch
-  • Block `rm -rf` on project directories
-  • Block MCP calls to production environments
-  • Validate file paths before write operations
-  
-  💡 Try it: Add a branch protection hook. Test it by asking the AI to commit on `main`. Watch it get blocked gracefully.
-  
-  #AgenticAI #Day33
+slackOneLiner: "🤖 Tip #33 — PreToolUse hooks block dangerous operations before they happen. Instructions get forgotten; hooks are structural."
+keyPointsTitle: "How Prevention Works"
+actionItemsTitle: "Patterns to Implement"
+keyPoints:
+  - "PreToolUse fires before any tool call — if the hook exits with code 1, the tool call is blocked. The AI gets the error message and must find another approach."
+  - "**Branch protection example** — hook matches `Bash(git commit*)`, script checks current branch, blocks if it's main/master/development/develop with a clear message."
+  - "**Why a hook instead of instructions** — instructions get forgotten in long sessions. Context windows compress. Conventions drift. Hooks are structural and can't be overridden by context loss."
+actionItems:
+  - |
+    Common PreToolUse patterns for real risks
+    - Block `git push --force` to any branch
+    - Block `rm -rf` on project directories
+    - Block MCP calls to production environments
+    - Validate file paths before write operations
+  - "Add a branch protection hook — test it by asking the AI to commit on `main` and watch it get blocked gracefully"
+  - "List the 3 most dangerous commands for your project and write a PreToolUse matcher for each"
+  - "Keep hook scripts simple — check one thing, exit 0 (allow) or exit 1 (block with message). Complex scripts slow down every tool call."
 ---
-
-```
-# scripts/check-branch.sh
-#!/bin/bash
-BRANCH=$(git branch --show-current)
-if [[ "$BRANCH" =~ ^(main|master|development|develop)$ ]]; then
-  echo "BLOCKED: Cannot commit on $BRANCH"
-  exit 1
-fi
-exit 0
-```

--- a/website/src/content/tips/rules-context-that-auto-loads-by-path.md
+++ b/website/src/content/tips/rules-context-that-auto-loads-by-path.md
@@ -4,50 +4,29 @@ category: "Context — The Secret Sauce"
 focus: "Claude Code · CLI"
 tags: [".claude/rules/","Path-Scoped","Auto-Load"]
 overview: "Rules are markdown files that load automatically when you work on matching files. A SCSS rule only loads for .scss files. A JavaScript rule only loads for .js files. This keeps context relevant and prevents noise from unrelated conventions."
-codeLabel: "Path-scoped rule"
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 10
-slackText: |
-  🤖 Agentic AI Tip #10 — Rules: Context That Auto-Loads by Path
-  
-  CLAUDE.md is global — loaded every session. But some conventions only apply to specific file types. That's what rules are for.
-  
-  *How rules work:*
-  Put a markdown file in `.claude/rules/` with path patterns in the frontmatter. When you work on a matching file, the rule auto-loads into context.
-  
-  Example: A SCSS rule that only activates for stylesheets:
-  ```
-  ---
-  paths: ["**/*.scss"]
-  ---
-  Use node-sass syntax. Variables in _variables.scss.
-  Mobile-first breakpoints. Never use !important.
-  ```
-  
-  *Why this matters:*
-  Without path-scoped rules, you'd dump every convention into CLAUDE.md. JavaScript conventions would pollute SCSS sessions. AEM backend rules would confuse frontend work.
-  
-  *Real-world example from our project:*
-  We have separate rules for JavaScript (ESLint Airbnb), SCSS (node-sass, sass-lint), accessibility (WCAG 2.1 AA), and naming conventions. Each only loads when relevant.
-  
-  *Dual frontmatter gotcha:* For Copilot CLI, you also need `applyTo:` in the YAML. Without it, the rule only works in Claude Code.
-  
-  💡 Try it: Create a rule for your most common file type. Add 3-5 conventions. Watch the AI follow them automatically.
-  
-  #AgenticAI #Day10
+slackOneLiner: "🤖 Tip #10 — Rules auto-load by file path — SCSS conventions only appear for .scss files. Targeted context, zero noise."
+keyPointsTitle: "How Path-Scoped Rules Work"
+actionItemsTitle: "Creating Effective Rules"
+keyPoints:
+  - "Rules are markdown files in `.claude/rules/` with path patterns in the frontmatter — when you work on a matching file, the rule auto-loads into context."
+  - "**Global vs. scoped** — CLAUDE.md is global (loaded every session), but rules are path-scoped. JavaScript conventions don't pollute SCSS sessions, AEM backend rules don't confuse frontend work."
+  - |
+    Real-world example — separate rules for each concern
+    - JavaScript (ESLint Airbnb conventions)
+    - SCSS (node-sass, sass-lint)
+    - Accessibility (WCAG 2.1 AA)
+    - Naming conventions
+    - Each only loads when relevant
+actionItems:
+  - "**Dual frontmatter gotcha** — for Copilot CLI, you also need `applyTo:` in the YAML. Without it, the rule only works in Claude Code. Use both `paths:` and `applyTo:` for cross-platform compatibility."
+  - "Create a rule for your most common file type — add 3-5 conventions and watch the AI follow them automatically"
+  - |
+    Always include dual frontmatter for cross-platform support
+    - `paths: ["**/*.scss"]` — Claude Code
+    - `applyTo: "**/*.scss"` — Copilot CLI
+  - "Keep rules focused — one topic per file. A 'styles' rule, a 'testing' rule, a 'naming' rule. Easier to maintain and debug."
 ---
-
-```
-# .claude/rules/fe-styles.md
----
-paths: ["**/*.scss"]
-applyTo: "**/*.scss"
----
-
-Use node-sass syntax (not dart-sass).
-Variables in _variables.scss partial.
-Mobile-first breakpoints.
-Never use !important.
-```

--- a/website/src/content/tips/sessionstart-validate-on-every-launch.md
+++ b/website/src/content/tips/sessionstart-validate-on-every-launch.md
@@ -4,55 +4,26 @@ category: "Hooks — Guardrails"
 focus: "Claude Code"
 tags: ["SessionStart","Validation","Environment"]
 overview: "SessionStart hooks fire once when you start a Claude Code session. They're perfect for environment validation: check Node version, verify MCP servers are reachable, validate config files. Catch problems in the first 2 seconds instead of 20 minutes into a failed pipeline."
-codeLabel: "Environment check"
 screenshot: null
 week: 7
 weekLabel: "Skills — Advanced"
 order: 35
-slackText: |
-  🤖 Agentic AI Tip #35 — SessionStart: Validate on Every Launch
-  
-  Nothing is worse than running a 15-minute pipeline only to discover at step 7 that your Node version was wrong.
-  
-  SessionStart hooks fix this by validating your environment *the moment you start a session*.
-  
-  *What to check:*
-  • *Node version* — our project needs v10, not v18
-  • *MCP server connectivity* — can we reach AEM? Figma? ADO?
-  • *Config files* — does `.ai/config.yaml` exist and have required fields?
-  • *Git state* — are you on a feature branch? Any uncommitted changes?
-  • *Dependencies* — is `node_modules/` present?
-  
-  *The output appears as a banner:*
-  ```
-  ✅ Node v10.16.0
-  ✅ AEM MCP: localhost:4502 reachable
-  ✅ Config: .ai/config.yaml valid
-  ⚠️ Uncommitted changes in 3 files
-  ```
-  
-  *Why this matters:*
-  Without it, environment issues surface as mysterious failures deep in a workflow. With it, you know the state of your world before typing the first command.
-  
-  *Matcher is empty:* `"matcher": ""` means "always fire" — SessionStart doesn't match tools, it matches session creation.
-  
-  💡 Try it: Create a SessionStart hook that checks your Node version. Just that. You'll be surprised how often you're on the wrong version.
-  
-  #AgenticAI #Day35
+slackOneLiner: "🤖 Tip #35 — SessionStart hooks validate your environment the moment you start a session. Catch problems in 2 seconds, not 15 minutes."
+keyPointsTitle: "What to Validate"
+actionItemsTitle: "Setup & Best Practices"
+keyPoints:
+  - "SessionStart fires once when a session begins — validate everything upfront so environment issues don't surface as mysterious failures deep in a workflow."
+  - |
+    What to check in a SessionStart hook
+    - **Node version** — our project needs v10, not v18
+    - **MCP server connectivity** — can we reach AEM? Figma? ADO?
+    - **Config files** — does `.ai/config.yaml` exist and have required fields?
+    - **Git state** — are you on a feature branch? Any uncommitted changes?
+    - **Dependencies** — is `node_modules/` present?
+  - "The output appears as a banner with status indicators — you see the state of your world before typing the first command."
+actionItems:
+  - "**Matcher is empty** — `\"matcher\": \"\"` means 'always fire.' SessionStart doesn't match tools, it matches session creation."
+  - "Create a SessionStart hook that checks your Node version — just that one check. You'll be surprised how often you're on the wrong version."
+  - "Add MCP connectivity checks next — a lightweight call to each server catches 'connection refused' before you burn tokens"
+  - "Keep SessionStart hooks fast (under 3 seconds) — they run on every session start and slow hooks delay your first prompt"
 ---
-
-```
-# hooks.json
-{
-  "event": "SessionStart",
-  "matcher": "",
-  "command": "./scripts/validate-env.sh"
-}
-
-# validate-env.sh
-#!/bin/bash
-node -v | grep -q "v10" || {
-  echo "⚠️ Wrong Node version"
-  echo "Run: nvm use 10"
-}
-```

--- a/website/src/content/tips/skill-frontmatter-the-yaml-that-controls-everythin.md
+++ b/website/src/content/tips/skill-frontmatter-the-yaml-that-controls-everythin.md
@@ -4,45 +4,29 @@ category: "Skills — Recipe Book"
 focus: "Claude Code · CLI"
 tags: ["Frontmatter","YAML","Metadata"]
 overview: "The YAML block at the top of a skill file isn't just metadata — it controls how the skill behaves. The description field determines when the skill triggers. allowed-tools controls permissions. argument-hint shows what parameters to pass. Get the frontmatter right and the skill works. Get it wrong and it fails silently."
-codeLabel: "Real skill frontmatter"
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
 order: 13
-slackText: |
-  🤖 Agentic AI Tip #13 — Skill Frontmatter: The YAML That Controls Everything
-  
-  The YAML block at the top of a skill file is more important than the instructions below it. Here's what each field does:
-  
-  *name:* The slash command name (`/my-skill`)
-  
-  *description:* This is critical — it's what the AI uses to decide when to invoke the skill. Write it like a search query: "Generate implementation plan from requirements" not "This skill generates plans."
-  
-  *allowed-tools:* Which tools the skill can use without asking permission. Without this in Copilot CLI, every single tool call prompts you for approval. Game-changing for automation.
-  
-  *argument-hint:* Shows in autocomplete. `"<ticket-id>"` tells users what to pass.
-  
-  *disable-model-invocation:* Advanced — makes the skill a "coordinator" that dispatches subagents instead of thinking itself.
-  
-  *The silent failure trap:*
-  If you misspell a field or use wrong YAML syntax, the skill doesn't error — it just ignores the frontmatter and treats the whole file as instructions. You won't know something is wrong until the skill behaves unexpectedly.
-  
-  💡 Try it: Open any existing skill file and read the frontmatter. Notice how the description is written — that's the trigger text.
-  
-  #AgenticAI #Day13
+slackOneLiner: "🤖 Tip #13 — The YAML block at the top of a skill controls everything: triggering, permissions, parameters. Get it wrong and the skill fails silently."
+keyPointsTitle: "Every Field Explained"
+actionItemsTitle: "Audit Your Skills Now"
+keyPoints:
+  - "**name** — The slash command name (`/my-skill`). This is what users type to invoke the skill."
+  - "**description** — The most critical field. The AI uses this to decide when to invoke the skill. Write it like a search query: 'Generate implementation plan from requirements' not 'This skill generates plans.'"
+  - "**allowed-tools** — Which tools the skill can use without asking permission. Without this in Copilot CLI, every single tool call prompts for approval. Game-changing for automation."
+  - "**argument-hint** — Shows in autocomplete. `\"<ticket-id>\"` tells users what to pass before they even read the docs."
+  - "**disable-model-invocation** — Advanced field that makes the skill a 'coordinator' that dispatches subagents instead of thinking itself. Used for multi-step pipelines."
+actionItems:
+  - |
+    Audit your skill descriptions for trigger quality
+    - Rewrite any that say "This skill does X" to instead say "Do X from Y"
+    - The description is search text, not documentation — write it like a query
+    - Open any existing skill file and study how the description reads as trigger text
+  - |
+    Check for silent frontmatter failures
+    - Validate YAML syntax (proper indentation, no tabs)
+    - Verify field names are spelled correctly (allowed-tools, not allowedTools)
+    - Test that the skill actually picks up the frontmatter by checking tool permissions
+  - "**The silent failure trap** — If you misspell a field or use wrong YAML syntax, the skill doesn't error. It ignores the frontmatter and treats the whole file as instructions. You won't know until the skill behaves unexpectedly."
 ---
-
-```
----
-name: dx-plan
-description: Generate implementation
-  plan from requirements
-argument-hint: "<ticket-id>"
-allowed-tools:
-  - read
-  - write
-  - glob
-  - grep
-  - bash
----
-```

--- a/website/src/content/tips/skill-scripts-the-deterministic-helper.md
+++ b/website/src/content/tips/skill-scripts-the-deterministic-helper.md
@@ -4,50 +4,24 @@ category: "Skills — Recipe Book"
 focus: "Claude Code · CLI"
 tags: ["Bash Scripts","Deterministic","Hybrid"]
 overview: "AI is non-deterministic — same prompt, different results. But some operations must be exact every time: detecting Node version, checking environment, copying files. Put those in bash scripts alongside your skill. The AI runs the script for the deterministic part and reasons about the results."
-codeLabel: "Hybrid approach"
 screenshot: null
 week: 4
 weekLabel: "Context — The Secret Sauce"
 order: 16
-slackText: |
-  🤖 Agentic AI Tip #16 — Skill Scripts: The Deterministic Helper
-  
-  Here's a pattern that most people miss: not everything in a skill should be AI-driven.
-  
-  AI is non-deterministic — ask the same question twice, get slightly different answers. That's fine for reasoning, but terrible for operations that must be exact: checking Node versions, detecting project structure, copying files to specific locations.
-  
-  *The solution:* Put deterministic operations in bash scripts alongside your skill.
-  
-  ```
-  skills/my-skill/
-  ├── SKILL.md          ← AI reasoning
-  └── scripts/
-      └── detect-env.sh ← exact every time
-  ```
-  
-  In SKILL.md, tell the AI to run the script first:
-  "Run `scripts/detect-env.sh` and use its output to decide the next step."
-  
-  *Real examples from our codebase:*
-  • `detect-env.sh` — checks Node version, OS, installed tools
-  • `validate-config.sh` — verifies .ai/config.yaml structure
-  • `upload-component-js.sh` — copies build artifacts to exact paths
-  
-  The AI handles the thinking (what to do, why). Scripts handle the doing (exact commands, exact paths).
-  
-  💡 Try it: If you have a skill with complex bash commands inline, extract them to a script file. Reliability goes up immediately.
-  
-  #AgenticAI #Day16
+slackOneLiner: "🤖 Tip #16 — Not everything in a skill should be AI-driven. Put deterministic operations in bash scripts alongside SKILL.md — exact results every time."
+keyPointsTitle: "AI + Scripts Hybrid"
+actionItemsTitle: "Extract and Structure"
+keyPoints:
+  - "**The problem** — AI is non-deterministic. Ask the same question twice, get slightly different answers. Fine for reasoning, terrible for operations that must be exact: checking Node versions, detecting project structure, copying files."
+  - "**The solution** — Put deterministic operations in bash scripts alongside your skill in a `scripts/` subdirectory. The AI handles the thinking (what to do, why). Scripts handle the doing (exact commands, exact paths)."
+  - "**Directory structure** — `skills/my-skill/SKILL.md` for AI reasoning, `skills/my-skill/scripts/detect-env.sh` for exact operations. In SKILL.md, tell the AI: 'Run scripts/detect-env.sh and use its output to decide the next step.'"
+actionItems:
+  - "**Identify extraction candidates** — Look for skills with complex inline bash commands — multi-line shell blocks, piped commands, file operations. These are your extraction targets."
+  - |
+    Structure the hybrid approach
+    - `skills/my-skill/SKILL.md` — AI reasoning and decision-making
+    - `skills/my-skill/scripts/detect-env.sh` — deterministic operations
+    - In SKILL.md: "Run scripts/detect-env.sh and use its output to decide the next step"
+  - "**Real examples** — `detect-env.sh` checks Node version, OS, installed tools. `validate-config.sh` verifies .ai/config.yaml structure. `upload-component-js.sh` copies build artifacts to exact paths."
+  - "**Always chmod +x** — Make all script files executable. The AI will fail to run them otherwise. Add this to your skill-creation checklist."
 ---
-
-```
-# skills/my-skill/
-#   SKILL.md       ← AI instructions
-#   scripts/
-#     detect-env.sh  ← deterministic
-
-# In SKILL.md:
-Run scripts/detect-env.sh to detect
-the current environment, then use the
-output to decide which build to run.
-```

--- a/website/src/content/tips/spawning-vs-running-inline.md
+++ b/website/src/content/tips/spawning-vs-running-inline.md
@@ -4,51 +4,22 @@ category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Spawn","Inline","Context Isolation"]
 overview: "When you run a skill inline, it shares your context — everything in your conversation. When you spawn an agent, it gets its own isolated context. Spawned agents don't bloat your window. Their results come back as a summary. Use inline for simple tasks, spawned for heavy ones."
-codeLabel: "The difference"
 screenshot: null
 week: 5
 weekLabel: "Skills — Recipe Book"
 order: 24
-slackText: |
-  🤖 Agentic AI Tip #24 — Spawning vs Running Inline
-  
-  This is a key concept that affects both quality and cost.
-  
-  *Inline execution:*
-  The AI runs the task in your current conversation. Everything it reads, every file it analyzes, stays in your context window. Good for small tasks. Bad for large ones — your context fills up and quality degrades.
-  
-  *Spawned agent:*
-  The AI creates a new subprocess with its own context window. It does its work, then returns a summary to you. Your context stays clean.
-  
-  *When to use which:*
-  
-  Inline (simple, fast):
-  • "What does this function do?"
-  • "Add a null check here"
-  • Quick searches, small edits
-  
-  Spawned (heavy, isolated):
-  • Code review (reads many files)
-  • Implementation (lots of edits)
-  • Research (explores entire codebase)
-  • Anything that generates lots of output
-  
-  *The hidden benefit:*
-  Spawned agents can use a different model tier. Your main session runs on Opus, but the spawned file searcher uses Haiku. Mixed tiers in one workflow.
-  
-  💡 Try it: Next time you ask the AI to "find all usages of X," notice how your context grows. Try spawning an Explore agent instead — your context stays clean.
-  
-  #AgenticAI #Day24
+slackOneLiner: "🤖 Tip #24 — Inline execution shares your context; spawned agents get their own. Use inline for small tasks, spawned for heavy ones to keep your context clean."
+keyPointsTitle: "Two Execution Modes"
+actionItemsTitle: "When to Use Which"
+keyPoints:
+  - "**Inline execution** — The AI runs the task in your current conversation. Everything it reads, every file it analyzes, stays in your context window. Good for small tasks. Bad for large ones — context fills up and quality degrades."
+  - "**Spawned agent** — The AI creates a new subprocess with its own context window. It does its work, then returns a summary to you. Your context stays clean and focused."
+  - "**Hidden benefit — model tier mixing** — Spawned agents can use a different model tier. Your main session runs on Opus for deep reasoning, but the spawned file searcher uses Haiku for cost efficiency. Mixed tiers in one workflow."
+actionItems:
+  - |
+    Choose execution mode by task weight
+    - **Inline** → quick questions, small edits, simple searches
+    - **Spawned** → code review, implementation, research, multi-file analysis
+  - "**Try the difference** — Next time you ask AI to 'find all usages of X,' notice how your context grows. Then try spawning an Explore agent instead to keep your context clean."
+  - "**Configure model tiers** — Set spawned agents to appropriate tiers: Haiku for file search, Sonnet for implementation, Opus for review. Match cost to complexity."
 ---
-
-```
-# Inline — shares your context
-"Read auth.js and explain it"
-# Context grows, everything stays
-
-# Spawned — isolated context
-Agent tool → dx-code-reviewer
-  prompt: "Review the auth module"
-# Gets own context, returns summary
-# YOUR context stays clean
-```

--- a/website/src/content/tips/stdio-vs-http-mcp-servers.md
+++ b/website/src/content/tips/stdio-vs-http-mcp-servers.md
@@ -4,58 +4,43 @@ category: "MCP — System Integration"
 focus: "Claude Code · CLI"
 tags: ["stdio","HTTP","Config"]
 overview: "MCP servers come in two flavors. stdio servers are spawned as a process per session — the AI runs a command and communicates via stdin/stdout. HTTP servers run continuously and the AI sends HTTP requests. Choose stdio for heavy tools (AEM, Chrome), HTTP for lightweight services (Figma)."
-codeLabel: "Two flavors"
 screenshot: null
 week: 6
 weekLabel: "Skills — Recipe Book"
 order: 28
-slackText: |
-  🤖 Agentic AI Tip #28 — stdio vs HTTP MCP Servers
-  
-  MCP servers come in two flavors. Choosing the right one matters for reliability and performance.
-  
-  *stdio (standard I/O):*
-  The AI spawns a process and communicates via stdin/stdout.
-  ```json
-  "command": "npx", "args": ["aem-mcp-server"]
-  ```
-  • *New process per session* — clean state every time
-  • *Best for:* heavy tools that need isolation (AEM, Chrome DevTools)
-  • *Pro:* no port conflicts, no "is the server running?" issues
-  • *Con:* startup time on first use
-  
-  *HTTP:*
-  The server runs continuously, AI sends HTTP requests.
-  ```json
-  "type": "http", "url": "http://127.0.0.1:3845/mcp"
-  ```
-  • *Always running* — instant responses
-  • *Best for:* lightweight services (Figma desktop app)
-  • *Pro:* fast, shared across sessions
-  • *Con:* must be running before you start, port conflicts possible
-  
-  *Decision guide:*
-  • Does it need browser/process access? → stdio
-  • Is it a desktop app exposing an API? → HTTP
-  • Do you need fresh state per session? → stdio
-  • Do you need shared state across sessions? → HTTP
-  
-  💡 Try it: Check your `.mcp.json` — do you know which of your servers are stdio vs HTTP?
-  
-  #AgenticAI #Day28
+slackOneLiner: "🤖 Tip #28 — MCP servers come in stdio (process per session) and HTTP (always running) — pick based on isolation needs and startup cost."
+keyPointsTitle: "How Each Type Works"
+actionItemsTitle: "When to Use Which"
+keyPoints:
+  - |
+    **stdio (standard I/O)**
+    - AI spawns a process and communicates via stdin/stdout
+    - New process per session means clean state every time
+    - Best for heavy tools needing isolation (AEM, Chrome DevTools)
+    - No port conflicts, but has startup time on first use
+  - |
+    **HTTP (always running)**
+    - Server runs continuously, AI sends HTTP requests
+    - Always running means instant responses
+    - Best for lightweight services (Figma desktop app)
+    - Fast and shared across sessions, but must be running before you start
+  - |
+    **Config format difference**
+    - stdio uses 'command' and 'args' fields
+    - HTTP uses 'type: http' and 'url' fields pointing to the running endpoint
+actionItems:
+  - |
+    **Decision guide**
+    - Needs browser/process access? → stdio
+    - Desktop app exposing an API? → HTTP
+    - Need fresh state per session? → stdio
+    - Need shared state across sessions? → HTTP
+    - Worried about port conflicts? → stdio
+  - |
+    **stdio config example**
+    - "command": "npx", "args": ["aem-mcp-server", "-t", "stdio"]
+  - |
+    **HTTP config example**
+    - "type": "http", "url": "http://127.0.0.1:3845/mcp"
+  - "**Check your .mcp.json** — Identify which of your servers are stdio vs HTTP and whether the choice matches the decision guide above"
 ---
-
-```
-# stdio — process per session
-"AEM": {
-  "type": "stdio",
-  "command": "npx",
-  "args": ["aem-mcp-server", "-t", "stdio"]
-}
-
-# HTTP — always-running service
-"figma": {
-  "type": "http",
-  "url": "http://127.0.0.1:3845/mcp"
-}
-```

--- a/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
+++ b/website/src/content/tips/terminal-agents-claude-code-vs-copilot-cli.md
@@ -4,55 +4,42 @@ category: "Meet Your AI Tools"
 focus: "Claude Code · CLI"
 tags: ["Claude Code","Copilot CLI","Terminal"]
 overview: "Both Claude Code and Copilot CLI are terminal-native autonomous agents. Claude Code has 1M token context, worktree isolation, and persistent memory. Copilot CLI (GA Feb 2026) has /fleet for parallel subagents, multi-model support (Claude + GPT + Gemini), and cloud delegation. Same 69 skills run in both."
-codeLabel: "Two terminal agents"
 screenshot: null
 week: 1
 weekLabel: "Meet Your AI Tools"
 order: 3
-slackText: |
-  🤖 Agentic AI Tip #3 — Terminal Agents: Claude Code vs Copilot CLI
-  
-  Both are terminal-native agents. Both run our 69 skills. But they have distinct superpowers:
-  
-  *Claude Code:*
-  • 1M token context (with Opus)
-  • Worktree isolation — agents get their own repo copy
-  • Persistent memory across sessions
-  • 13 plugin agents with model tiering (Opus/Sonnet/Haiku)
-  • Full hook system (18 events + prompt hooks)
-  • Checkpoint rollback and @import in CLAUDE.md
-  
-  *Copilot CLI (GA Feb 2026):*
-  • Multi-model: Claude, GPT, Gemini — switch mid-session with /model
-  • /fleet: run same task across multiple subagents in parallel
-  • Plan mode (Shift+Tab): structured planning before coding
-  • Cloud delegation: prefix with & to offload to cloud agents
-  • Cross-session memory (remembers conventions)
-  • 25 Copilot agents (vs 13 in Claude Code)
-  
-  *When to use which:*
-  • Deep architecture work? Claude Code (1M context)
-  • Multi-model comparison? Copilot CLI (switch models)
-  • Parallel subtasks? Copilot CLI (/fleet)
-  • Plugin development? Claude Code (hooks + worktree)
-  • Both: same skills, same MCP servers, same results
-  
-  💡 Try it: Run the same /dx-plan on a ticket in both tools. Compare how they approach the problem with different models.
-  
-  #AgenticAI #Day3
+slackOneLiner: "🤖 Tip #3 — Both Claude Code and Copilot CLI are terminal-native agents running the same 69 skills. Pick by superpower, not capability."
+keyPointsTitle: "Two Agents, Different Superpowers"
+keyPoints:
+  - "Both are terminal-native agents running the same 69 skills with the same MCP servers — but each has distinct superpowers."
+  - |
+    Claude Code strengths
+    - 1M token context (with Opus) — 8x more than most models
+    - Worktree isolation — agents get their own repo copy
+    - Persistent memory across sessions
+    - 13 plugin agents with model tiering (Opus/Sonnet/Haiku)
+    - Full hook system (18 events + prompt hooks)
+    - Checkpoint rollback and @import in CLAUDE.md
+  - |
+    Copilot CLI strengths (GA Feb 2026)
+    - Multi-model: Claude, GPT, Gemini — switch mid-session with /model
+    - /fleet: run same task across multiple subagents in parallel
+    - Plan mode (Shift+Tab): structured planning before coding
+    - Cloud delegation: prefix with & to offload to cloud agents
+    - Cross-session memory (remembers conventions)
+    - 25 Copilot agents (vs 13 in Claude Code)
+actionItemsTitle: "When to Use Which"
+actionItems:
+  - |
+    Match tool to task
+    - Deep architecture work → Claude Code (1M context)
+    - Multi-model comparison → Copilot CLI (switch models)
+    - Parallel subtasks → Copilot CLI (/fleet)
+    - Plugin development → Claude Code (hooks + worktree)
+  - |
+    Pick your terminal agent based on your primary need
+    - Need depth and isolation → Claude Code
+    - Need model variety and parallelism → Copilot CLI
+  - "Run the same /dx-plan on a ticket in both tools — compare how they approach the problem with different models"
+  - "Try both for a week before settling on a default — they're complementary, not competing"
 ---
-
-```
-# Claude Code
-claude
-# 1M context, Opus/Sonnet/Haiku
-# Worktree isolation, persistent memory
-# 13 plugin agents, hook system
-
-# Copilot CLI
-copilot
-# 128K-1M context (depends on model), multi-model
-# /fleet parallel agents, Plan mode
-# 25 .github agents, cloud delegation
-# Cross-session memory
-```

--- a/website/src/content/tips/the-coordinator-pattern.md
+++ b/website/src/content/tips/the-coordinator-pattern.md
@@ -4,50 +4,24 @@ category: "Skills — Advanced"
 focus: "Claude Code"
 tags: ["Coordinator","disable-model-invocation","Orchestration"]
 overview: "Some skills shouldn't think — they should just dispatch. The coordinator pattern uses disable-model-invocation to create skills that orchestrate subagents without accumulating context. Each step runs in its own agent with its own context window. Perfect for multi-step pipelines."
-codeLabel: "Coordinator skill"
 screenshot: null
 week: 4
 weekLabel: "Context — The Secret Sauce"
 order: 18
-slackText: |
-  🤖 Agentic AI Tip #18 — The Coordinator Pattern
-  
-  This is one of the most powerful advanced patterns, and it's counter-intuitive: *a skill that doesn't think.*
-  
-  The problem: Multi-step pipelines (fetch → analyze → plan → implement) accumulate context. By step 4, the AI is carrying the weight of steps 1-3 in its context window. Quality degrades.
-  
-  The solution: A "coordinator" skill with `disable-model-invocation: true`. It doesn't reason — it just dispatches subagents:
-  
-  ```
-  Step 1: Spawn agent → extract Figma design
-  Step 2: Spawn agent → generate prototype
-  Step 3: Spawn agent → verify against reference
-  ```
-  
-  Each step gets a *fresh context window*. Step 3 doesn't carry the weight of step 1's output.
-  
-  *Why disable-model-invocation?*
-  Without it, the coordinator would try to "think" about the instructions — wasting tokens on reasoning that isn't needed. With it, the skill is a pure dispatcher.
-  
-  *Real example:* Our `/dx-figma-all` skill orchestrates 3 sub-skills. Each runs as a separate agent. Total pipeline: 0 context bloat.
-  
-  💡 Try it: Look at any multi-step skill you've built. Could the steps run independently? If yes, make it a coordinator.
-  
-  #AgenticAI #Day18
+slackOneLiner: "🤖 Tip #18 — The most powerful advanced pattern is counter-intuitive: a skill that doesn't think, just dispatches subagents with fresh context windows."
+keyPointsTitle: "The Context Problem"
+actionItemsTitle: "Build a Coordinator"
+keyPoints:
+  - "**The problem** — Multi-step pipelines (fetch, analyze, plan, implement) accumulate context. By step 4, the AI carries the weight of steps 1-3 in its context window. Quality degrades as context fills up."
+  - "**The solution** — A 'coordinator' skill with `disable-model-invocation: true`. It doesn't reason — it just dispatches subagents. Each step gets a fresh context window. Step 3 doesn't carry the weight of step 1's output."
+  - "**Why disable-model-invocation** — Without it, the coordinator would try to 'think' about the instructions, wasting tokens on reasoning that isn't needed. With it, the skill is a pure dispatcher."
+actionItems:
+  - "**Real example** — `/dx-figma-all` orchestrates 3 sub-skills: extract Figma design, generate prototype, verify against reference. Each runs as a separate agent. Total pipeline: zero context bloat."
+  - |
+    Create a coordinator skill
+    - Set `disable-model-invocation: true` in frontmatter
+    - Each step invokes a sub-skill via `Skill("dx-sub-skill")`
+    - Sub-skills communicate through spec files, not shared context
+  - "**When to use it** — If your multi-step skill's steps can run independently with just file I/O between them, make it a coordinator. Keep monolithic skills only when steps truly depend on shared in-memory context."
+  - "**Test sub-skills first** — Each sub-skill must work standalone before wiring them into a coordinator. Independent testability is the whole point of the pattern."
 ---
-
-```
----
-name: dx-figma-all
-disable-model-invocation: true
----
-
-# Step 1: Extract
-Invoke Skill("dx-figma-extract")
-
-# Step 2: Prototype
-Invoke Skill("dx-figma-prototype")
-
-# Step 3: Verify
-Invoke Skill("dx-figma-verify")
-```

--- a/website/src/content/tips/the-dual-frontmatter-trap.md
+++ b/website/src/content/tips/the-dual-frontmatter-trap.md
@@ -4,65 +4,23 @@ category: "Skills — Advanced"
 focus: "Claude Code · CLI"
 tags: ["paths","applyTo","Gotcha"]
 overview: "Rules files need BOTH paths: (for Claude Code) and applyTo: (for Copilot CLI) in their frontmatter. If you only add one, the rule silently doesn't load in the other tool. No error, no warning — just missing context."
-codeLabel: "The trap and the fix"
 screenshot: null
 week: 5
 weekLabel: "Skills — Recipe Book"
 order: 21
-slackText: |
-  🤖 Agentic AI Tip #21 — The Dual Frontmatter Trap
-  
-  This silent bug has cost teams hours of debugging: rules that work in one AI tool but not the other.
-  
-  *The problem:*
-  Claude Code reads `paths:` from rule frontmatter.
-  Copilot CLI reads `applyTo:`.
-  They ignore each other's field.
-  
-  ```yaml
-  # ❌ Only loads in Claude Code
-  ---
-  paths: ["**/*.scss"]
-  ---
-  
-  # ❌ Only loads in Copilot CLI
-  ---
-  applyTo: "**/*.scss"
-  ---
-  
-  # ✅ Loads in both
-  ---
-  paths: ["**/*.scss"]
-  applyTo: "**/*.scss"
-  ---
-  ```
-  
-  *Why this is dangerous:*
-  There's no error message. No warning. The rule just... doesn't load. You think the AI is ignoring your conventions, but actually it never received them.
-  
-  *The fix:* Always include BOTH fields. Yes, it's redundant. Yes, it's annoying. But it's the only way to ensure rules work across both tools.
-  
-  *Pro tip:* If you're building skills for a team, add a validation script that checks all rule files for dual frontmatter. We caught 12 missing fields this way.
-  
-  💡 Try it: Grep your `.claude/rules/` directory for files that have `paths:` but not `applyTo:`. Fix them now.
-  
-  #AgenticAI #Day21
+slackOneLiner: "🤖 Tip #21 — Rules that work in one AI tool but not the other? You're missing dual frontmatter. Claude Code reads `paths:`, Copilot CLI reads `applyTo:` — you need both."
+keyPointsTitle: "The Silent Failure"
+actionItemsTitle: "Fix and Prevent"
+keyPoints:
+  - "**The problem** — Claude Code reads `paths:` from rule frontmatter. Copilot CLI reads `applyTo:`. They ignore each other's field completely. A rule with only one field silently doesn't load in the other tool."
+  - "**Why this is dangerous** — There's no error message, no warning. The rule just doesn't load. You think the AI is ignoring your conventions, but actually it never received them."
+  - "**Silent failures waste hours** — Teams have spent hours debugging why the AI ignores their coding conventions, only to discover the rule file was missing one frontmatter field."
+actionItems:
+  - |
+    Always use dual frontmatter in rule files
+    - `paths: ["**/*.scss"]` — for Claude Code
+    - `applyTo: "**/*.scss"` — for Copilot CLI
+    - Both fields, same glob pattern, every rule file
+  - "**Audit right now** — Grep your `.claude/rules/` directory for files that have `paths:` but not `applyTo:` (or vice versa). Fix them immediately."
+  - "**Automate the check** — Add a CI check or validation script that flags rule files missing either `paths:` or `applyTo:`. We caught 12 missing fields this way. Prevent the trap from recurring."
 ---
-
-```
-# ❌ Only works in Claude Code
----
-paths: ["**/*.scss"]
----
-
-# ❌ Only works in Copilot CLI
----
-applyTo: "**/*.scss"
----
-
-# ✅ Works in both tools
----
-paths: ["**/*.scss"]
-applyTo: "**/*.scss"
----
-```

--- a/website/src/content/tips/the-spec-directory-convention.md
+++ b/website/src/content/tips/the-spec-directory-convention.md
@@ -4,55 +4,26 @@ category: "Plugins — Full Package"
 focus: "Claude Code"
 tags: ["Specs","Convention","Pipeline"]
 overview: "Every skill pipeline writes to .ai/specs/<ticket-id>-<slug>/. This directory is the handoff point between skills. It's inspectable (just read the files), resumable (re-run any step), and debuggable (if step 3 fails, check step 2's output). Convention over configuration at its best."
-codeLabel: "Complete spec directory"
 screenshot: null
 week: 8
 weekLabel: "Skills — Advanced"
 order: 40
-slackText: |
-  🤖 Agentic AI Tip #40 — The Spec Directory Convention
-  
-  This is the architectural decision I'm most proud of: *file convention over data passing*.
-  
-  Every skill in our pipeline writes to:
-  `.ai/specs/<ticket-id>-<slug>/`
-  
-  The directory grows as you progress:
-  ```
-  .ai/specs/12345-login-bug/
-  ├── raw-story.md       ← fetched ticket
-  ├── explain.md         ← dev requirements
-  ├── research.md        ← affected files
-  ├── implement.md       ← step-by-step plan
-  ├── share-plan.md      ← team summary
-  └── figma-extract.md   ← design specs
-  ```
-  
-  *Why this works so well:*
-  
-  *Inspectable:* Want to see what the AI extracted from the ticket? Read `raw-story.md`. No log diving, no API calls.
-  
-  *Resumable:* Step 3 failed? Fix the issue and re-run just step 3. It reads step 2's file, which is already there.
-  
-  *Debuggable:* If the plan looks wrong, check `explain.md` — maybe the requirements were misunderstood.
-  
-  *Shareable:* Copy the `share-plan.md` to Teams/Slack. It's a human-readable summary, not a log dump.
-  
-  💡 Try it: Run a few skills on a ticket and then explore the `.ai/specs/` directory. Read each file. You'll understand the entire pipeline.
-  
-  #AgenticAI #Day40
+slackOneLiner: "🤖 Tip #40 — Every skill writes to `.ai/specs/<id>-<slug>/`. Inspectable, resumable, debuggable — file convention over data passing at its best."
+keyPointsTitle: "How Specs Work"
+actionItemsTitle: "Explore and Debug"
+keyPoints:
+  - "**The convention** — Every skill in the pipeline writes to `.ai/specs/<ticket-id>-<slug>/`. The directory grows as you progress: raw-story.md, explain.md, research.md, implement.md, share-plan.md, figma-extract.md."
+  - "**Inspectable** — Want to see what the AI extracted from the ticket? Read `raw-story.md`. No log diving, no API calls. Every intermediate result is a plain text file you can read."
+  - "**Resumable** — Step 3 failed? Fix the issue and re-run just step 3. It reads step 2's file, which is already there. No need to repeat the entire pipeline."
+actionItems:
+  - "**Debuggable** — If the plan looks wrong, check `explain.md` — maybe the requirements were misunderstood. Trace backwards through the files to find where things went off track."
+  - |
+    Know what each file represents
+    - `raw-story.md` — fetched ticket from ADO/Jira
+    - `explain.md` — dev-focused requirements
+    - `research.md` — affected files and codebase analysis
+    - `implement.md` — step-by-step implementation plan
+    - `share-plan.md` — team-shareable summary
+    - `dod.md` — definition of done checklist
+  - "**Shareable** — Copy `share-plan.md` to Teams or Slack. It's a human-readable summary, not a log dump. Stakeholders can review AI output without touching dev tools."
 ---
-
-```
-.ai/specs/12345-login-bug/
-├── raw-story.md       # /dx-req (Phase 1)
-├── explain.md         # /dx-req (Phase 3)
-├── research.md        # /dx-req (Phase 4)
-├── implement.md       # /dx-plan
-├── share-plan.md      # /dx-req (Phase 5)
-├── dod.md             # /dx-req-dod
-├── figma-extract.md   # /dx-figma-extract
-└── prototype/         # /dx-figma-prototype
-    ├── index.html
-    └── screenshot.png
-```

--- a/website/src/content/tips/the-three-tools-you-need-to-know.md
+++ b/website/src/content/tips/the-three-tools-you-need-to-know.md
@@ -4,55 +4,40 @@ category: "Meet Your AI Tools"
 focus: "All Tools"
 tags: ["VSCode Chat","Copilot CLI","Claude Code"]
 overview: "You have three AI coding tools — all three are now full agentic platforms that update almost daily. VSCode Chat has Agent mode (edits files, runs commands, uses MCP). Copilot CLI is a terminal-native autonomous agent. Claude Code has the deepest context (1M tokens) and plugin ecosystem. They're nearly identical in capability now — the difference is WHERE you prefer to work."
-codeLabel: "When to use which"
 screenshot: "/images/tldr/cli-and-chat-3-tools.png"
 week: 1
 weekLabel: "Meet Your AI Tools"
 order: 1
-slackText: |
-  🤖 Agentic AI Tip #1 — The Three Tools You Need to Know
-  
-  You have three AI coding tools, and all three are now *full agents*. Updates ship almost daily — keep your tools current or you'll miss new capabilities.
-  
-  All three can edit files, run commands, use MCP servers, and follow custom skills. They're converging fast. The real question isn't "which is best?" — it's *"where do you prefer to work?"*
-  
-  *VSCode Chat* — Use when you're already in the IDE
-  • Inline diffs and visual file review
-  • Language server diagnostics (errors, references, symbols)
-  • Drag & drop files as context
-  • Three modes: Agent (autonomous), Plan (think first), Ask (Q&A)
-  
-  *Copilot CLI* — Use when you live in the terminal
-  • Multi-model support (Claude, GPT, Gemini — switch with /model)
-  • /fleet for parallel subagents across files
-  • Cloud delegation (prefix with & to offload)
-  • Plan mode with Shift+Tab
-  
-  *Claude Code* — Use when you need depth
-  • 1M token context (8x more than Copilot)
-  • Worktree isolation for safe parallel agents
-  • Full hook system (18 events)
-  • Persistent memory across sessions
-  
-  Same plugins power all three. Pick by comfort, not by capability.
-  
-  💡 Try it: Update all three tools today. Then open each and compare — you'll be surprised how similar they've become.
-  
-  #AgenticAI #Day1
+slackOneLiner: "🤖 Tip #1 — You have three AI coding tools, and all three are now full agents. Pick by comfort, not capability."
+keyPointsTitle: "Three Tools, One Ecosystem"
+keyPoints:
+  - "All three are full agentic platforms now — they edit files, run commands, use MCP servers, and follow custom skills. Updates ship almost daily."
+  - |
+    VSCode Chat — best when you're already in the IDE
+    - Inline diffs and visual file review
+    - Language server diagnostics (errors, references, symbols)
+    - Drag & drop files as context
+    - Three modes: Agent (autonomous), Plan (think first), Ask (Q&A)
+  - |
+    Copilot CLI — best when you live in the terminal
+    - Multi-model support (Claude, GPT, Gemini — switch with /model)
+    - /fleet for parallel subagents across files
+    - Cloud delegation (prefix with & to offload)
+    - Plan mode with Shift+Tab
+  - |
+    Claude Code — best when you need depth
+    - 1M token context (8× more than Copilot)
+    - Worktree isolation for safe parallel agents
+    - Full hook system (18 events)
+    - Persistent memory across sessions
+actionItemsTitle: "Pick by Comfort, Not Capability"
+actionItems:
+  - "Same plugins power all three — they're converging fast. The real question isn't 'which is best?' but 'where do you prefer to work?'"
+  - |
+    Pick your default based on comfort
+    - IDE person → VSCode Chat
+    - Terminal person → Copilot CLI
+    - Depth person → Claude Code
+  - "Update all three tools today — they ship updates almost daily and you'll miss new capabilities if you're behind"
+  - "Quick test — run the same task in each tool (e.g. 'explain this function') and compare the experience. You'll be surprised how similar they've become."
 ---
-
-```
-# When to use which:
-
-# VSCode Chat — you're already in the IDE
-# Inline diffs, LSP diagnostics, drag & drop
-# Best: visual refactoring, focused edits
-
-# Copilot CLI — you live in the terminal
-# Multi-model, /fleet, cloud delegation
-# Best: multi-step workflows, CI/CD
-
-# Claude Code — you need depth
-# 1M context, worktree isolation, hooks
-# Best: architecture, complex debugging
-```

--- a/website/src/content/tips/three-levels-of-autonomous-ai-review-coding-agent-.md
+++ b/website/src/content/tips/three-levels-of-autonomous-ai-review-coding-agent-.md
@@ -4,56 +4,32 @@ category: "Real-World Workflows"
 focus: "All Tools"
 tags: ["PR Review","Coding Agent","Autonomous","CI/CD"]
 overview: "Three levels of autonomous AI: (1) Our custom PR reviewer via ADO webhooks + Lambda — confidence-scored findings. (2) GitHub's Copilot coding agent — assign an issue, it creates a PR. (3) Our full automation pipeline — PR review + DoD checks + bug fixes running 24/7. Each level adds autonomy and risk."
-codeLabel: "Three autonomy levels"
 screenshot: null
 week: 9
 weekLabel: "Agents — AI Personas"
 order: 44
-slackText: |
-  🤖 Agentic AI Tip #44 — Three Levels of Autonomous AI
-  
-  Autonomous AI isn't binary — there are levels. Here's how we've structured ours:
-  
-  *Level 1: Autonomous PR Review*
-  ADO webhook triggers Lambda → AI analyzes diff → posts structured comments.
-  • Confidence scoring: ≥90% = MUST-FIX, ≥80% = SUGGESTION, <80% = skip
-  • Includes fix patches — author can accept with one click
-  • Cost: ~$0.15-0.50 per review (Sonnet tier)
-  
-  *Level 2: Copilot Coding Agent (GitHub)*
-  Assign a GitHub issue to Copilot → it spins up a GitHub Actions environment, creates a branch, writes code, runs tests, opens a draft PR.
-  • Reads AGENTS.md AND CLAUDE.md for project context
-  • Supports custom .agent.md agents and MCP servers
-  • Available on: Pro, Pro+, Business, Enterprise plans
-  
-  *Level 3: Full Automation Pipeline (ours)*
-  ADO webhook → work item router → agent selection → complete workflow.
-  DoR validation → Dev implementation → 6-phase verification → PR creation → AI review.
-  • Runs 24/7 on AWS Lambda
-  • Token budgets per run (prevent runaway costs)
-  • Dead letter queue for failed jobs
-  • Capability gating per project
-  
-  Each level adds autonomy — and risk. Start with Level 1 (review only), graduate to Level 3 once you trust the system.
-  
-  💡 Try it: Start with AI PR review. It's low-risk (read-only) and high-value (instant feedback on every PR).
-  
-  #AgenticAI #Day44
+slackOneLiner: "🤖 Tip #44 — Autonomous AI isn't binary — three levels from read-only PR review to full 24/7 automation pipeline."
+keyPointsTitle: "Three Autonomy Levels"
+actionItemsTitle: "Choosing Your Level"
+keyPoints:
+  - "**Level 1 — Autonomous PR Review** — ADO webhook triggers Lambda, AI analyzes the diff and posts structured comments with confidence scoring (>=90% MUST-FIX, >=80% SUGGESTION, <80% skip). Includes fix patches the author can accept with one click. Cost ~$0.15-0.50 per review."
+  - "**Level 2 — Copilot Coding Agent** — Assign a GitHub issue to Copilot, it spins up a GitHub Actions environment, creates a branch, writes code, runs tests, and opens a draft PR. Reads both AGENTS.md and CLAUDE.md for context. Supports custom .agent.md agents and MCP servers."
+  - "**Level 3 — Full Automation Pipeline** — ADO webhook triggers work item router, selects the right agent, runs complete workflow: DoR validation, dev implementation, 6-phase verification, PR creation, AI review. Runs 24/7 on AWS Lambda with token budgets and dead letter queues."
+actionItems:
+  - |
+    **Start with Level 1** — It's read-only (low risk) and high-value (instant feedback on every PR)
+    - No code changes, just structured review comments
+    - Confidence scoring filters noise automatically
+    - Cheapest to run, easiest to trust
+  - |
+    **Match level to team trust**
+    - Level 1 → read-only review, no code changes
+    - Level 2 → code changes but human merges the PR
+    - Level 3 → full autonomy with guardrails
+  - |
+    **Safety controls for Levels 2-3**
+    - Token budgets per run prevent runaway costs
+    - Capability gating limits what each project allows
+    - Dead letter queue catches failed jobs for human review
+    - Set up alerting before enabling any autonomous code generation
 ---
-
-```
-# Level 1: Autonomous PR Review
-# ADO webhook → Lambda → AI review
-# Posts comments with ≥80% confidence
-
-# Level 2: Copilot Coding Agent
-# Assign GitHub issue to Copilot
-# → Spins up Actions environment
-# → Writes code, runs tests
-# → Opens draft PR
-
-# Level 3: Full Automation Pipeline
-# Webhook → Router → Agent selection
-# DoR check → Dev → Verify → PR → Review
-# Running 24/7 on Lambda
-```

--- a/website/src/content/tips/token-budgets-and-cost-control.md
+++ b/website/src/content/tips/token-budgets-and-cost-control.md
@@ -4,55 +4,34 @@ category: "Mastery"
 focus: "All Tools"
 tags: ["Tokens","Cost","Budget"]
 overview: "AI costs money. Opus costs 60x more than Haiku. A careless pipeline burning Opus tokens for simple lookups can cost $50/day. Track token usage, tier your models, and set budgets. Our autonomous agents have hard token caps per run."
-codeLabel: "Cost comparison"
 screenshot: null
 week: 10
 weekLabel: "Agents — AI Personas"
 order: 48
-slackText: |
-  🤖 Agentic AI Tip #48 — Token Budgets and Cost Control
-  
-  AI tools aren't free, and costs can sneak up on you.
-  
-  *Token pricing (approximate per 1M tokens):*
-  • Opus: $15 input / $75 output
-  • Sonnet: $3 input / $15 output
-  • Haiku: $0.25 input / $1.25 output
-  
-  *A typical pipeline run with tiered models:*
-  4 Haiku lookups + 2 Sonnet implementations + 1 Opus review ≈ $2.50
-  
-  *The same pipeline all on Opus:*
-  7 Opus calls ≈ $25+
-  
-  *That's 10x more for the same result.*
-  
-  *Cost control strategies:*
-  1. *Tier your models* — don't use Opus for file searches
-  2. *Set maxTurns on agents* — prevents runaway loops
-  3. *Use pre-flight checks* — don't burn tokens on doomed pipelines
-  4. *Start fresh sessions* — long conversations waste tokens on history
-  5. *Use spawned agents* — isolated context instead of growing the main window
-  
-  *For autonomous agents (CI/CD):*
-  We set hard token budgets per Lambda run. If an agent exceeds its budget, it stops and reports what it completed. Better to stop early than to bankrupt the team.
-  
-  💡 Try it: Check your AI spending for the last week. Identify the most expensive operations and consider if they could use a cheaper model.
-  
-  #AgenticAI #Day48
+slackOneLiner: "🤖 Tip #48 — AI tools aren't free. A tiered pipeline costs ~$2.50 per run; the same pipeline all-Opus costs $25+. Tier your models."
+keyPointsTitle: "What AI Actually Costs"
+keyPoints:
+  - |
+    Token pricing (approximate per 1M tokens)
+    - Opus: $15 input / $75 output
+    - Sonnet: $3 input / $15 output
+    - Haiku: $0.25 input / $1.25 output
+  - "A tiered pipeline run — 4 Haiku lookups + 2 Sonnet implementations + 1 Opus review = ~$2.50. The same pipeline all on Opus = $25+. That's 10x more for the same result."
+  - "Autonomous agents (CI/CD) — we set hard token budgets per Lambda run. If an agent exceeds its budget, it stops and reports what it completed. Better to stop early than to bankrupt the team."
+actionItemsTitle: "How to Control Costs"
+actionItems:
+  - |
+    Cost control strategies
+    - Tier your models — don't use Opus for file searches
+    - Set maxTurns on agents — prevents runaway loops
+    - Use pre-flight checks — don't burn tokens on doomed pipelines
+    - Start fresh sessions — long conversations waste tokens on history
+    - Use spawned agents — isolated context instead of growing the main window
+  - |
+    Apply the tiering principle to your pipeline
+    - Lookups and file search → Haiku ($)
+    - Implementation and execution → Sonnet ($$)
+    - Code review and architecture → Opus ($$$)
+  - "Check your AI spending for the last week — identify the most expensive operations and consider if they could use a cheaper model"
+  - "Set maxTurns on all your agents to prevent runaway token consumption from infinite loops"
 ---
-
-```
-# Cost per 1M tokens (approximate):
-# Opus:   $15 input / $75 output
-# Sonnet: $3 input / $15 output
-# Haiku:  $0.25 input / $1.25 output
-
-# A single pipeline run:
-# 4 Haiku lookups:    ~$0.02
-# 2 Sonnet steps:     ~$0.50
-# 1 Opus review:      ~$2.00
-# Total:              ~$2.52
-
-# vs all-Opus:        ~$25+
-```

--- a/website/src/content/tips/vscode-chat-agent-mode-not-what-you-remember.md
+++ b/website/src/content/tips/vscode-chat-agent-mode-not-what-you-remember.md
@@ -4,60 +4,39 @@ category: "Meet Your AI Tools"
 focus: "VSCode · CLI"
 tags: ["Agent Mode","Plan Mode","Ask Mode"]
 overview: "Forget what you knew about VSCode Chat — Agent mode (GA Feb 2025) transformed it into a full autonomous agent. It now edits files, runs terminal commands, uses MCP tools, and self-heals on errors. Three modes: Agent (autonomous), Plan (thinks first), Ask (Q&A only). Edit mode is being deprecated — merged into Agent."
-codeLabel: "Three modes"
 screenshot: null
 week: 1
 weekLabel: "Meet Your AI Tools"
 order: 2
-slackText: |
-  🤖 Agentic AI Tip #2 — VSCode Chat Agent Mode: Not What You Remember
-  
-  If you tried VSCode Chat a year ago and dismissed it as "just autocomplete" — try again. Everything changed.
-  
-  *Agent mode (GA Feb 2025):*
-  • Edits files across your workspace autonomously
-  • Runs terminal commands (builds, tests, installs)
-  • Uses MCP server tools (AEM, Chrome DevTools, Figma, ADO)
-  • Self-heals — monitors errors and fixes them automatically
-  • Permission levels: confirm each action, auto-approve all, or full autopilot
-  
-  *Three built-in modes:*
-  • *Agent* — full autonomy: edits, runs, iterates
-  • *Plan* — structured thinking before coding
-  • *Ask* — Q&A only, no file modifications
-  
-  *What's gone:* Edit mode is being deprecated and merged into Agent mode.
-  
-  *What Chat has that CLIs don't:*
-  • Inline diffs in the editor (visual review)
-  • Language server integration (symbols, references, diagnostics)
-  • File/selection attachment with drag & drop
-  • Interactive handoff buttons between agents
-  
-  *What CLIs have that Chat doesn't:*
-  • Subagent orchestration with worktree isolation
-  • Persistent cross-session memory
-  • Full plugin hook system
-  • 1M token context (Claude Code)
-  
-  💡 Try it: Open VSCode Chat, switch to Agent mode, and ask it to "fix any lint errors in this file and run the build."
-  
-  #AgenticAI #Day2
+slackOneLiner: "🤖 Tip #2 — VSCode Chat Agent mode (GA Feb 2025) is a full autonomous agent now — edits files, runs commands, self-heals. Not what you remember."
+keyPointsTitle: "Agent Mode — What Changed"
+keyPoints:
+  - "If you tried VSCode Chat a year ago and dismissed it — try again. Agent mode (GA Feb 2025) is a full autonomous agent now."
+  - |
+    What Agent mode can do
+    - Edit files across your workspace autonomously
+    - Run terminal commands (builds, tests, installs)
+    - Use MCP server tools (AEM, Chrome DevTools, Figma, ADO)
+    - Self-heal — monitors errors and fixes them automatically
+  - |
+    Three built-in modes
+    - Agent — full autonomy: edits, runs, iterates
+    - Plan — structured thinking before coding
+    - Ask — Q&A only, no file modifications
+  - "Permission levels — confirm each action, auto-approve edits, or full autopilot. You control the trust level."
+actionItemsTitle: "Chat vs CLI — When to Use Which"
+actionItems:
+  - |
+    What Chat has that CLIs don't
+    - Inline diffs in the editor (visual review)
+    - Language server integration (symbols, references, diagnostics)
+    - File/selection attachment with drag & drop
+    - Interactive handoff buttons between agents
+  - |
+    What CLIs have that Chat doesn't
+    - Subagent orchestration with worktree isolation
+    - Persistent cross-session memory
+    - Full plugin hook system
+    - 1M token context (Claude Code)
+  - "Quick test — open Chat, switch to Agent mode, ask it to 'fix any lint errors in this file and run the build'. Compare with doing the same in your terminal agent."
 ---
-
-```
-# Three modes in VSCode Chat:
-
-# Agent — full autonomy
-"Fix the auth bug, run tests, and
- update the changelog"
-→ edits files, runs terminal, iterates
-
-# Plan — think before coding
-"Plan how to refactor the modal system"
-→ structured plan, then executes
-
-# Ask — Q&A only (no changes)
-"How does the routing work?"
-→ explains, no file modifications
-```

--- a/website/src/content/tips/what-is-a-skill.md
+++ b/website/src/content/tips/what-is-a-skill.md
@@ -4,51 +4,33 @@ category: "Skills — Recipe Book"
 focus: "Claude Code · CLI"
 tags: ["Skill","Markdown","Slash Command"]
 overview: "A skill is just a markdown file with instructions. When you type /skill-name, the AI reads the file and follows its instructions. Think of it as a recipe — you write it once, and the AI follows it every time. No code, no API, just a text file."
-codeLabel: "A simple skill"
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
 order: 12
-slackText: |
-  🤖 Agentic AI Tip #12 — What is a Skill?
-  
-  A skill is the simplest concept in agentic AI — and the most powerful.
-  
-  *It's a markdown file with instructions.*
-  
-  That's it. You write a `.md` file, put it in the right directory, and invoke it with `/skill-name`. The AI reads the instructions and follows them.
-  
-  *Why this is powerful:*
-  • *Repeatable* — same instructions, consistent results
-  • *Shareable* — commit to git, entire team benefits
-  • *Composable* — skills can invoke other skills
-  • *No code needed* — it's just markdown
-  
-  *Where skills live:*
-  • `.claude/commands/` — for Claude Code
-  • `.github/skills/` — for Copilot CLI (in GitHub repos)
-  
-  *The anatomy of a skill:*
-  1. YAML frontmatter (name, description, tools)
-  2. Instructions (what the AI should do)
-  3. Optional: scripts, references, templates
-  
-  Think of the difference between telling a new hire "figure out the build" vs handing them a step-by-step checklist. Skills are the checklist.
-  
-  💡 Try it: Create `.claude/commands/hello.md` with the content "Say hello and tell me three interesting facts about this project." Then run `/hello` in Claude Code.
-  
-  #AgenticAI #Day12
+slackOneLiner: "🤖 Tip #12 — A skill is a markdown file with instructions. Write it once, invoke with /skill-name, get consistent results every time. No code needed."
+keyPointsTitle: "The Simplest, Most Powerful Concept"
+keyPoints:
+  - "A skill is the simplest concept in agentic AI — and the most powerful. It's a markdown file with instructions. Put it in the right directory, invoke it with /skill-name."
+  - |
+    Why skills are powerful
+    - Repeatable — same instructions, consistent results
+    - Shareable — commit to git, entire team benefits
+    - Composable — skills can invoke other skills
+    - No code needed — it's just markdown
+  - |
+    The anatomy of a skill
+    - YAML frontmatter (name, description, tools)
+    - Instructions (what the AI should do)
+    - Optional: scripts, references, templates
+  - "Think of the difference between telling a new hire 'figure out the build' vs handing them a step-by-step checklist. Skills are the checklist."
+actionItemsTitle: "Get Started in 2 Minutes"
+actionItems:
+  - |
+    Where skills live
+    - .claude/commands/ — for Claude Code
+    - .github/skills/ — for Copilot CLI (in GitHub repos)
+  - "Create .claude/commands/hello.md with 'Say hello and tell me three interesting facts about this project' — then run /hello in Claude Code"
+  - "Identify a task you repeat weekly and write a skill for it — you'll save time on every future run"
+  - "Commit your skills to git so the entire team can invoke them with the same /command"
 ---
-
-```
-# .claude/commands/check-build.md
----
-name: check-build
-description: Run build and report errors
-allowed-tools: [bash, read]
----
-
-Run the build command from CLAUDE.md.
-If it fails, read the error output and
-suggest specific fixes for each error.
-```

--- a/website/src/content/tips/what-is-an-agent-two-formats-one-concept.md
+++ b/website/src/content/tips/what-is-an-agent-two-formats-one-concept.md
@@ -4,59 +4,39 @@ category: "Agents — AI Personas"
 focus: "Claude Code"
 tags: ["Agent",".agent.md","Plugin Agent","13+25"]
 overview: "An agent is a persona with specific tools and model. Two formats exist: Claude Code plugin agents (model tiering, worktree isolation, memory) and Copilot .agent.md files (multi-model, handoffs, MCP inline config). We maintain 13 plugin agents + 25 Copilot agents. Same concepts, different capabilities."
-codeLabel: "Two agent formats"
 screenshot: null
 week: 5
 weekLabel: "Skills — Recipe Book"
 order: 22
-slackText: |
-  🤖 Agentic AI Tip #22 — What is an Agent? Two Formats, One Concept
-  
-  An agent is a persona — model + tools + constraints. But today there are *two formats*:
-  
-  *Claude Code plugin agents* (`agents/*.md`):
-  • `model:` — Opus/Sonnet/Haiku (explicit tier)
-  • `permissionMode:` — plan (read-only) or acceptEdits
-  • `isolation: worktree` — agent gets its own repo copy
-  • `memory:` — persistent across sessions
-  • `maxTurns:` — safety cap
-  
-  *Copilot agents* (`.github/agents/*.agent.md`):
-  • `tools:` — read, edit, search, execute, codebase
-  • `handoffs:` — interactive buttons to chain agents (VS Code)
-  • `mcp-servers:` — inline MCP config in YAML
-  • `model:` — fallback chain: `[claude-sonnet, gpt-4o]`
-  • `allowed-tools:` — auto-approve these tools
-  
-  We maintain *both*: 13 plugin agents for Claude Code, 25 Copilot agents in .github/agents/. Generated from shared templates by our init script.
-  
-  *Tool name differences:*
-  • Claude Code: `Read, Glob, Bash, Edit`
-  • Copilot: `read, codebase, execute, edit`
-  Templates include both — unrecognized names are ignored per platform.
-  
-  💡 Try it: Open `.github/agents/` and a plugin `agents/` directory side by side. Compare the frontmatter fields.
-  
-  #AgenticAI #Day22
+slackOneLiner: "🤖 Tip #22 — An agent is a persona (model + tools + constraints), and two formats exist — Claude Code plugin agents and Copilot .agent.md files."
+keyPointsTitle: "Two Agent Formats"
+actionItemsTitle: "Choosing & Creating Agents"
+keyPoints:
+  - "An agent is a persona — model + tools + constraints. Same concept in both formats, different capabilities and frontmatter fields."
+  - |
+    Claude Code plugin agents (`agents/*.md`) — deep platform integration
+    - `model:` — explicit tier (Opus/Sonnet/Haiku)
+    - `permissionMode:` — plan (read-only) or acceptEdits
+    - `isolation: worktree` — agent gets its own repo copy
+    - `memory:` — persistent across sessions
+    - `maxTurns:` — safety cap
+  - |
+    Copilot agents (`.github/agents/*.agent.md`) — multi-model and interactive
+    - `tools:` — read, edit, search, execute, codebase
+    - `handoffs:` — interactive buttons to chain agents (VS Code)
+    - `mcp-servers:` — inline MCP config in YAML
+    - `model:` — fallback chain: `[claude-sonnet, gpt-4o]`
+    - `allowed-tools:` — auto-approve these tools
+actionItems:
+  - "We maintain both — 13 plugin agents for Claude Code, 25 Copilot agents in `.github/agents/`. Generated from shared templates by the init script."
+  - |
+    Tool name differences between platforms
+    - Claude Code: `Read, Glob, Bash, Edit`
+    - Copilot: `read, codebase, execute, edit`
+    - Templates include both — unrecognized names are ignored per platform
+  - |
+    Know which format to use
+    - Need model tiering or worktree isolation — Claude Code plugin agent
+    - Need handoffs or multi-model fallback — Copilot .agent.md
+  - "When adding a new agent, create both formats from shared templates so all platforms are covered"
 ---
-
-```
-# Claude Code (plugin agent):
----
-name: dx-code-reviewer
-model: opus
-permissionMode: plan
-isolation: worktree
-maxTurns: 50
----
-
-# Copilot (.github/agents/):
----
-name: DxCodeReview
-tools: [read, codebase, search]
-handoffs:
-  - label: "Create PR"
-    agent: DxCommit
-allowed-tools: [read, edit, execute]
----
-```

--- a/website/src/content/tips/what-is-mcp-works-everywhere-now.md
+++ b/website/src/content/tips/what-is-mcp-works-everywhere-now.md
@@ -4,63 +4,37 @@ category: "MCP — System Integration"
 focus: "All Tools"
 tags: ["MCP","GA in VSCode","All Platforms"]
 overview: "MCP (Model Context Protocol) is now GA in ALL three tools — Claude Code, Copilot CLI, AND VSCode Chat (since July 2025). Same protocol, different config files: .mcp.json for CLIs, .vscode/mcp.json for VSCode. Agents can even declare MCP servers inline in their frontmatter. One protocol, every tool."
-codeLabel: "MCP on all platforms"
 screenshot: null
 week: 6
 weekLabel: "Skills — Recipe Book"
 order: 27
-slackText: |
-  🤖 Agentic AI Tip #27 — What is MCP? Works Everywhere Now
-  
-  MCP (Model Context Protocol) went from "Claude Code only" to *GA on all platforms* in 2025. This changes everything.
-  
-  *The analogy:* MCP is like USB for AI. Plug in a server, AI gets new tools. One protocol, every platform.
-  
-  *Where MCP works (2025+):*
-  • *Claude Code* — native since day 1 (`.mcp.json`)
-  • *Copilot CLI* — full support (`.mcp.json`, same format)
-  • *VSCode Chat* — GA since July 2025 (`.vscode/mcp.json`)
-  • *Copilot coding agent* — MCP servers in cloud environments
-  • *Copilot agents* — inline `mcp-servers:` in .agent.md frontmatter
-  
-  *Config file differences:*
-  • CLIs: `.mcp.json` with `"mcpServers": {}`
-  • VSCode: `.vscode/mcp.json` with `"servers": {}`
-  Root key is different! Copy-paste will break.
-  
-  *Our 6 MCP servers:*
-  • ADO — work items, PRs, builds, wiki
-  • AEM — JCR content, components, pages
-  • Chrome DevTools — screenshots, navigation, DOM
-  • Figma — designs, tokens, screenshots
-  • axe — accessibility audits
-  • GitHub MCP — built into Copilot
-  
-  *Before MCP:* "I can't see websites." *After MCP:* 📸 screenshot in 2 seconds.
-  
-  💡 Try it: Add Chrome DevTools MCP to both `.mcp.json` AND `.vscode/mcp.json`. Test in Claude Code, Copilot CLI, and VSCode Chat.
-  
-  #AgenticAI #Day27
+slackOneLiner: "🤖 Tip #27 — MCP is like USB for AI — plug in a server, AI gets new tools. Now GA on all three platforms."
+keyPointsTitle: "The Protocol & Platforms"
+actionItemsTitle: "Config & Our Servers"
+keyPoints:
+  - "MCP (Model Context Protocol) — the analogy is USB for AI. Plug in a server, AI gets new tools. One protocol, every platform."
+  - |
+    Where MCP works (2025+)
+    - Claude Code — native since day 1 (`.mcp.json`)
+    - Copilot CLI — full support (`.mcp.json`, same format)
+    - VSCode Chat — GA since July 2025 (`.vscode/mcp.json`)
+    - Copilot coding agent — MCP servers in cloud environments
+    - Copilot agents — inline `mcp-servers:` in .agent.md frontmatter
+  - |
+    Config file differences — root key matters, copy-paste will break
+    - CLIs: `.mcp.json` with `"mcpServers": {}`
+    - VSCode: `.vscode/mcp.json` with `"servers": {}`
+  - "Before MCP — 'I can't see websites.' After MCP — screenshot in 2 seconds. The capability gap between tools has collapsed."
+actionItems:
+  - |
+    Our 6 MCP servers — each adds a distinct capability
+    - ADO — work items, PRs, builds, wiki
+    - AEM — JCR content, components, pages
+    - Chrome DevTools — screenshots, navigation, DOM
+    - Figma — designs, tokens, screenshots
+    - axe — accessibility audits
+    - GitHub MCP — built into Copilot
+  - "Add Chrome DevTools MCP to both `.mcp.json` AND `.vscode/mcp.json` — test in Claude Code, Copilot CLI, and VSCode Chat"
+  - "Remember the root key difference — `mcpServers` for CLIs, `servers` for VSCode. Don't copy-paste between them without changing the key"
+  - "For Copilot agents, try inline `mcp-servers:` in the .agent.md frontmatter — no separate config file needed"
 ---
-
-```
-# Claude Code / Copilot CLI:
-# .mcp.json
-{ "mcpServers": {
-    "chrome": { "command": "npx",
-      "args": ["chrome-devtools-mcp"] }
-}}
-
-# VSCode Chat:
-# .vscode/mcp.json
-{ "servers": {
-    "chrome": { "command": "npx",
-      "args": ["chrome-devtools-mcp"] }
-}}
-
-# Copilot agent inline MCP:
-# .github/agents/MyAgent.agent.md
-# mcp-servers:
-#   chrome:
-#     command: npx chrome-devtools-mcp
-```

--- a/website/src/content/tips/worktree-isolation-safe-parallel-work.md
+++ b/website/src/content/tips/worktree-isolation-safe-parallel-work.md
@@ -4,49 +4,25 @@ category: "Mastery"
 focus: "Claude Code"
 tags: ["Worktree","Isolation","Safety"]
 overview: 'The isolation: "worktree" parameter gives an agent its own copy of the repo. It can make changes, run builds, even break things — without affecting your working directory. Perfect for code review agents that need to explore without risk.'
-codeLabel: "Worktree isolation"
 screenshot: null
 week: 10
 weekLabel: "Agents — AI Personas"
 order: 47
-slackText: |
-  🤖 Agentic AI Tip #47 — Worktree Isolation: Safe Parallel Work
-  
-  Ever worried about an AI agent messing up your working directory? Worktree isolation solves this completely.
-  
-  *What it does:*
-  `isolation: "worktree"` creates a temporary git worktree — a separate checkout of your repo. The agent works there instead of in your active directory.
-  
-  *Why this matters:*
-  • Agent can make experimental changes safely
-  • Your uncommitted work is untouched
-  • Agent can run builds that might fail
-  • Multiple agents can work on different branches simultaneously
-  • If anything goes wrong, delete the worktree — zero impact
-  
-  *Real use case: Code review*
-  Our `dx-code-reviewer` runs in a worktree. It checks out the PR branch, reads the code, maybe even runs the build to verify. Your main workspace stays exactly as you left it.
-  
-  *Another use case: Parallel feature work*
-  Two agents working on two different features simultaneously, each in their own worktree, while you do a third thing in your main directory.
-  
-  *The cleanup:*
-  If the agent makes no changes, the worktree is auto-cleaned. If it made changes, you get the worktree path and branch name to review.
-  
-  💡 Try it: Next time you spawn an agent for research or review, add `isolation: "worktree"`. Feel the safety.
-  
-  #AgenticAI #Day47
+slackOneLiner: "🤖 Tip #47 — Worktree isolation gives agents their own repo copy — they can break things without touching your working directory."
+keyPointsTitle: "How Worktrees Protect You"
+actionItemsTitle: "Best Use Cases"
+keyPoints:
+  - "**What it does** — `isolation: \"worktree\"` creates a temporary git worktree, a separate checkout of your repo. The agent works there instead of in your active directory."
+  - "**Safety guarantees** — Agent can make experimental changes, run builds that might fail, and explore freely. Your uncommitted work is completely untouched. If anything goes wrong, delete the worktree with zero impact."
+  - "**Cleanup behavior** — If the agent makes no changes, the worktree is auto-cleaned. If it made changes, you get the worktree path and branch name to review before deciding what to keep."
+actionItems:
+  - "**Code review** — Our `dx-code-reviewer` runs in a worktree. It checks out the PR branch, reads the code, maybe even runs the build to verify. Your main workspace stays exactly as you left it."
+  - "**Parallel features** — Two agents working on two different features simultaneously, each in their own worktree, while you do a third thing in your main directory."
+  - |
+    **Best candidates for worktree isolation**
+    - Code review agents — need to checkout PR branches
+    - Build verification agents — might break things
+    - Experimental refactoring — safe to explore without risk
+    - Parallel feature work — multiple agents, multiple branches
+  - "**Try it now** — Next time you spawn an agent for research or review, add `isolation: \"worktree\"` to feel the safety. Run `git worktree list` to see current worktrees."
 ---
-
-```
-# Spawn agent in isolated worktree:
-Agent tool:
-  subagent_type: "dx-code-reviewer"
-  isolation: "worktree"
-  prompt: "Review the auth module"
-
-# Agent gets a COPY of the repo
-# Can edit, build, test freely
-# Your working dir is untouched
-# If it messes up → delete worktree
-```

--- a/website/src/content/tips/writing-your-first-custom-skill.md
+++ b/website/src/content/tips/writing-your-first-custom-skill.md
@@ -4,66 +4,26 @@ category: "Skills — Recipe Book"
 focus: "Claude Code"
 tags: ["Custom","Commands","DIY"]
 overview: "You can create a custom skill in under 2 minutes. Create a markdown file in .claude/commands/, add frontmatter and instructions, and invoke it with /your-skill-name. Start with something small — a build checker, a convention reminder, a component scaffolder."
-codeLabel: "Your first skill"
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
 order: 15
-slackText: |
-  🤖 Agentic AI Tip #15 — Writing Your First Custom Skill
-  
-  Stop telling AI the same instructions over and over. Write a skill once, use it forever.
-  
-  *Step 1:* Create the file
-  ```
-  .claude/commands/check-component.md
-  ```
-  
-  *Step 2:* Add frontmatter
-  ```yaml
-  ---
-  name: check-component
-  description: Verify a web component follows project patterns
-  argument-hint: "<component-name>"
-  allowed-tools: [read, grep, glob]
-  ---
-  ```
-  
-  *Step 3:* Write instructions
-  ```
-  1. Find the component file matching the given name in src/
-  2. Verify it extends CustomComponent
-  3. Check that lifecycle methods (beforeLoad, afterLoad) exist
-  4. Check that data-model parsing is implemented
-  5. Report findings with specific file:line references
-  ```
-  
-  *Step 4:* Use it
-  ```
-  /check-component hero
-  ```
-  
-  That's it. No JavaScript, no API, no build step. Just a markdown file that the AI follows as instructions.
-  
-  *Pro tip:* Commit the file to git. Now your entire team has the skill.
-  
-  💡 Try it: Think of an instruction you've given AI more than twice. Write it as a skill file right now. It takes 2 minutes.
-  
-  #AgenticAI #Day15
+slackOneLiner: "🤖 Tip #15 — Stop repeating yourself. Write a skill once in 2 minutes, use it forever — no JavaScript, no API, no build step."
+keyPointsTitle: "Four Steps to a Skill"
+actionItemsTitle: "Build One Right Now"
+keyPoints:
+  - "**Step 1 — Create the file** — Just a markdown file at `.claude/commands/check-component.md`. That's the only location requirement."
+  - "**Step 2 — Add frontmatter** — name, description, argument-hint, and allowed-tools in a YAML block. This controls how the skill behaves and what it can access."
+  - "**Step 3 — Write instructions** — Numbered steps telling the AI what to do. 'Find the component, verify it extends CustomComponent, check lifecycle methods, report findings with file:line references.'"
+  - "**Step 4 — Use it** — Type `/check-component hero` and the AI follows your instructions exactly. No JavaScript, no API, no build step."
+actionItems:
+  - "**Find your first candidate** — Think of an instruction you've given AI more than twice. A build checker, a convention reminder, a component scaffolder. That's your first skill."
+  - |
+    Create the skill file now
+    - Create `.claude/commands/your-skill.md`
+    - Add frontmatter: name, description, argument-hint, allowed-tools
+    - Write 3-5 numbered instruction steps
+    - Test with `/your-skill <argument>`
+  - "**Commit to git** — Once the skill file is in version control, your entire team has the skill automatically. Shared knowledge encoded as a file."
+  - "**Start small, iterate** — Your first skill doesn't need to be perfect. Get it working, then refine the instructions as you use it."
 ---
-
-```
-# .claude/commands/check-component.md
----
-name: check-component
-description: Verify a web component
-  follows project patterns
-argument-hint: "<component-name>"
-allowed-tools: [read, grep, glob]
----
-
-1. Find the component file in src/
-2. Verify it extends CustomComponent
-3. Check lifecycle methods exist
-4. Report any missing patterns
-```

--- a/website/src/content/tips/your-first-mcp-chrome-devtools.md
+++ b/website/src/content/tips/your-first-mcp-chrome-devtools.md
@@ -4,62 +4,33 @@ category: "MCP — System Integration"
 focus: "Claude Code"
 tags: ["Chrome","DevTools","Screenshots"]
 overview: "The easiest MCP to start with is Chrome DevTools. One line in your .mcp.json, zero API keys needed. The AI can then take screenshots, navigate pages, click elements, inspect DOM, read console logs, and analyze network requests. Visual verification becomes possible."
-codeLabel: "Zero-config MCP"
 screenshot: null
 week: 7
 weekLabel: "Skills — Advanced"
 order: 31
-slackText: |
-  🤖 Agentic AI Tip #31 — Your First MCP: Chrome DevTools
-  
-  If you're going to set up one MCP server, make it Chrome DevTools. Zero config, zero API keys, instant value.
-  
-  *Setup:*
-  Add this to your `.mcp.json`:
-  ```json
-  {
-    "mcpServers": {
-      "chrome-devtools": {
-        "command": "npx",
-        "args": ["chrome-devtools-mcp@latest"]
-      }
-    }
-  }
-  ```
-  
-  *What you can do:*
-  • 📸 *Take screenshots* — "screenshot localhost:3000"
-  • 🧭 *Navigate pages* — "open localhost:3000/login"
-  • 🖱️ *Click elements* — "click the submit button"
-  • 🔍 *Inspect DOM* — "what's the HTML structure of the nav?"
-  • 📋 *Read console* — "are there any console errors?"
-  • 🌐 *Monitor network* — "what API calls does the page make?"
-  
-  *Real workflow:*
-  1. AI implements a component
-  2. AI takes a screenshot to verify it renders
-  3. AI compares screenshot against Figma reference
-  4. AI fixes visual differences
-  
-  This turns "I can't see the browser" into "Let me check how it looks." Visual verification without leaving the terminal.
-  
-  💡 Try it: Add the config above, restart Claude Code, and ask it to take a screenshot of any localhost page.
-  
-  #AgenticAI #Day31
+slackOneLiner: "🤖 Tip #31 — Chrome DevTools MCP: zero config, zero API keys — the AI can now see your browser, take screenshots, and verify UI visually."
+keyPointsTitle: "What It Unlocks"
+actionItemsTitle: "Get Started in 2 Minutes"
+keyPoints:
+  - "**Zero-config setup** — Add one entry to .mcp.json with command 'npx' and args 'chrome-devtools-mcp@latest'. No API keys, no authentication, no server to manage."
+  - |
+    **Full browser capabilities**
+    - Take screenshots of any page
+    - Navigate to URLs, click elements, fill forms
+    - Inspect DOM structure and computed styles
+    - Read console logs and monitor network requests
+  - "**Visual verification workflow** — AI implements a component, takes a screenshot to verify it renders, compares against a Figma reference, and fixes visual differences. All without leaving the terminal."
+  - "**The fundamental unlock** — Turns 'I can't see the browser' into 'Let me check how it looks.' This is the key enabler for UI development with AI — visual verification without tab-switching."
+actionItems:
+  - |
+    **Add Chrome DevTools MCP to your .mcp.json**
+    - "command": "npx"
+    - "args": ["chrome-devtools-mcp@latest"]
+  - "**Restart Claude Code** — MCP servers are loaded at startup, so restart after adding the config"
+  - "**Test it** — Ask the AI to take a screenshot of any localhost page and describe what it sees"
+  - |
+    **Where it shines**
+    - Bug verification — AI follows repro steps and screenshots each one
+    - Figma comparison — screenshot prototype, compare against Figma reference
+    - Responsive testing — screenshot at different viewport widths
 ---
-
-```
-# Add to .mcp.json:
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
-    }
-  }
-}
-
-# Then in Claude Code:
-"Take a screenshot of localhost:4502
- and check if the hero renders"
-```

--- a/website/src/content/tips/your-plugin-journey-zero-to-production.md
+++ b/website/src/content/tips/your-plugin-journey-zero-to-production.md
@@ -4,60 +4,33 @@ category: "Mastery"
 focus: "All Tools"
 tags: ["Journey","Evolution","Production"]
 overview: "You don't build a plugin in a day. Start with one skill solving one pain point. Add an agent when you need a different model tier. Add hooks when you need guardrails. Add MCP when you need external systems. Bundle as a plugin when 2+ projects need the same tools. Our plugins evolved over months, not days."
-codeLabel: "Plugin evolution"
 screenshot: null
 week: 11
 weekLabel: "MCP — System Integration"
 order: 51
-slackText: |
-  🤖 Agentic AI Tip #51 — Your Plugin Journey: Zero to Production
-  
-  You've made it to Day 50! Here's the meta-lesson from building 69 skills across 4 plugins.
-  
-  *Don't plan a plugin. Grow one.*
-  
-  *Month 1: Solve one pain point*
-  Create a single skill that saves you 10 minutes per day. A build checker, a component verifier, a convention reminder. One file. Done.
-  
-  *Month 2: Add related skills*
-  As you use the first skill, you'll notice patterns. "I always do X before Y." Write a skill for X too. Add rules for your conventions.
-  
-  *Month 3: Add agents*
-  Some tasks need a different model tier. Your build checker (Haiku) is different from your code reviewer (Opus). Create agent definitions.
-  
-  *Month 4: Add guardrails*
-  You'll make a mistake — commit on the wrong branch, edit a config file incorrectly. Add hooks to prevent it structurally.
-  
-  *Month 5: Package and share*
-  If two projects need the same skills, bundle them as a plugin. Write a sync script. Version it.
-  
-  *The key insight:*
-  Our plugins didn't start as "let's build a comprehensive AI development platform." They started as "I'm tired of typing the same build command." Everything else grew from there.
-  
-  Start small. Ship today. Iterate tomorrow.
-  
-  💡 Try it: Write your first skill. Right now. Today. That's your Day 1.
-  
-  #AgenticAI #Day51
+slackOneLiner: "🤖 Tip #51 — Don't plan a plugin — grow one. Start with one skill solving one pain point, then add agents, hooks, and MCP as real needs emerge."
+keyPointsTitle: "The Growth Path"
+actionItemsTitle: "Your First Steps"
+keyPoints:
+  - "**The meta-lesson** — Don't plan a plugin. Grow one. Our 69 skills across 4 plugins didn't start as a 'comprehensive AI development platform' — they started as 'I'm tired of typing the same build command.'"
+  - |
+    **Month-by-month evolution**
+    - Month 1 — One skill solving one pain point (a build checker, a convention reminder)
+    - Month 2 — Add related skills as patterns emerge ('I always do X before Y') plus rules
+    - Month 3 — Add agents when tasks need different model tiers (Haiku for lookups, Opus for review)
+    - Month 4 — Add hooks as guardrails after you make a mistake (wrong branch, bad config edit)
+    - Month 5 — Package as a plugin when 2+ projects need the same tools
+  - "**Start from real friction** — Each skill should save you 10 minutes per day. A build checker, a component verifier, a convention reminder. If it doesn't solve a real pain point, don't build it."
+  - "**Patterns reveal themselves** — As you use your first skill, you'll notice what you always do before and after it. Those adjacent tasks become your next skills."
+actionItems:
+  - "**Write your first skill today** — Pick the one task you repeat most and automate it with a single SKILL.md file. That's your Day 1."
+  - |
+    **Follow the natural growth path**
+    - Start with `.claude/commands/` for project-local skills
+    - Add `.claude/rules/` when you notice recurring conventions
+    - Add `agents/` when different tasks need different model tiers
+    - Add `hooks/hooks.json` when you need structural guardrails
+    - Graduate to a plugin when multiple projects need the same tools
+  - "**Package when shared** — The moment two projects need the same skills, bundle them as a plugin. Write a sync script. Version it. One source, many consumers."
+  - "**Don't over-engineer early** — Resist the urge to plan the full plugin up front. Let real usage drive what you build next. Iterate tomorrow."
 ---
-
-```
-# The evolution:
-# Month 1: One skill
-.claude/commands/check-build.md
-
-# Month 2: Three skills + rules
-.claude/commands/
-.claude/rules/
-
-# Month 3: Skills + agents
-+ agents/code-reviewer.md
-
-# Month 4: + hooks + MCP
-+ hooks/hooks.json
-+ .mcp.json
-
-# Month 5: Package as plugin
-+ .claude-plugin/plugin.json
-# → Install in all projects
-```

--- a/website/src/content/tips/your-plugin-journey-zero-to-production.md
+++ b/website/src/content/tips/your-plugin-journey-zero-to-production.md
@@ -6,7 +6,7 @@ tags: ["Journey","Evolution","Production"]
 overview: "You don't build a plugin in a day. Start with one skill solving one pain point. Add an agent when you need a different model tier. Add hooks when you need guardrails. Add MCP when you need external systems. Bundle as a plugin when 2+ projects need the same tools. Our plugins evolved over months, not days."
 screenshot: null
 week: 11
-weekLabel: "MCP — System Integration"
+weekLabel: "Plugins & Mastery"
 order: 51
 slackOneLiner: "🤖 Tip #51 — Don't plan a plugin — grow one. Start with one skill solving one pain point, then add agents, hooks, and MCP as real needs emerge."
 keyPointsTitle: "The Growth Path"

--- a/website/src/pages/learn/tldr.astro
+++ b/website/src/pages/learn/tldr.astro
@@ -22,16 +22,7 @@ const weekLabels: Record<number, string> = {
   8: 'Skills — Advanced',
   9: 'Agents — AI Personas',
   10: 'Agents — AI Personas',
-  11: 'MCP — System Integration',
-  12: 'MCP — System Integration',
-  13: 'Hooks — Guardrails',
-  14: 'Hooks — Guardrails',
-  15: 'Plugins — Full Package',
-  16: 'Plugins — Full Package',
-  17: 'Real-World Workflows',
-  18: 'Real-World Workflows',
-  19: 'Mastery',
-  20: 'Mastery',
+  11: 'Plugins & Mastery',
 };
 
 // Group by weekLabel
@@ -53,10 +44,13 @@ const base = import.meta.env.BASE_URL;
     subtitle="One tip per day. From basics to production patterns. Built from 78 skills and 3 plugins."
   />
 
-  {Object.entries(grouped).map(([weekLabel, weekTips], groupIdx) => (
+  {Object.entries(grouped).map(([weekLabel, weekTips], groupIdx) => {
+    const weeks = [...new Set(weekTips.map(t => t.data.week))].sort((a, b) => (a ?? 0) - (b ?? 0));
+    const weekBadge = weeks.length > 1 ? `Weeks ${weeks[0]}–${weeks[weeks.length - 1]}` : `Week ${weeks[0] ?? '?'}`;
+    return (
     <>
       <SectionHeading
-        badge={`Week ${weekTips[0]?.data.week ?? '?'}`}
+        badge={weekBadge}
         badgeColor={badgeColors[groupIdx % badgeColors.length]}
         title={weekLabel}
         subtitle={`${weekTips.length} tips`}
@@ -79,5 +73,6 @@ const base = import.meta.env.BASE_URL;
         </ul>
       </Section>
     </>
-  ))}
+  );
+  })}
 </SidebarLayout>

--- a/website/src/pages/learn/tldr.astro
+++ b/website/src/pages/learn/tldr.astro
@@ -63,33 +63,20 @@ const base = import.meta.env.BASE_URL;
         bg={groupIdx % 2 === 0 ? 'alt' : 'default'}
       />
       <Section>
-        <div class="grid md:grid-cols-2 gap-4">
+        <ul class="space-y-1">
           {weekTips.map((tip) => (
-            <a href={`${base}/learn/tldr/${tip.id.replace(/\.md$/, '')}/`} class="no-underline">
-              <div class="border border-gray-200 rounded-lg bg-white p-5 hover:shadow-md transition-shadow h-full">
-                <div class="flex items-center gap-2 mb-2">
-                  <span class="inline-block px-2 py-0.5 bg-brand-700 text-white rounded text-xs font-mono font-bold">
-                    #{tip.data.order ?? '?'}
-                  </span>
-                  {tip.data.focus && (
-                    <span class="inline-block px-2 py-0.5 border border-cyan rounded text-xs font-mono text-cyan-dark">
-                      {tip.data.focus}
-                    </span>
-                  )}
-                </div>
-                <h3 class="font-semibold text-brand-900 mb-1 text-[1.1rem]">{tip.data.title}</h3>
-                <p class="text-sm text-gray-600 leading-relaxed mb-2">{tip.data.overview}</p>
-                <div class="flex flex-wrap gap-1">
-                  {tip.data.tags.map((tag) => (
-                    <span class="inline-block px-2 py-0.5 border border-gray-200 rounded text-[0.65rem] font-mono text-gray-500">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </a>
+            <li>
+              <a href={`${base}/learn/tldr/${tip.id.replace(/\.md$/, '')}/`} class="flex items-baseline gap-3 py-1.5 px-2 rounded hover:bg-gray-50 transition-colors no-underline group">
+                <span class="text-xs font-mono font-bold text-brand-700 w-6 text-right flex-shrink-0">
+                  {tip.data.order ?? '?'}
+                </span>
+                <span class="text-[0.95rem] text-gray-800 group-hover:text-brand-700 transition-colors">
+                  {tip.data.title}
+                </span>
+              </a>
+            </li>
           ))}
-        </div>
+        </ul>
       </Section>
     </>
   ))}

--- a/website/src/pages/learn/tldr/[id].astro
+++ b/website/src/pages/learn/tldr/[id].astro
@@ -2,7 +2,7 @@
 import SidebarLayout from '../../../layouts/SidebarLayout.astro';
 import PageHero from '../../../components/PageHero.astro';
 import Section from '../../../components/Section.astro';
-import SectionHeading from '../../../components/SectionHeading.astro';
+import CommandBlock from '../../../components/CommandBlock.astro';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -15,68 +15,166 @@ export async function getStaticPaths() {
 
 const { tip } = Astro.props;
 const { Content } = await render(tip);
+const { title, order, week, category, overview, tags, focus, slackText, slackOneLiner, keyPoints, keyPointsTitle, actionItems, actionItemsTitle, screenshot } = tip.data;
+
+function parsePoint(text: string) {
+  const lines = text.split('\n').filter(l => l.trim());
+  const main = lines[0];
+  const subs = lines.slice(1).filter(l => l.trim().startsWith('- ')).map(l => l.trim().slice(2));
+  const dashIdx = main.indexOf(' — ');
+  return { main, dashIdx, subs };
+}
 ---
 
-<SidebarLayout title={tip.data.title} sidebar="learn">
-  <PageHero title={tip.data.title} subtitle={`Day ${tip.data.order ?? '?'} · Week ${tip.data.week ?? '?'} · ${tip.data.category}`} />
+<SidebarLayout title={title} sidebar="learn">
+  <PageHero title={title} subtitle={`Day ${order ?? '?'} · Week ${week ?? '?'} · ${category}`} />
 
   <Section>
-    <!-- Meta badges -->
-    <div class="flex flex-wrap gap-2 mb-6">
-      {tip.data.order && (
-        <span class="inline-block px-3 py-1 bg-brand-700 text-white rounded text-xs font-mono font-bold">
-          #{tip.data.order}
-        </span>
-      )}
-      <span class="inline-block px-3 py-1 bg-brand-100 rounded text-xs font-semibold text-brand-700">
-        {tip.data.category}
-      </span>
-      {tip.data.focus && (
-        <span class="inline-block px-3 py-1 bg-cyan/10 rounded text-xs font-semibold text-cyan-dark">
-          {tip.data.focus}
-        </span>
-      )}
-      {tip.data.tags.map((tag) => (
-        <span class="inline-block px-2 py-1 border border-gray-200 rounded text-xs font-mono text-gray-600">
-          {tag}
-        </span>
-      ))}
-    </div>
-
-    <!-- Overview -->
-    <div class="bg-brand-100 rounded p-5 mb-6">
-      <p class="text-[0.95rem] text-[#1a1a2e] leading-relaxed">{tip.data.overview}</p>
-    </div>
-
-    <!-- Main content (code examples, explanation) -->
-    <div class="prose prose-lg max-w-none mb-8">
-      <Content />
-    </div>
-
-    <!-- Slack message (copy-paste ready) -->
-    {tip.data.slackText && (
-      <div class="border border-gray-200 rounded-lg overflow-hidden">
+    <!-- Slack One-Liner -->
+    {slackOneLiner && (
+      <div class="border border-gray-200 rounded-lg overflow-hidden mb-8">
         <div class="flex justify-between items-center px-5 py-3 bg-gray-50 border-b border-gray-200">
           <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Slack Message — copy & paste</span>
           <button
-            id="copy-slack"
+            id="copy-oneliner"
             class="px-3 py-1 text-xs font-medium bg-brand-700 text-white rounded hover:bg-brand-500 transition-colors"
           >
             Copy
           </button>
         </div>
         <div class="p-5">
-          <pre id="slack-text" class="text-[0.8rem] text-gray-600 leading-relaxed whitespace-pre-wrap font-sans bg-transparent p-0 m-0">{tip.data.slackText}</pre>
+          <p id="oneliner-text" class="text-base text-gray-700 leading-relaxed font-medium">{slackOneLiner}</p>
         </div>
       </div>
     )}
 
-    <!-- Screenshot -->
-    {tip.data.screenshot && (
-      <div class="mt-6">
-        <img src={`${import.meta.env.BASE_URL}/${tip.data.screenshot}`} alt={`${tip.data.title} example`} class="rounded border border-gray-200 w-full" />
+    <!-- Two-Column Share Cards -->
+    {keyPoints && keyPoints.length > 0 && actionItems && actionItems.length > 0 && (
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <!-- Key Insight Card -->
+        <div class="border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
+          <div class="flex flex-wrap gap-2 mb-3">
+            {order && (
+              <span class="inline-block px-3 py-1 bg-brand-700 text-white rounded text-xs font-mono font-bold">
+                #{order}
+              </span>
+            )}
+            {focus && (
+              <span class="inline-block px-3 py-1 bg-cyan/10 rounded text-xs font-semibold text-cyan-dark">
+                {focus}
+              </span>
+            )}
+          </div>
+          <h3 class="text-xl font-bold text-[#1a1a2e] mb-4">{keyPointsTitle || title}</h3>
+          <ul class="space-y-3 flex-1">
+            {keyPoints.map((point: string) => {
+              const { main, dashIdx, subs } = parsePoint(point);
+              return (
+                <li>
+                  <div class="flex items-start gap-2.5">
+                    <span class="w-1.5 h-1.5 rounded-full bg-brand-700 mt-[7px] flex-shrink-0"></span>
+                    <span class="text-[0.9rem] text-gray-700 leading-[1.7]">
+                      {dashIdx > -1 ? (
+                        <><strong class="text-[#1a1a2e]">{main.slice(0, dashIdx)}</strong>{' — '}<span class="text-gray-600">{main.slice(dashIdx + 3)}</span></>
+                      ) : (
+                        <span class="text-gray-600">{main}</span>
+                      )}
+                    </span>
+                  </div>
+                  {subs.length > 0 && (
+                    <ul class="ml-6 mt-1.5 space-y-1">
+                      {subs.map((sub: string) => (
+                        <li class="flex items-start gap-2">
+                          <span class="text-brand-700 -mt-[3px] flex-shrink-0">›</span>
+                          <span class="text-[0.85rem] text-gray-500 leading-[1.6]">{sub}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+          {tags && tags.length > 0 && (
+            <div class="flex flex-wrap gap-2 pt-3 mt-4 border-t border-gray-100">
+              {tags.map((tag: string) => (
+                <span class="inline-block px-2 py-1 border border-gray-200 rounded text-xs font-mono text-gray-600">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <!-- Try It Card -->
+        <div class="border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
+          <div class="flex flex-wrap gap-2 mb-3">
+            {order && (
+              <span class="inline-block px-3 py-1 bg-brand-700 text-white rounded text-xs font-mono font-bold">
+                #{order}
+              </span>
+            )}
+            <span class="inline-block px-3 py-1 bg-brand-100 rounded text-xs font-semibold text-brand-700">
+              {category}
+            </span>
+          </div>
+          <h3 class="text-xl font-bold text-[#1a1a2e] mb-4">{actionItemsTitle || title}</h3>
+          <ol class="space-y-3 flex-1">
+            {actionItems.map((item: string, i: number) => {
+              const { main, dashIdx, subs } = parsePoint(item);
+              return (
+                <li>
+                  <div class="flex items-start gap-2.5">
+                    <span class="w-6 h-6 rounded-full bg-brand-100 text-brand-700 text-xs font-bold flex items-center justify-center flex-shrink-0 mt-0.5">{i + 1}</span>
+                    <span class="text-[0.9rem] text-gray-700 leading-[1.7]">
+                      {dashIdx > -1 ? (
+                        <><strong class="text-[#1a1a2e]">{main.slice(0, dashIdx)}</strong>{' — '}<span class="text-gray-600">{main.slice(dashIdx + 3)}</span></>
+                      ) : (
+                        <span class="text-gray-600">{main}</span>
+                      )}
+                    </span>
+                  </div>
+                  {subs.length > 0 && (
+                    <ul class="ml-[2.35rem] mt-1.5 space-y-1">
+                      {subs.map((sub: string) => (
+                        <li class="flex items-start gap-2">
+                          <span class="text-brand-700 -mt-[3px] flex-shrink-0">›</span>
+                          <span class="text-[0.85rem] text-gray-500 leading-[1.6]">{sub}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+          {tags && tags.length > 0 && (
+            <div class="flex flex-wrap gap-2 pt-3 mt-4 border-t border-gray-100">
+              {tags.map((tag: string) => (
+                <span class="inline-block px-2 py-1 border border-gray-200 rounded text-xs font-mono text-gray-600">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     )}
+
+    <!-- Custom Screenshot Placeholder -->
+    <div class="mb-8">
+      {screenshot ? (
+        <img src={`${import.meta.env.BASE_URL}/${screenshot}`} alt={`${title} example`} class="rounded-xl border border-gray-200 w-full" />
+      ) : (
+        <div class="border-2 border-dashed border-gray-300 rounded-xl p-8 flex flex-col items-center justify-center min-h-[180px] bg-gray-50/50">
+          <svg class="w-10 h-10 text-gray-300 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <span class="text-sm text-gray-400 font-medium">Your screenshot here</span>
+          <span class="text-xs text-gray-300 mt-1">Optional — add a screenshot from your own workflow</span>
+        </div>
+      )}
+    </div>
 
     <!-- Navigation -->
     <div class="mt-8 pt-4 border-t border-gray-200">
@@ -87,23 +185,26 @@ const { Content } = await render(tip);
   </Section>
 
   <script>
-    const btn = document.getElementById('copy-slack');
-    const text = document.getElementById('slack-text');
-    btn?.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(text?.textContent ?? '');
-        btn.textContent = 'Copied!';
-        setTimeout(() => btn.textContent = 'Copy', 2000);
-      } catch {
-        const ta = document.createElement('textarea');
-        ta.value = text?.textContent ?? '';
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-        btn.textContent = 'Copied!';
-        setTimeout(() => btn.textContent = 'Copy', 2000);
-      }
-    });
+    function setupCopy(btnId: string, textId: string) {
+      const btn = document.getElementById(btnId);
+      const text = document.getElementById(textId);
+      btn?.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(text?.textContent ?? '');
+          btn.textContent = 'Copied!';
+          setTimeout(() => btn.textContent = 'Copy', 2000);
+        } catch {
+          const ta = document.createElement('textarea');
+          ta.value = text?.textContent ?? '';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+          btn.textContent = 'Copied!';
+          setTimeout(() => btn.textContent = 'Copy', 2000);
+        }
+      });
+    }
+    setupCopy('copy-oneliner', 'oneliner-text');
   </script>
 </SidebarLayout>


### PR DESCRIPTION
## Summary
- Redesign all 51 tip pages into a Slack-share-friendly two-card layout
- Each tip now has: one-liner Slack message (copy button), two balanced presentation-style cards, and a screenshot placeholder
- Cards have unique titles, bold leads with sub-bullets, badges, and tags pinned as footer
- Migrated all content from old format (slackText + code body) into structured keyPoints/actionItems frontmatter
- Net reduction of 1,214 lines — content is denser and more structured

## Test plan
- [ ] Visit any tip page on dev server (e.g. `/learn/tldr/the-three-tools-you-need-to-know/`)
- [ ] Verify two cards render side-by-side with balanced content
- [ ] Verify Slack one-liner copy button works
- [ ] Verify screenshot placeholder shows for tips without screenshots
- [ ] Verify tags are pinned to bottom of both cards
- [ ] Verify bold leads and sub-bullets render correctly
- [ ] Run `npx astro build` — all 95 pages build clean
- [ ] Check TLDR listing page still works (`/learn/tldr/`)