### PR TITLE
feat: configure nested subagent setting in dx-sync

### DIFF
--- a/plugins/dx-core/skills/dx-sync/scripts/sync-consumers.sh
+++ b/plugins/dx-core/skills/dx-sync/scripts/sync-consumers.sh
@@ -538,11 +538,13 @@ step_8c_vscode_settings() {
 
   if $DRY_RUN; then
     if [ -f "$vscode_settings" ]; then
-      local has_skills has_instr
+      local has_skills has_instr has_subagents
       has_skills=$(grep -c "agentSkillsLocations" "$vscode_settings" 2>/dev/null | tail -1 || echo 0)
       has_instr=$(grep -c "instructionsFilesLocations" "$vscode_settings" 2>/dev/null | tail -1 || echo 0)
+      has_subagents=$(grep -c "allowInvocationsFromSubagents" "$vscode_settings" 2>/dev/null | tail -1 || echo 0)
       [ "$has_skills" -eq 0 ] && log_dry "  would add chat.agentSkillsLocations"
       [ "$has_instr" -eq 0 ] && log_dry "  would add chat.instructionsFilesLocations"
+      [ "$has_subagents" -eq 0 ] && log_dry "  would add chat.subagents.allowInvocationsFromSubagents"
     else
       log_dry "  would create .vscode/settings.json with VS Code Chat settings"
     fi
@@ -559,23 +561,30 @@ step_8c_vscode_settings() {
     },
     "chat.agentSkillsLocations": {
         ".claude/skills": true
-    }
+    },
+    "chat.subagents.allowInvocationsFromSubagents": true
 }
 SETTINGS_EOF
     log_info "  created .vscode/settings.json"
   else
     # Check if settings already have our entries
     local needs_update=false
+    local missing_entries=""
     if ! grep -q "instructionsFilesLocations" "$vscode_settings" 2>/dev/null; then
       needs_update=true
+      missing_entries="$missing_entries\n  Add: \"chat.instructionsFilesLocations\": { \".claude/rules\": true, \".github/instructions\": true }"
     fi
     if ! grep -q "agentSkillsLocations" "$vscode_settings" 2>/dev/null; then
       needs_update=true
+      missing_entries="$missing_entries\n  Add: \"chat.agentSkillsLocations\": { \".claude/skills\": true }"
+    fi
+    if ! grep -q "allowInvocationsFromSubagents" "$vscode_settings" 2>/dev/null; then
+      needs_update=true
+      missing_entries="$missing_entries\n  Add: \"chat.subagents.allowInvocationsFromSubagents\": true"
     fi
     if $needs_update; then
       log_warn "  .vscode/settings.json exists but missing VS Code Chat settings — add manually"
-      log_info '  Add: "chat.instructionsFilesLocations": { ".claude/rules": true, ".github/instructions": true }'
-      log_info '  Add: "chat.agentSkillsLocations": { ".claude/skills": true }'
+      echo -e "$missing_entries" | while read -r line; do [ -n "$line" ] && log_info "$line"; done
     else
       log_info "  .vscode/settings.json already has VS Code Chat settings"
     fi

--- a/website/src/pages/learn/cli-vs-chat.mdx
+++ b/website/src/pages/learn/cli-vs-chat.mdx
@@ -225,15 +225,17 @@ import { stats } from '../../config/stats';
     </ContentCard>
   </div>
 
-  <HighlightBox severity="success" title="Setup -- One Setting">
-    Add to <code>.vscode/settings.json</code> to expose plugin skills to VS Code Chat:
+  <HighlightBox severity="success" title="Setup -- Key Settings">
+    Add to <code>.vscode/settings.json</code> to expose plugin skills and enable nested agent orchestration:
     <CommandBlock label=".vscode/settings.json">{`"chat.agentSkillsLocations": {
   ".claude/skills": true,
   "dx-aem-flow/dx/plugins/dx-core/skills": true,
   "dx-aem-flow/dx/plugins/dx-aem/skills": true
-}`}</CommandBlock>
-    VS Code Chat also defaults to reading <code>.claude/rules/</code> and <code>.github/agents/</code> --
-    the same files Claude Code and Copilot CLI use. No duplication needed.
+},
+"chat.subagents.allowInvocationsFromSubagents": true`}</CommandBlock>
+    The subagent setting (VS Code 1.113+) lets coordinator agents like DxAgentAll dispatch subagents
+    programmatically. Without it, nested orchestration is disabled.
+    <code>/dx-sync</code> configures this automatically for consumer projects.
   </HighlightBox>
 
   <div class="overflow-x-auto mt-4">


### PR DESCRIPTION
## Summary

- **dx-sync** now adds `chat.subagents.allowInvocationsFromSubagents: true` to `.vscode/settings.json` for consumer projects — enables VS Code Chat 1.113+ nested agent orchestration
- Dry-run and existing-file checks updated to detect the missing setting
- Website `cli-vs-chat.mdx` updated to show the setting alongside `agentSkillsLocations`

Without this setting, the `agents:` allowlist added to coordinator templates in PR #69 has no effect — VS Code silently blocks nested subagent dispatch.

## Test plan

- [ ] Run `dx-sync --dry-run` — should report "would add chat.subagents.allowInvocationsFromSubagents" for projects without it
- [ ] Run `dx-sync` on a consumer — verify `.vscode/settings.json` includes the new setting
- [ ] `cd website && npm run build` — 95 pages, no errors