### PR TITLE
fix: platform-neutral tips and updated Copilot model roster

### DIFF
--- a/website/src/content/tips/context-window-why-ai-forgets.md
+++ b/website/src/content/tips/context-window-why-ai-forgets.md
@@ -3,7 +3,7 @@ title: 'Context Window: Why AI "Forgets"'
 category: "Context — The Secret Sauce"
 focus: "All Tools"
 tags: ["1M Tokens","200K Tokens","Fresh Sessions"]
-overview: "AI models have a fixed context window — Opus holds 1M tokens, Sonnet 200K. When your conversation exceeds this, older messages get compressed or dropped. This is why long sessions degrade. Start fresh for new tasks. Don't try to do everything in one conversation."
+overview: "Every AI model has a fixed context window — Claude Opus holds ~1M tokens, GPT-5.x models ~128K–200K, Gemini 2.5 Pro ~1M. When your conversation exceeds this, older messages get compressed or dropped. This is why long sessions degrade. Start fresh for new tasks. Don't try to do everything in one conversation."
 screenshot: null
 week: 3
 weekLabel: "Context — The Secret Sauce"
@@ -12,10 +12,11 @@ slackOneLiner: "🤖 Tip #11 — AI gets confused late in long sessions because 
 keyPointsTitle: "How Context Windows Work"
 keyPoints:
   - |
-    Context window sizes
-    - Opus: ~1M tokens (~750K words)
-    - Sonnet: ~200K tokens (~150K words)
-    - GPT-4: ~128K tokens (~95K words)
+    Context window sizes vary by model
+    - Claude Opus: ~1M tokens (~750K words)
+    - Claude Sonnet: ~200K tokens (~150K words)
+    - GPT-5.x models: ~128K–200K tokens depending on variant
+    - Gemini 2.5 Pro: ~1M tokens
   - "When your conversation fills the window, older messages get compressed or dropped — the AI literally can't see them anymore."
   - |
     Symptoms of context overflow
@@ -31,8 +32,8 @@ actionItems:
     - Start fresh for new tasks — don't chain unrelated work in one session
     - Use subagents for expensive operations — they get their own context
     - Put conventions in CLAUDE.md — re-loaded automatically, never forgotten
-    - Use the /compact command in Claude Code — it summarizes and frees space (but loses nuance)
-  - "Check Claude Code's token usage display — start a new session when you switch to a different task"
+    - Compact your context when sessions get long — it summarizes and frees space (but loses nuance)
+  - "Watch your token usage — start a new session when you switch to a different task"
   - "Move important conventions and decisions into CLAUDE.md so they survive across sessions"
-  - "Use /compact when a session gets long but you're not ready to start fresh — it summarizes and frees space"
+  - "Compact context when a session gets long but you're not ready to start fresh — it summarizes and frees space"
 ---

--- a/website/src/content/tips/model-selection-more-models-than-you-think.md
+++ b/website/src/content/tips/model-selection-more-models-than-you-think.md
@@ -3,12 +3,12 @@ title: "Model Selection: More Models Than You Think"
 category: "Meet Your AI Tools"
 focus: "All Tools"
 tags: ["Opus $$$","Sonnet $$","Haiku $","Multi-Model"]
-overview: "Claude Code uses Anthropic models (Opus/Sonnet/Haiku). Copilot CLI and VSCode Chat support Claude, GPT, AND Gemini — switch mid-session with /model. Each model family has strengths. Copilot agents support model fallback chains: model: [claude-sonnet, gpt-4o] — if one fails, try the next."
+overview: "Claude Code uses Anthropic models (Opus/Sonnet/Haiku). Copilot CLI and VS Code Chat support Claude, GPT-5.x, Gemini, Grok, and fine-tuned models — switch mid-session with /model. Each model family has strengths. Copilot agents support model fallback chains: model: [claude-sonnet-4-6, gpt-5.4] — if one fails, try the next."
 screenshot: null
 week: 2
 weekLabel: "Meet Your AI Tools"
 order: 6
-slackOneLiner: "🤖 Tip #6 — Which tool you use determines your model options. Claude Code = Anthropic only. Copilot = Claude + GPT + Gemini. Tier wisely."
+slackOneLiner: "🤖 Tip #6 — Which tool you use determines your model options. Claude Code = Anthropic only. Copilot = Claude + GPT-5.x + Gemini + Grok. Tier wisely."
 keyPointsTitle: "The Model Landscape"
 keyPoints:
   - "The model landscape is wider than you think — which tool you use determines your options."
@@ -19,12 +19,14 @@ keyPoints:
     - Haiku ($): fast lookups, file search, simple transforms
     - Switch with /model or /fast for Sonnet quick-mode
   - |
-    Copilot CLI & VSCode Chat — multi-model
-    - Claude Sonnet 4.6, Claude Haiku 4.5
-    - GPT-4o, GPT-5.3-Codex
-    - Gemini 2.5 Pro, Gemini 3 Pro
+    Copilot CLI & VS Code Chat — multi-provider
+    - Anthropic: Claude Opus 4.6, Sonnet 4.6, Haiku 4.5
+    - OpenAI: GPT-5.4, GPT-5.3-Codex, GPT-5.2, GPT-5.1-Codex, GPT-5 mini
+    - Google: Gemini 2.5 Pro, Gemini 3.1 Pro, Gemini 3 Flash
+    - xAI: Grok Code Fast 1
+    - Fine-tuned: Raptor mini, Goldeneye
     - Switch mid-session with /model — each model family has strengths
-  - "Copilot agent fallback chains — specify `model: [claude-sonnet-4, gpt-4o]` in agent config. If Claude is down, fall back to GPT automatically. Claude Code doesn't support this."
+  - "Copilot agent fallback chains — specify `model: [claude-sonnet-4-6, gpt-5.4]` in agent config. If Claude is down, fall back to GPT automatically. Claude Code doesn't support this."
 actionItemsTitle: "Tier Wisely, Save 10x"
 actionItems:
   - "The tiering principle — use the cheapest model that can do the job. Our 13 agents use 3 tiers: 1 Opus agent (code review), 8 Sonnet agents (execution), 4 Haiku agents (lookups). This saves 10x vs using Opus for everything."


### PR DESCRIPTION
## Summary
- **Tip #11 (Context Window):** replace stale GPT-4 reference with current model families; remove Claude Code-specific `/compact` wording — now says "compact context" to work for both platforms
- **Tip #6 (Model Selection):** update Copilot model list to current roster — GPT-5.x family, Gemini 3.x, Grok Code Fast 1, fine-tuned models (Raptor mini, Goldeneye), Claude Opus 4.6

## Test plan
- [x] `npm run build` passes locally (96 pages)
- [ ] Verify tip pages render correctly on deployed site