### PR TITLE
fix: escape tildes and backslashes in MDX to fix website build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ node_modules/
 # Claude Code local state
 .claude/settings.local.json
 .claude/subagent-log.txt
+.claude/skills/demo-vscode/
+.claude/agents/
 
 # Website build artifacts
 website/dist/

--- a/website/src/pages/contributing/technical-ref.mdx
+++ b/website/src/pages/contributing/technical-ref.mdx
@@ -289,7 +289,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       </thead>
       <tbody>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">1 (highest)</td><td class="py-2 px-4">Enterprise managed settings</td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4">2</td><td class="py-2 px-4"><code>~/.claude/settings.json</code> (user)</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4">2</td><td class="py-2 px-4"><code>{"~"}/.claude/settings.json</code> (user)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">3</td><td class="py-2 px-4"><code>.claude/settings.json</code> (project)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4">4 (lowest)</td><td class="py-2 px-4"><code>.claude/settings.local.json</code> (local, gitignored)</td></tr>
       </tbody>

--- a/website/src/pages/setup/copilot-cli.mdx
+++ b/website/src/pages/setup/copilot-cli.mdx
@@ -60,7 +60,7 @@ import { stats } from '../../config/stats';
 <Section>
   <HighlightBox severity="warning" title="Copilot CLI Does Not Read Project .mcp.json">
     Claude Code reads <code>.mcp.json</code> at the project root. Copilot CLI only reads from
-    <code>~/.copilot/mcp-config.json</code> (global) or plugin-bundled <code>.mcp.json</code> files.
+    <code>{"~"}/.copilot/mcp-config.json</code> (global) or plugin-bundled <code>.mcp.json</code> files.
     Project-specific servers like ADO must be configured manually.
   </HighlightBox>
 
@@ -92,7 +92,7 @@ import { stats } from '../../config/stats';
       <tbody>
         <tr class="border-t border-gray-200"><td class="p-3">Claude Code</td><td class="p-3"><code>.mcp.json</code></td><td class="p-3"><code>mcpServers</code></td><td class="p-3">Per-project</td></tr>
         <tr class="border-t border-gray-200"><td class="p-3">VS Code Chat</td><td class="p-3"><code>.vscode/mcp.json</code></td><td class="p-3"><code>servers</code></td><td class="p-3">Per-project</td></tr>
-        <tr class="border-t border-gray-200"><td class="p-3">Copilot CLI</td><td class="p-3"><code>~/.copilot/mcp-config.json</code></td><td class="p-3"><code>servers</code></td><td class="p-3">Global</td></tr>
+        <tr class="border-t border-gray-200"><td class="p-3">Copilot CLI</td><td class="p-3"><code>{"~"}/.copilot/mcp-config.json</code></td><td class="p-3"><code>servers</code></td><td class="p-3">Global</td></tr>
       </tbody>
     </table>
   </div>
@@ -156,7 +156,7 @@ import { stats } from '../../config/stats';
       conversation context.
     </ContentCard>
     <ContentCard icon="mdi:account" iconColor="bg-brand-700" title="Personal Skills Directory">
-      <code>~/.agents/skills/</code> is now a personal skill discovery directory (aligning with VS Code Chat).
+      <code>{"~"}/.agents/skills/</code> is now a personal skill discovery directory (aligning with VS Code Chat).
       Use it for individual developer customizations that don't belong in the shared repo.
     </ContentCard>
     <ContentCard icon="mdi:swap-horizontal" iconColor="bg-amber-500" title="Session Management">

--- a/website/src/pages/setup/index.mdx
+++ b/website/src/pages/setup/index.mdx
@@ -81,7 +81,7 @@ export AEM_INSTANCES="local:http://localhost:4502:admin:admin"
 # export AXE_API_KEY="your-axe-api-key"
 # export QA_BASIC_AUTH_USER="your-qa-username"
 # export QA_BASIC_AUTH_PASS="your-qa-password"`}</CommandBlock>
-    Restart your terminal or run <code>source ~/.zshrc</code> after adding these.
+    Restart your terminal or run <code>{"source ~/.zshrc"}</code> after adding these.
     These env vars work in both Claude Code and Copilot CLI.
   </HighlightBox>
 

--- a/website/src/pages/setup/vscode-chat.mdx
+++ b/website/src/pages/setup/vscode-chat.mdx
@@ -36,7 +36,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 <Section>
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:store" iconColor="bg-brand-700" title="Marketplace Install (Recommended)" tags={[{ label: 'New in VS Code 1.110+', color: 'info' }]}>
-      VS Code clones the plugin repo into <code>~/Library/Application Support/Code/agentPlugins/</code>
+      VS Code clones the plugin repo into <code>{"~/Library/Application Support/Code/agentPlugins/"}</code>
       (macOS) and reads <code>marketplace.json</code> to discover all plugins. Full plugin support:
       agents, skills, hooks, MCP servers, instructions, and prompts.
 
@@ -213,9 +213,9 @@ import CommandBlock from '../../components/CommandBlock.astro';
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-3">macOS</td><td class="py-2 px-3"><code>~/Library/Application Support/Code/agentPlugins/github.com/&#123;owner&#125;/&#123;repo&#125;/</code></td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-3">Windows</td><td class="py-2 px-3"><code>%APPDATA%\Code\agentPlugins\github.com\&#123;owner&#125;\&#123;repo&#125;\</code></td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-3">Linux</td><td class="py-2 px-3"><code>~/.config/Code/agentPlugins/github.com/&#123;owner&#125;/&#123;repo&#125;/</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-3">macOS</td><td class="py-2 px-3"><code>{"~/Library/Application Support/Code/agentPlugins/github.com/{owner}/{repo}/"}</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-3">Windows</td><td class="py-2 px-3"><code>{"%APPDATA%\\Code\\agentPlugins\\github.com\\{owner}\\{repo}\\"}</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-3">Linux</td><td class="py-2 px-3"><code>{"~/.config/Code/agentPlugins/github.com/{owner}/{repo}/"}</code></td></tr>
       </tbody>
     </table>
   </div>
@@ -230,8 +230,8 @@ import CommandBlock from '../../components/CommandBlock.astro';
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-3 font-semibold">Claude Code CLI</td><td class="py-2 px-3"><code>~/.claude/plugins/</code></td><td class="py-2 px-3"><code>/plugin marketplace add</code></td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-3 font-semibold">Copilot CLI</td><td class="py-2 px-3"><code>~/.copilot/state/installed-plugins/</code></td><td class="py-2 px-3"><code>/plugin marketplace add</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-3 font-semibold">Claude Code CLI</td><td class="py-2 px-3"><code>{"~/.claude/plugins/"}</code></td><td class="py-2 px-3"><code>/plugin marketplace add</code></td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-3 font-semibold">Copilot CLI</td><td class="py-2 px-3"><code>{"~/.copilot/state/installed-plugins/"}</code></td><td class="py-2 px-3"><code>/plugin marketplace add</code></td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-3 font-semibold">VS Code Chat</td><td class="py-2 px-3"><code>agentPlugins/</code> (see above)</td><td class="py-2 px-3"><code>chat.plugins.marketplaces</code> setting</td></tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- MDX parser treats `~` as strikethrough and `\` as escape characters even inside `<code>` JSX tags, causing build failures
- Wrapped file paths containing `~` and `\` in `{"..."}` JSX string expressions to bypass markdown parsing
- Fixed 4 MDX files: `vscode-chat.mdx` (build breaker), `copilot-cli.mdx`, `index.mdx`, `technical-ref.mdx`

## Test plan
- [x] `npm run build` passes locally (96 pages)
- [ ] GitHub Actions build passes