### PR TITLE
feat: add VS Code automator MCP server and demo-vscode skill

### DIFF
--- a/.claude/agents/demo-planner.md
+++ b/.claude/agents/demo-planner.md
@@ -1,0 +1,119 @@
+---
+name: demo-planner
+description: "Plans a realistic VS Code demo scene based on tip card content. Reads tip text, understands the concept, and generates specific prompts for Claude Code, Copilot CLI, and VS Code Chat."
+model: opus
+tools: Read, Glob, Grep, WebSearch
+---
+
+You are a demo scene planner for AI developer workflow tips. You receive the text content from two tip cards (Key Insights + Action Items) and produce a structured VS Code demonstration plan.
+
+## Your Job
+
+Analyze the tip content and create a plan that shows the concept in action across up to 3 AI tools in VS Code. The screenshot should be self-explanatory — someone seeing it should immediately understand the concept.
+
+## Input
+
+You receive:
+- **Block 1 text**: Key Insights card content
+- **Block 2 text**: Action Items card content
+- **Focus**: Which tools the tip covers ("All Tools", "Claude Code", "Copilot CLI", "VSCode Chat", etc.)
+
+## Output Format
+
+Return EXACTLY this markdown structure:
+
+```markdown
+## Demo Plan
+
+### Focus
+<which tools to show — derived from tip focus>
+
+### Scene Layout
+- panels: <comma-separated: terminal, chat>
+- terminal_count: <1-3>
+- chat_visible: <true/false>
+
+### Actions
+<numbered list — each action is ONE tool call>
+The execution order is ALWAYS: Copilot CLI first, then Claude Code, then VS Code Chat.
+All prompts are typed first, then a single wait at the end for all to respond.
+
+1. open_copilot_cli
+2. wait: 5
+3. clear_input
+4. type: "<prompt for Copilot CLI>" | enter: true
+5. focus_terminal
+6. new_terminal
+7. wait: 1
+8. type: "claude" | enter: true
+9. wait: 12
+10. type: "<prompt for Claude Code>" | enter: true
+11. new_chat
+12. type: "<prompt for VS Code Chat>" | enter: true
+
+### Final Wait
+<seconds — single wait for ALL tools to finish responding, typically 30s>
+```
+
+## Rules
+
+1. **Prompts must be realistic and relevant** to the tip topic. If the tip is about hooks, the Claude Code prompt should ask about hooks. If about agents, ask about agents.
+
+2. **Prompts should produce visual output** — prefer prompts that generate lists, tables, or structured responses (not one-line answers). Good: "Show me all available agents", "List the hook events and what they do". Bad: "What is a hook?" (might produce a wall of text).
+
+3. **Keep prompts SHORT** (under 80 chars) — they need to be readable in a terminal screenshot at normal zoom.
+
+4. **Match the focus**:
+   - "All Tools" → show all 3 (Claude Code + Copilot CLI + VS Code Chat)
+   - "Claude Code" → show Claude Code prominently, optionally one more
+   - "Copilot CLI" → show Copilot CLI prominently, optionally one more
+   - "VSCode Chat" → show VS Code Chat prominently, optionally one more
+   - If focus mentions multiple specific tools, show those
+
+5. **Claude Code prompts**: Can use slash commands (`/agents`, `/help`, `/model`) or natural language. Slash commands produce clean, structured output — prefer them when relevant.
+
+6. **Copilot CLI prompts**: Can use `/agents`, `/model`, `/fleet`, or natural language. Similar slash commands available.
+
+7. **VS Code Chat prompts**: Use `@workspace` prefix for codebase questions. Can reference files with `#file:`. Agent mode is default.
+
+8. **Wait times**:
+   - After launching claude/copilot: 12s (init + MCP)
+   - After short prompts (slash commands): 8-12s
+   - After natural language prompts: 20-30s
+   - Final wait before screenshot: 10-15s extra buffer
+
+9. **Use WebSearch if needed** to understand what a specific UI or command output looks like, so you can pick the most visually interesting prompt.
+
+## Examples
+
+### Tip about "What is a Skill?" (All Tools)
+```
+### Actions
+1. open_copilot_cli
+2. wait: 5
+3. clear_input
+4. type: "Show me the skill catalog" | enter: true
+5. new_terminal
+6. wait: 1
+7. type: "claude" | enter: true
+8. wait: 12
+9. type: "List all available skills from installed plugins" | enter: true
+10. new_chat
+11. type: "@workspace What skills are available?" | enter: true
+
+### Final Wait
+30
+```
+
+### Tip about "Hooks: Event-Driven Automation" (Claude Code focus)
+```
+### Actions
+1. new_terminal
+2. wait: 1
+3. type: "claude" | enter: true
+4. wait: 12
+5. type: "Show me the hook events in this project" | enter: true
+
+### Final Wait
+25
+```

