### PR TITLE
feat: add tip-block class for screenshot automation

### DIFF
--- a/website/src/pages/learn/tldr/[id].astro
+++ b/website/src/pages/learn/tldr/[id].astro
@@ -52,7 +52,7 @@ function parsePoint(text: string) {
     {keyPoints && keyPoints.length > 0 && actionItems && actionItems.length > 0 && (
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         <!-- Key Insight Card -->
-        <div class="border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
+        <div class="tip-block border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
           <div class="flex flex-wrap gap-2 mb-3">
             {order && (
               <span class="inline-block px-3 py-1 bg-brand-700 text-white rounded text-xs font-mono font-bold">
@@ -107,7 +107,7 @@ function parsePoint(text: string) {
         </div>
 
         <!-- Try It Card -->
-        <div class="border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
+        <div class="tip-block border border-gray-200 rounded-lg bg-white p-5 flex flex-col">
           <div class="flex flex-wrap gap-2 mb-3">
             {order && (
               <span class="inline-block px-3 py-1 bg-brand-700 text-white rounded text-xs font-mono font-bold">


### PR DESCRIPTION
## Summary
- Adds `.tip-block` class to both Key Insight and Try It cards on the tips detail page (`/learn/tldr/[id]`)
- Enables automated screenshot capture of tip cards without selecting the screenshot placeholder

## Test plan
- [ ] Visit any tip detail page and inspect both cards — verify `.tip-block` class is present
- [ ] Verify the screenshot placeholder div does NOT have the class
- [ ] Run screenshot automation script and confirm both cards are captured