--- a/.claude/skills/demo-vscode/SKILL.md
+++ b/.claude/skills/demo-vscode/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: demo-vscode
+description: "Capture 3 screenshots for a tip page — two card captures from the website + a VS Code demo. Trigger: /demo-vscode <tip-url>"
+argument-hint: "<tip-page-url>"
+model: opus
+allowed-tools: Read, Write, Glob, Grep, Agent, ToolSearch, WebFetch,
+  mcp__chrome-devtools-mcp__navigate_page,
+  mcp__chrome-devtools-mcp__take_snapshot,
+  mcp__chrome-devtools-mcp__take_screenshot,
+  mcp__chrome-devtools-mcp__evaluate_script,
+  mcp__chrome-devtools-mcp__emulate,
+  mcp__chrome-devtools-mcp__wait_for,
+  mcp__vscode-automator__vscode_focus,
+  mcp__vscode-automator__vscode_screenshot,
+  mcp__vscode-automator__vscode_type,
+  mcp__vscode-automator__vscode_keystroke,
+  mcp__vscode-automator__vscode_new_terminal,
+  mcp__vscode-automator__vscode_open_panel,
+  mcp__vscode-automator__vscode_command,
+  mcp__vscode-automator__vscode_wait
+---
+
+## IMPORTANT: VS Code Ownership
+
+**Before starting, tell the user:**
+
+> This skill will take full control of your VS Code window for screenshot capture.
+> Do NOT interact with VS Code while this is running — any clicks or keystrokes will break the automation.
+> Work in a different app (browser, other terminal) while this runs.
+
+## Goal
+
+Produce 3 screenshot images for a developer tip page, ready to share on Slack:
+1. **Insights card** — Key Insights block from the tip page
+2. **Actions card** — Action Items block from the tip page
+3. **VS Code demo** — Live demonstration of the tip concept in VS Code
+
+## Flow
+
+```dot
+digraph demo_vscode {
+  "Parse URL & derive slug" [shape=box];
+  "Navigate to tip page" [shape=box];
+  "Wait for page load" [shape=box];
+  "Extract block text" [shape=box];
+  "Screenshot block 1" [shape=box];
+  "Screenshot block 2" [shape=box];
+  "Spawn demo-planner" [shape=box];
+  "Plan valid?" [shape=diamond];
+  "Execute VS Code demo" [shape=box];
+  "Screenshot VS Code" [shape=box];
+  "Report" [shape=doublecircle];
+
+  "Parse URL & derive slug" -> "Navigate to tip page";
+  "Navigate to tip page" -> "Wait for page load";
+  "Wait for page load" -> "Extract block text";
+  "Extract block text" -> "Screenshot block 1";
+  "Screenshot block 1" -> "Screenshot block 2";
+  "Screenshot block 2" -> "Spawn demo-planner";
+  "Spawn demo-planner" -> "Plan valid?";
+  "Plan valid?" -> "Execute VS Code demo" [label="yes"];
+  "Plan valid?" -> "Spawn demo-planner" [label="retry (max 2)"];
+  "Execute VS Code demo" -> "Screenshot VS Code";
+  "Screenshot VS Code" -> "Report";
+}
+```
+
+## Node Details
+
+### Parse URL & derive slug
+
+Extract the slug from the URL path. Example:
+- URL: `https://easingthemes.github.io/dx-aem-flow/learn/tldr/the-three-tools-you-need-to-know/`
+- Slug: `the-three-tools-you-need-to-know`
+
+Create output directory: `tools/screenshots/<slug>/`
+
+### Navigate to tip page
+
+```
+mcp__chrome-devtools-mcp__navigate_page(type: "url", url: "<tip-url>")
+```
+
+### Wait for page load
+
+Wait for the tip blocks to render:
+
+```
+mcp__chrome-devtools-mcp__wait_for(
+  selector: ".tip-block",
+  state: "visible",
+  timeout: 10000
+)
+```
+
+### Extract block text
+
+Use `evaluate_script` to get the text content from both tip blocks. Both cards have the `tip-block` class — first is insights, second is actions.
+
+```
+mcp__chrome-devtools-mcp__evaluate_script(
+  function: "() => {
+    const blocks = document.querySelectorAll('.tip-block');
+    return {
+      insights: blocks[0]?.innerText || '',
+      actions: blocks[1]?.innerText || '',
+      focus: blocks[0]?.querySelector('[class*=bg-cyan]')?.innerText || 'All Tools'
+    };
+  }"
+)
+```
+
+Save the extracted text — it becomes the input for the planner.
+
+### Screenshot block 1
+
+Inject ARIA attributes so `.tip-block` divs appear in the a11y tree with UIDs:
+
+```
+mcp__chrome-devtools-mcp__evaluate_script(
+  function: "() => {
+    const blocks = document.querySelectorAll('.tip-block');
+    blocks[0]?.setAttribute('role', 'region');
+    blocks[0]?.setAttribute('aria-label', 'tip-insights');
+    blocks[1]?.setAttribute('role', 'region');
+    blocks[1]?.setAttribute('aria-label', 'tip-actions');
+    return blocks.length;
+  }"
+)
+```
+
+Take a snapshot to get UIDs — look for `region "tip-insights"` and `region "tip-actions"`:
+
+```
+mcp__chrome-devtools-mcp__take_snapshot()
+```
+
+Screenshot each block by UID:
+
+```
+mcp__chrome-devtools-mcp__take_screenshot(
+  uid: "<tip-insights-uid>",
+  filePath: "tools/screenshots/<slug>/<slug>-insights.png"
+)
+```
+
+### Screenshot block 2
+
+```
+mcp__chrome-devtools-mcp__take_screenshot(
+  uid: "<tip-actions-uid>",
+  filePath: "tools/screenshots/<slug>/<slug>-actions.png"
+)
+```
+
+### Spawn demo-planner
+
+Spawn the `demo-planner` agent with the extracted block text:
+
+```
+Agent(
+  subagent_type: "demo-planner",
+  prompt: "Plan a VS Code demo for this tip.
+
+Block 1 (Key Insights):
+<insights text>
+
+Block 2 (Action Items):
+<actions text>
+
+Focus: <focus value>
+
+Return the demo plan in the specified format."
+)
+```
+
+### Plan valid?
+
+The planner returns a structured plan. Validate:
+- Has at least 1 action
+- Every `type:` action has `enter: true`
+- Wait times are reasonable (1-30s each, total under 120s)
+- Prompts are under 80 chars
+- At least one tool matches the focus
+
+If invalid, retry with feedback (max 2 retries).
+
+### Execute VS Code demo
+
+Execute the plan actions sequentially using vscode-automator MCP tools.
+
+#### VS Code Layout
+
+VS Code has two distinct areas for running AI tools:
+- **Terminal Panel** (bottom) — standard integrated terminal. Claude Code runs here.
+- **Editor Area** (top/main) — where files and editor tabs live. Copilot CLI opens here via Command Palette.
+- **Chat Panel** (side panel) — VS Code Chat / Copilot Chat. Separate from both terminal and editor.
+
+#### Verified Execution Sequence
+
+**CRITICAL RULES:**
+- `type` and `keystroke(enter)` must be back-to-back — NO intervening tool calls
+- Always wait 1s after focus switch before typing (AppleScript race condition)
+- Each tool needs a FRESH session — don't reuse existing ones
+- Clear input before typing: `Ctrl+E` → `Ctrl+U` (readline fields only, NOT VS Code Chat)
+
+#### Step-by-step (order matters):
+
+```
+ 1. vscode_focus()
+
+ 2. vscode_command("Chat: New CLI Session to the Side")     → fresh Copilot CLI in Editor Area
+ 3. wait 5s (Copilot CLI init)
+ 4. Ctrl+E → Ctrl+U                                         → clear any leftover input
+ 5. type "<copilot prompt>" + enter                          → Copilot CLI working
+
+ 6. vscode_new_terminal()                                    → fresh terminal
+ 7. wait 1s
+ 8. type "claude" + enter                                    → Claude Code launching
+ 9. wait 12s (init + MCP servers)
+10. type "<claude prompt>" + enter                           → Claude Code working
+
+11. Cmd+Shift+I                                              → focus VS Code Chat
+12. wait 1s
+13. Cmd+N                                                    → NEW chat session (clean input)
+14. wait 1s
+15. type "<chat prompt>" + enter                             → Chat working
+
+16. wait 30s                                                 → ALL THREE respond in parallel
+17. vscode_screenshot
+```
+
+#### Focus Switching (for additional prompts after initial setup)
+
+| Tool | Focus command | Wait | Clear input |
+|------|-------------|------|-------------|
+| **Copilot CLI** | `vscode_command("View: Focus First Editor Group")` | 1s | `Ctrl+E` → `Ctrl+U` |
+| **Claude Code** | `vscode_keystroke(key: "\`", modifiers: ["control"])` | 1s | `Ctrl+E` → `Ctrl+U` |
+| **VS Code Chat** | `vscode_keystroke(key: "i", modifiers: ["command", "shift"])` | 1s | `Cmd+N` (new chat, not clear) |
+
+#### Action Mapping (from planner output)
+
+| Plan action | MCP calls |
+|-------------|-----------|
+| `open_copilot_cli` | `vscode_command("Chat: New CLI Session to the Side")` |
+| `new_terminal` | `vscode_new_terminal()` |
+| `new_chat` | `Cmd+Shift+I` → wait 1s → `Cmd+N` → wait 1s |
+| `focus_copilot` | `vscode_command("View: Focus First Editor Group")` → wait 1s |
+| `focus_terminal` | `Ctrl+backtick` → wait 1s |
+| `focus_chat` | `Cmd+Shift+I` → wait 1s |
+| `clear_input` | `Ctrl+E` → `Ctrl+U` (terminal/CLI only) |
+| `type: "text" \| enter: true` | `vscode_type(text)` then IMMEDIATELY `vscode_keystroke(key: "enter")` |
+| `wait: N` | `vscode_wait(seconds: N)` |
+
+After all actions + final wait from the plan:
+- Proceed to screenshot
+
+### Screenshot VS Code
+
+```
+mcp__vscode-automator__vscode_screenshot(
+  output_path: "tools/screenshots/<slug>/<slug>-demo.png"
+)
+```
+
+### Report
+
+Print a summary with the 3 image paths:
+
+```
+## Screenshots Ready
+
+| Image | Path |
+|-------|------|
+| Insights card | `tools/screenshots/<slug>/<slug>-insights.png` |
+| Actions card | `tools/screenshots/<slug>/<slug>-actions.png` |
+| VS Code demo | `tools/screenshots/<slug>/<slug>-demo.png` |
+
+Ready to share on Slack.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ node_modules/
 # Claude Code local state
 .claude/settings.local.json
 .claude/subagent-log.txt
-.claude/skills/demo-vscode/
-.claude/agents/
 
 # Website build artifacts
 website/dist/
@@ -38,4 +36,4 @@ docs/brainstorming/
 docs/todo
 .mcp.json
 logo.JPG
-tools/
+tools/screenshots/

--- a/plugins/dx-core/skills/dx-sync/scripts/sync-consumers.sh
+++ b/plugins/dx-core/skills/dx-sync/scripts/sync-consumers.sh
@@ -909,7 +909,7 @@ else
     # Use worktree for git operations, original path for --no-git mode
     WORK_PATH="$C_PATH"
     WT_PATH="/tmp/dx-sync-$(basename "$C_PATH")"
-    local wt_marker="/tmp/dx-sync-wtpath-$(basename "$C_PATH")"
+    wt_marker="/tmp/dx-sync-wtpath-$(basename "$C_PATH")"
 
     if ! $NO_GIT; then
       rm -f "$wt_marker"

--- a/tools/vscode-automator/package-lock.json
+++ b/tools/vscode-automator/package-lock.json
@@ -1,0 +1,1142 @@
+{
+  "name": "vscode-automator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-automator",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/tools/vscode-automator/package.json
+++ b/tools/vscode-automator/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vscode-automator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  }
+}

--- a/tools/vscode-automator/server.mjs
+++ b/tools/vscode-automator/server.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+
+/**
+ * VS Code Automator — Locked-down MCP server for VS Code screenshot automation.
+ *
+ * Only exposes specific, hardcoded AppleScript operations for:
+ * - Focusing VS Code
+ * - Opening/switching panels (terminal, chat, explorer)
+ * - Typing text into the active element
+ * - Sending keystrokes (Enter, Tab, Escape, etc.)
+ * - Taking screenshots of the VS Code window
+ * - Waiting for a specified duration
+ *
+ * NO arbitrary script execution. Every operation maps to a fixed AppleScript snippet.
+ *
+ * Usage:
+ *   node server.mjs                    # stdio MCP server
+ *
+ * Requires macOS Accessibility permission for the hosting terminal app.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { z } from 'zod';
+
+const exec = promisify(execFile);
+
+// ── AppleScript snippets (hardcoded, no user input in script body) ──────
+
+const SCRIPTS = {
+  focus: `
+    tell application "Visual Studio Code"
+      activate
+    end tell
+    delay 0.5
+  `,
+
+  panels: {
+    terminal: 'tell application "System Events" to keystroke "`" using {control down}',
+    chat: 'tell application "System Events" to keystroke "i" using {control down, shift down}',
+    explorer: 'tell application "System Events" to keystroke "b" using {command down}',
+    problems: 'tell application "System Events" to keystroke "m" using {command down, shift down}',
+    output: 'tell application "System Events" to keystroke "u" using {command down, shift down}',
+    'command-palette': 'tell application "System Events" to keystroke "p" using {command down, shift down}',
+  },
+
+  newTerminal: `
+    tell application "System Events"
+      keystroke "\`" using {control down, shift down}
+    end tell
+  `,
+
+  screenshot: (outputPath) => {
+    const safePath = outputPath.replace(/'/g, "'\\''");
+    // Get CGWindowID via Swift/CoreGraphics (no Python dependency), then screencapture -l
+    return `do shell script "winid=$(swift -e 'import CoreGraphics; let ws = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String:Any]] ?? []; for w in ws { if (w[kCGWindowOwnerName as String] as? String) == " & quote & "Code" & quote & ", let n = w[kCGWindowNumber as String] as? Int, (w[kCGWindowLayer as String] as? Int) == 0 { print(n); break } }'); screencapture -l $winid -o '${safePath}'"`;
+  },
+};
+
+// ── Allowed keystrokes (whitelist) ──────────────────────────────────────
+
+const ALLOWED_KEYS = {
+  'return': 'return',
+  'enter': 'return',
+  'tab': 'tab',
+  'escape': 'escape',
+  'space': 'space',
+  'delete': 'delete',
+  'up': 'up arrow',
+  'down': 'down arrow',
+  'left': 'left arrow',
+  'right': 'right arrow',
+};
+
+const ALLOWED_MODIFIERS = ['command', 'control', 'shift', 'option'];
+
+// ── Safe text sanitization ─────────────────────────────────────────────
+
+function sanitizeForAppleScript(text) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\r\n\t\0]/g, ' ');
+}
+
+// ── Execute a fixed AppleScript snippet ────────────────────────────────
+
+async function runAppleScript(script, timeoutMs = 10000) {
+  try {
+    const { stdout } = await exec('osascript', ['-e', script], {
+      timeout: timeoutMs,
+    });
+    return stdout.trim();
+  } catch (err) {
+    throw new Error(`AppleScript failed: ${err.message}`);
+  }
+}
+
+// ── Server setup ──────────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: 'vscode-automator',
+  version: '1.0.0',
+});
+
+// ── Tool: vscode_focus ────────────────────────────────────────────────
+
+server.tool(
+  'vscode_focus',
+  'Focus the VS Code window and bring it to front.',
+  {},
+  async () => {
+    await runAppleScript(SCRIPTS.focus);
+    return { content: [{ type: 'text', text: 'VS Code focused.' }] };
+  }
+);
+
+// ── Tool: vscode_open_panel ──────────────────────────────────────────
+
+server.tool(
+  'vscode_open_panel',
+  'Open a VS Code panel using keyboard shortcut. Available panels: terminal, chat, explorer, problems, output, command-palette.',
+  {
+    panel: z.enum(['terminal', 'chat', 'explorer', 'problems', 'output', 'command-palette']).describe('Which panel to open/toggle.'),
+  },
+  async ({ panel }) => {
+    const script = SCRIPTS.panels[panel];
+    if (!script) throw new Error(`Unknown panel: ${panel}`);
+    await runAppleScript(SCRIPTS.focus);
+    await runAppleScript(script);
+    return { content: [{ type: 'text', text: `Panel "${panel}" toggled.` }] };
+  }
+);
+
+// ── Tool: vscode_new_terminal ────────────────────────────────────────
+
+server.tool(
+  'vscode_new_terminal',
+  'Open a new terminal tab in VS Code.',
+  {},
+  async () => {
+    await runAppleScript(SCRIPTS.focus);
+    await runAppleScript(SCRIPTS.newTerminal);
+    return { content: [{ type: 'text', text: 'New terminal opened.' }] };
+  }
+);
+
+// ── Tool: vscode_type ────────────────────────────────────────────────
+
+server.tool(
+  'vscode_type',
+  'Type text into the currently focused element in VS Code. Does NOT press Enter after — use vscode_keystroke for that.',
+  {
+    text: z.string().max(500).describe('Text to type. Max 500 characters.'),
+    delay_between_chars: z.number().min(0).max(1).optional().describe('Delay between characters in seconds (default 0.02).'),
+  },
+  async ({ text, delay_between_chars }) => {
+    if (!text) throw new Error('Text must be 1-500 characters.');
+    const delay = delay_between_chars ?? 0.02;
+    const safeText = sanitizeForAppleScript(text);
+    const script = `
+      tell application "System Events"
+        set textToType to "${safeText}"
+        repeat with c in (characters of textToType)
+          keystroke c
+          delay ${Math.min(Math.max(delay, 0), 1)}
+        end repeat
+      end tell
+    `;
+    await runAppleScript(script, 30000);
+    return { content: [{ type: 'text', text: `Typed ${text.length} characters.` }] };
+  }
+);
+
+// ── Tool: vscode_keystroke ───────────────────────────────────────────
+
+server.tool(
+  'vscode_keystroke',
+  'Send a keyboard shortcut or special key to VS Code. Special keys: return/enter, tab, escape, space, delete, up, down, left, right. With modifiers, any single character key is allowed (e.g., key:"i" modifiers:["control","command"] for Ctrl+Cmd+I). Modifiers: command, control, shift, option.',
+  {
+    key: z.string().max(20).describe('The key to press. Special keys: return, enter, tab, escape, space, delete, up, down, left, right. Or any single character (a-z, 0-9, backtick, etc.) when used with modifiers.'),
+    modifiers: z.array(z.enum(['command', 'control', 'shift', 'option'])).optional().describe('Modifier keys to hold (optional). Required when using character keys.'),
+  },
+  async ({ key, modifiers }) => {
+    const modStr = (modifiers || [])
+      .filter(m => ALLOWED_MODIFIERS.includes(m))
+      .map(m => `${m} down`)
+      .join(', ');
+
+    const specialKeyCodes = {
+      'return': 36, 'enter': 36, 'tab': 48, 'escape': 53, 'space': 49, 'delete': 51,
+      'up': 126, 'down': 125, 'left': 123, 'right': 124,
+      'up arrow': 126, 'down arrow': 125, 'left arrow': 123, 'right arrow': 124,
+    };
+
+    const isSpecialKey = key.toLowerCase() in specialKeyCodes || key.toLowerCase() in ALLOWED_KEYS;
+    const isSingleChar = key.length === 1;
+
+    // Single character keys require modifiers (safety: prevents arbitrary typing via keystroke)
+    if (!isSpecialKey && isSingleChar && !modStr) {
+      throw new Error(`Character key "${key}" requires at least one modifier. Use vscode_type for plain text.`);
+    }
+    if (!isSpecialKey && !isSingleChar) {
+      throw new Error(`Key "${key}" not recognized. Use special key names or a single character with modifiers.`);
+    }
+
+    let script;
+    if (isSingleChar && !isSpecialKey && modStr) {
+      // Character key with modifiers (e.g., Cmd+Shift+P, Ctrl+Cmd+I)
+      const safeChar = sanitizeForAppleScript(key);
+      script = `tell application "System Events" to keystroke "${safeChar}" using {${modStr}}`;
+    } else {
+      const keyName = ALLOWED_KEYS[key.toLowerCase()] || key.toLowerCase();
+      const keyCode = specialKeyCodes[keyName] || specialKeyCodes[key.toLowerCase()];
+      if (keyCode === undefined) throw new Error(`Key "${key}" not found in key code map.`);
+
+      if (modStr) {
+        script = `tell application "System Events" to key code ${keyCode} using {${modStr}}`;
+      } else if (keyName === 'return') {
+        script = 'tell application "System Events" to keystroke return';
+      } else if (keyName === 'tab') {
+        script = 'tell application "System Events" to keystroke tab';
+      } else if (keyName === 'escape') {
+        script = 'tell application "System Events" to key code 53';
+      } else if (keyName === 'space') {
+        script = 'tell application "System Events" to keystroke space';
+      } else if (keyName === 'delete') {
+        script = 'tell application "System Events" to key code 51';
+      } else {
+        script = `tell application "System Events" to key code ${keyCode}`;
+      }
+    }
+
+    await runAppleScript(script);
+    return { content: [{ type: 'text', text: `Pressed ${key}${modStr ? ` with ${modifiers.join('+')}` : ''}.` }] };
+  }
+);
+
+// ── Tool: vscode_command ────────────────────────────────────────────
+
+server.tool(
+  'vscode_command',
+  'Run a VS Code command via the Command Palette. Opens Cmd+Shift+P, types the command name, and presses Enter. Atomic operation — no focus loss between steps. Examples: "Chat: New CLI Session to the Side", "Terminal: Create New Terminal in Editor Area".',
+  {
+    command: z.string().max(200).describe('The VS Code command to run (as it appears in Command Palette).'),
+  },
+  async ({ command }) => {
+    // Open Command Palette
+    await runAppleScript('tell application "System Events" to keystroke "p" using {command down, shift down}');
+    await new Promise(r => setTimeout(r, 500));
+
+    // Type command name
+    const safeCommand = sanitizeForAppleScript(command);
+    await runAppleScript(`
+      tell application "System Events"
+        keystroke "${safeCommand}"
+      end tell
+    `);
+    await new Promise(r => setTimeout(r, 800));
+
+    // Execute
+    await runAppleScript('tell application "System Events" to keystroke return');
+
+    return { content: [{ type: 'text', text: `Executed VS Code command: ${command}` }] };
+  }
+);
+
+// ── Tool: vscode_screenshot ──────────────────────────────────────────
+
+server.tool(
+  'vscode_screenshot',
+  'Take a screenshot of the VS Code window and save to a file.',
+  {
+    output_path: z.string().optional().describe('File path for the screenshot (PNG). Must be under tools/. Defaults to tools/screenshots/vscode-screenshot-<timestamp>.png.'),
+  },
+  async ({ output_path }) => {
+    const outputPath = output_path || join(
+      'tools', 'screenshots',
+      `vscode-screenshot-${Date.now()}.png`
+    );
+
+    const resolvedPath = resolve(outputPath);
+    const allowedPrefixes = [
+      join(process.cwd(), 'tools'),
+    ];
+    const isAllowed = allowedPrefixes.some(prefix => resolvedPath.startsWith(prefix));
+    if (!isAllowed) {
+      throw new Error(`Screenshot path must be under tools/. Got: ${outputPath}`);
+    }
+
+    await runAppleScript(SCRIPTS.focus);
+    await new Promise(r => setTimeout(r, 300));
+    await runAppleScript(SCRIPTS.screenshot(resolvedPath));
+    return { content: [{ type: 'text', text: `Screenshot saved to ${resolvedPath}` }] };
+  }
+);
+
+// ── Tool: vscode_wait ────────────────────────────────────────────────
+
+server.tool(
+  'vscode_wait',
+  'Wait for a specified number of seconds. Use to let VS Code respond before taking a screenshot.',
+  {
+    seconds: z.number().min(1).max(120).describe('Seconds to wait (1-120).'),
+  },
+  async ({ seconds }) => {
+    const secs = Math.min(Math.max(seconds || 5, 1), 120);
+    await new Promise(r => setTimeout(r, secs * 1000));
+    return { content: [{ type: 'text', text: `Waited ${secs} seconds.` }] };
+  }
+);
+
+// ── Tool: vscode_click_tab ───────────────────────────────────────────
+
+server.tool(
+  'vscode_click_tab',
+  'Click on a specific terminal tab by name in VS Code terminal panel. Uses accessibility API to find and click the tab.',
+  {
+    tab_name: z.string().describe('Name of the terminal tab to click (e.g., "Claude Code", "bash", "Copilot").'),
+  },
+  async ({ tab_name }) => {
+    const tabName = sanitizeForAppleScript(tab_name);
+    const script = `
+      tell application "System Events"
+        tell process "Code"
+          set tabButtons to every radio button of every tab group of every group of every group of front window
+          repeat with btn in (a reference to every radio button of every tab group of every group of every group of front window)
+            try
+              if name of btn contains "${tabName}" then
+                click btn
+                return "clicked"
+              end if
+            end try
+          end repeat
+        end tell
+      end tell
+      return "not found"
+    `;
+    const result = await runAppleScript(script, 10000);
+    if (result === 'not found') {
+      return { content: [{ type: 'text', text: `Terminal tab "${tab_name}" not found. Try exact name from the terminal tab bar.` }] };
+    }
+    return { content: [{ type: 'text', text: `Clicked terminal tab "${tab_name}".` }] };
+  }
+);
+
+// ── Start server ─────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+console.error('vscode-automator MCP server started (stdio)');


### PR DESCRIPTION
## Summary

- **VS Code Automator MCP server** (`tools/vscode-automator/`) — locked-down AppleScript-based automation for VS Code screenshot capture. 10 tools: focus, type, keystroke (with modifier keys), Command Palette execution, screenshot, terminal management, and wait.
- **demo-vscode skill** (`.claude/skills/demo-vscode/`) — coordinator that captures 3 screenshots per tip page: two card captures via Chrome DevTools MCP + one VS Code demo showing AI tools in action.
- **demo-planner agent** (`.claude/agents/demo-planner.md`) — plans realistic VS Code demo scenes based on tip card content.
- **Security**: no arbitrary script execution, path-restricted screenshots, AppleScript injection prevention (control char stripping), input sanitization.

## Test plan
- [ ] Run `/mcp` to connect vscode-automator server
- [ ] Test `vscode_focus`, `vscode_type`, `vscode_keystroke` with modifiers
- [ ] Test `vscode_command` with Command Palette commands
- [ ] Test `vscode_screenshot` with relative path
- [ ] Test full 3-zone layout: Copilot CLI (editor) + Claude Code (terminal) + VS Code Chat (side panel)
- [ ] Run `/demo-vscode <tip-url>` end-to-end