### PR TITLE
feat: shift messaging to enterprise, multi-platform, and AEM full-flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@
 [![semantic-release](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Four plugins for AI-assisted software development: requirements-to-PR workflow for ADO/Jira projects, multi-repo orchestration, AEM component tooling and QA, and autonomous CI agents. Runs locally and in pipelines. Supports Claude Code, Copilot CLI, and VS Code Chat.
+Enterprise AI development platform for teams shipping on Azure DevOps and Atlassian. 70+ skills that run identically across **Claude Code**, **GitHub Copilot CLI**, and **VS Code Chat** — from ticket to PR, fully autonomous. Deep AEM specialization built in.
 
 ## Why This Exists
 
-AI coding assistants are powerful, but without structure they produce inconsistent results. You end up re-explaining your project, your conventions, and your workflow every session.
+Enterprise development teams need more than AI code completion. They need governance — DoR validation before work starts, 6-phase verification before code merges, autonomous PR review that enforces standards 24/7. They need consistency across repos, across IDEs, across team members. And they need it without re-explaining the project every session.
 
-KAI is a structured development workflow built as a plugin system. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines. A single command like `/dx-req-all` pulls the ticket from ADO/Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically. You run a skill, then refine with simple follow-ups — the agent already has the full picture.
+KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines across every major AI platform. A single command like `/dx-req-all` pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
 
 **What makes it different:**
+- **Every AI platform** — same 70+ skills work identically in Claude Code, GitHub Copilot CLI, and VS Code Chat. Same plugins, same config, same results — regardless of which IDE your team uses.
+- **Enterprise governance** — DoR validation, 6-phase verification gate (compile, lint, test, secret scan, architecture review, AI code review), autonomous PR review, and branch protection. Ship with confidence.
+- **AEM full-flow** — the deepest AI-powered AEM tooling available. Figma → component → dialog inspection → JCR content → editorial QA → browser automation → demo capture. The complete AEM development lifecycle.
 - **Config-driven, not prompt-driven** — your build commands, branch names, and conventions live in one config file. Every skill reads it. No hardcoded values, no repeated instructions.
 - **Persistent memory between steps** — each skill writes structured output to local files. The next skill picks it up automatically. Sessions can end and resume without losing context.
-- **Multi-source context** — skills don't just read source code. They pull ADO/Jira tickets, Figma designs, AEM content, and browser screenshots through MCP integrations.
 - **Autonomous mode** — the same skills that run locally also run unattended as ADO pipeline agents, triggered by webhooks. Tag a ticket, get a verified bugfix with a PR.
-- **[Superpowers](https://github.com/obra/superpowers) integration** — 6 skills optionally invoke superpowers methodology (brainstorming, TDD, systematic debugging, verification) when installed, with inline fallback when it's not.
 
 ## Install
 
@@ -57,9 +58,9 @@ Hub directory management for coordinating work across multiple consumer repos �
 
 **3 skills.**
 
-### [dx-aem](plugins/dx-aem/) — AEM Component Tools
+### [dx-aem](plugins/dx-aem/) — AEM Full-Flow
 
-AEM-specific tools: component dialog inspection, page search, snapshot/verify lifecycle, QA automation, and demo capture.
+The complete AEM development lifecycle: component dialog inspection, JCR content, page authoring, editorial QA with browser automation, snapshot/verify lifecycle, and demo capture. The deepest AI-powered AEM tooling available.
 
 **12 skills, 6 agents.** Requires dx plugin.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Enterprise AI development platform for teams shipping on Azure DevOps and Atlass
 
 ## Why This Exists
 
-Enterprise development teams need more than AI code completion. They need governance — DoR validation before work starts, 6-phase verification before code merges, autonomous PR review that enforces standards 24/7. They need consistency across repos, across IDEs, across team members. And they need it without re-explaining the project every session.
+Enterprise development teams need more than AI code completion. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Consistent across repos, across IDEs, across team members. And without re-explaining the project every session.
 
 KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines across every major AI platform. A single command like `/dx-req-all` pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Enterprise AI development platform for teams shipping on Azure DevOps and Atlass
 
 ## Why This Exists
 
-Enterprise development teams need more than AI code completion. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Consistent across repos, across IDEs, across team members. And without re-explaining the project every session.
+Enterprise teams run complex sprints across multiple repos, multiple IDEs, and multiple team members. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Without re-explaining the project every session.
 
 KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines across every major AI platform. A single command like `/dx-req-all` pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
 

--- a/docs/reference/agent-catalog.md
+++ b/docs/reference/agent-catalog.md
@@ -192,10 +192,10 @@ Finds all AEM pages using a given component. Searches configured content paths a
 |----------|-------|
 | **Model** | Sonnet |
 | **File** | `plugins/dx-aem/agents/aem-bug-executor.md` |
-| **Used by** | `/dx-bug-verify` (for AEM-specific bugs) |
+| **Used by** | `/dx-bug-verify` (for AEM bugs) |
 | **Tools** | Read, Write, Glob, Grep, ToolSearch, Chrome DevTools MCP, AEM MCP |
 
-AEM-specific bug verification agent. Navigates to affected AEM pages, follows reproduction steps, captures screenshot evidence, and optionally checks JCR state. Returns structured verification result with evidence table.
+AEM bug verification agent. Navigates to affected AEM pages, follows reproduction steps, captures screenshot evidence, and optionally checks JCR state. Returns structured verification result with evidence table.
 
 ---
 
@@ -418,7 +418,7 @@ Figma design-to-code coordinator. Chains `/dx-figma-extract` → `/dx-figma-prot
 
 ## Copilot Agents — aem plugin (10 agents)
 
-AEM Copilot agents are seeded into `.github/agents/` when Copilot support is enabled during `/aem-init`. They extend the DX agents with AEM-specific capabilities.
+AEM Copilot agents are seeded into `.github/agents/` when Copilot support is enabled during `/aem-init`. They provide the AEM full-flow lifecycle — component dialogs, JCR content, editorial QA, browser automation, and demo capture.
 
 ### AEMBefore
 

--- a/website/src/pages/architecture/cross-agent.mdx
+++ b/website/src/pages/architecture/cross-agent.mdx
@@ -14,7 +14,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
 <PageHero
   title="Cross-Agent Communication"
-  subtitle="How agents from different plugins interact across Claude Code and GitHub Copilot CLI. Single-source conventions, dual-platform skills, and unified hooks."
+  subtitle="How agents from different plugins interact across Claude Code, GitHub Copilot CLI, and VS Code Chat. Single-source conventions, multi-platform skills, and unified hooks."
 />
 
 <SectionHeading

--- a/website/src/pages/architecture/overview.mdx
+++ b/website/src/pages/architecture/overview.mdx
@@ -29,7 +29,7 @@ import HighlightBox from '../../components/HighlightBox.astro';
 {`dx-aem-flow/dx/plugins/
   dx-core/   ${stats.dxCoreSkills} skills, ${stats.dxCoreAgents} agents -- ADO/Jira workflow (any stack)
   dx-hub/              ${stats.dxHubSkills} skills -- multi-repo hub orchestration
-  dx-aem/              ${stats.dxAemSkills} skills, ${stats.dxAemAgents} agents -- AEM verification & QA
+  dx-aem/              ${stats.dxAemSkills} skills, ${stats.dxAemAgents} agents -- AEM full-flow lifecycle
   dx-automation/       ${stats.dxAutomationSkills} skills -- autonomous 24/7 agents`}
     </CommandBlock>
   </HighlightBox>
@@ -823,8 +823,8 @@ aem:
     <ContentCard icon="mdi:target" iconColor="bg-cyan" title="Model Tier Strategy" horizontal>
       Opus for deep code review. Sonnet for execution. Haiku for simple lookups. Cost scales with complexity, not volume.
     </ContentCard>
-    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-brand-700" title="Dual-IDE: Claude Code + GitHub Copilot" horizontal>
-      Skills written for Claude Code, auto-discovered by Copilot CLI. Agent templates generated for Copilot orchestration. Core workflows work in both IDEs.
+    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-brand-700" title="Every AI Platform" horizontal>
+      Same skills work across Claude Code, GitHub Copilot CLI, and VS Code Chat. Agent templates generated for Copilot orchestration. Install once, use everywhere.
     </ContentCard>
   </div>
 
@@ -843,7 +843,7 @@ aem:
       <li class="py-0.5"><strong>Persona system</strong> -- not in the guide; KAI's me.md makes AI output indistinguishable from human teammates</li>
       <li class="py-0.5"><strong>Hooks for LLM offloading</strong> -- the guide focuses on skill instructions; KAI uses shell hooks for deterministic work</li>
       <li class="py-0.5"><strong>24/7 autonomous agents</strong> -- the guide covers interactive use; KAI runs the same skills unattended on ADO pipelines</li>
-      <li class="py-0.5"><strong>Dual-IDE support</strong> -- same {stats.totalSkills} skills + shared marketplace work in both Claude Code and GitHub Copilot CLI</li>
+      <li class="py-0.5"><strong>Multi-platform support</strong> -- same {stats.totalSkills} skills + shared marketplace work across Claude Code, GitHub Copilot CLI, and VS Code Chat</li>
     </ul>
   </HighlightBox>
 

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -14,8 +14,8 @@ import { stats } from '../config/stats';
 export const base = import.meta.env.BASE_URL;
 
 <PageHero
-  title="AI-Powered Development Platform"
-  subtitle="AI plugin system that automates your sprint: fetch tickets, plan implementation, write code, review PRs, and create documentation. Works with Claude Code and GitHub Copilot CLI."
+  title="Enterprise AI Development Platform"
+  subtitle="For enterprise teams on Azure DevOps and Atlassian. 70+ skills that run identically across Claude Code, GitHub Copilot CLI, and VS Code Chat — from ticket to PR, fully autonomous. Deep AEM specialization built in."
 />
 
 <Section>
@@ -33,8 +33,8 @@ export const base = import.meta.env.BASE_URL;
       <div class="text-sm text-gray-500">Plugins</div>
     </div>
     <div>
-      <div class="text-4xl font-extrabold text-cyan">4</div>
-      <div class="text-sm text-gray-500">Repos Supported</div>
+      <div class="text-4xl font-extrabold text-cyan">3</div>
+      <div class="text-sm text-gray-500">AI Platforms</div>
     </div>
     <div>
       <div class="text-4xl font-extrabold text-cyan">13</div>
@@ -50,10 +50,10 @@ export const base = import.meta.env.BASE_URL;
 />
 <Section>
   <p class="text-sm text-gray-600 leading-relaxed">
-    AI coding assistants are powerful, but without structure they produce inconsistent results. You end up re-explaining your project, your conventions, and your workflow every session.
+    Enterprise development teams need more than AI code completion. They need governance — DoR validation before work starts, 6-phase verification before code merges, autonomous PR review that enforces standards 24/7. They need consistency across repos, across IDEs, across team members.
   </p>
   <p class="text-sm text-gray-600 leading-relaxed mt-3">
-    KAI is a structured development workflow built as a plugin system. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into <strong>skills</strong> that orchestrate multi-agent pipelines. A single command like <code>/dx-req</code> pulls the ticket from ADO/Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
+    KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into <strong>skills</strong> that orchestrate multi-agent pipelines across every major AI platform. A single command like <code>/dx-req</code> pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
   </p>
 
   <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
@@ -69,11 +69,11 @@ export const base = import.meta.env.BASE_URL;
     <ContentCard icon="mdi:lightning-bolt" iconColor="bg-red-500" title="Autonomous Mode" horizontal>
       The same skills that run locally also run unattended as ADO pipeline agents, triggered by webhooks. Tag a ticket, get a verified bugfix with a PR.
     </ContentCard>
-    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-emerald-600" title="Dual-IDE" horizontal>
-      Same {stats.totalSkills} skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
+    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-emerald-600" title="Every AI Platform" horizontal>
+      Same {stats.totalSkills} skills work in Claude Code, GitHub Copilot CLI, and VS Code Chat. Same plugins, same config — install once, use everywhere.
     </ContentCard>
-    <ContentCard icon="mdi:star" iconColor="bg-cyan-dark" title="Superpowers Integration" horizontal>
-      6 skills optionally invoke <a href="https://github.com/obra/superpowers" class="text-brand-700">superpowers</a> methodology (brainstorming, TDD, debugging, verification) when installed.
+    <ContentCard icon="mdi:shield-check" iconColor="bg-cyan-dark" title="Enterprise Governance" horizontal>
+      DoR validation, 6-phase verification gate, autonomous PR review, secret scanning, and branch protection. Ship with confidence.
     </ContentCard>
   </div>
 </Section>
@@ -102,7 +102,7 @@ export const base = import.meta.env.BASE_URL;
 <SectionHeading
   badge="Design-to-Code"
   title="Figma to Production Code"
-  subtitle="One command turns a Figma URL into a production AEM component that matches the design."
+  subtitle="One command turns a Figma URL into a production AEM component. The only AI platform with deep AEM knowledge — dialogs, JCR, OSGi, Sling models, all understood natively."
   bg="primary"
 />
 <Section>
@@ -167,7 +167,7 @@ export const base = import.meta.env.BASE_URL;
   badge="Plugins"
   badgeColor="success"
   title="Four Plugins, Independently Installable"
-  subtitle="Non-AEM projects only need dx. AEM-specific logic never pollutes a pure frontend project."
+  subtitle="Core workflow for any stack. AEM specialization for teams that need it — the deepest AI-powered AEM tooling available."
   bg="primary"
 />
 <Section>
@@ -176,7 +176,7 @@ export const base = import.meta.env.BASE_URL;
       Full development lifecycle -- requirements, planning, execution, review, PR, accessibility, documentation. Works with any stack.
     </ContentCard>
     <ContentCard icon="mdi:cube-outline" iconColor="bg-amber-500" title="dx-aem" tags={[{ label: `${stats.dxAemSkills} skills`, color: 'warning' }, { label: `${stats.dxAemAgents} agents`, color: 'secondary' }]}>
-      AEM-specific -- component verification, QA with browser automation, demo capture, project knowledge (seed data).
+      AEM full-flow -- component dialogs, JCR content, editorial QA, browser automation, demo capture. The complete AEM development lifecycle.
     </ContentCard>
     <ContentCard icon="mdi:lightning-bolt" iconColor="bg-red-500" title="dx-automation" tags={[{ label: `${stats.dxAutomationSkills} skills`, color: 'error' }]}>
       24/7 autonomous agents -- DoR, PR review, bug fix, DevAgent, QA, estimation. AWS Lambda + ADO pipelines.
@@ -187,7 +187,7 @@ export const base = import.meta.env.BASE_URL;
 <SectionHeading
   badge="Engineering"
   title="What Makes This Different"
-  subtitle="Built for real teams shipping real code."
+  subtitle="Built for enterprise development teams."
   bg="alt"
 />
 <Section>
@@ -201,8 +201,8 @@ export const base = import.meta.env.BASE_URL;
     <ContentCard icon="mdi:lightning-bolt" iconColor="bg-emerald-600" title="Direct Skill Invocation" horizontal>
       Coordinators invoke skills directly via Skill() calls. No intermediary agent needed. Self-healing with 3 layers: fix, heal, retry loop.
     </ContentCard>
-    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-brand-700" title="Dual-IDE Support" horizontal>
-      Same {stats.totalSkills} skills work in Claude Code and GitHub Copilot CLI. Same plugins, same marketplace — install once, use everywhere.
+    <ContentCard icon="mdi:hammer-wrench" iconColor="bg-brand-700" title="Every AI Platform" horizontal>
+      Same {stats.totalSkills} skills work in Claude Code, GitHub Copilot CLI, and VS Code Chat. Same plugins, same config — install once, use everywhere.
     </ContentCard>
     <ContentCard icon="mdi:target" iconColor="bg-cyan" title="Model Tier Strategy" horizontal>
       Opus for deep code review. Sonnet for execution. Haiku for simple lookups. Cost scales with complexity, not volume.

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -50,7 +50,7 @@ export const base = import.meta.env.BASE_URL;
 />
 <Section>
   <p class="text-sm text-gray-600 leading-relaxed">
-    Enterprise development teams need more than AI code completion. They need governance — DoR validation before work starts, 6-phase verification before code merges, autonomous PR review that enforces standards 24/7. They need consistency across repos, across IDEs, across team members.
+    Enterprise development teams need more than AI code completion. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Consistent across repos, across IDEs, across team members.
   </p>
   <p class="text-sm text-gray-600 leading-relaxed mt-3">
     KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into <strong>skills</strong> that orchestrate multi-agent pipelines across every major AI platform. A single command like <code>/dx-req</code> pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -50,7 +50,7 @@ export const base = import.meta.env.BASE_URL;
 />
 <Section>
   <p class="text-sm text-gray-600 leading-relaxed">
-    Enterprise development teams need more than AI code completion. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Consistent across repos, across IDEs, across team members.
+    Enterprise teams run complex sprints across multiple repos, multiple IDEs, and multiple team members. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step.
   </p>
   <p class="text-sm text-gray-600 leading-relaxed mt-3">
     KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into <strong>skills</strong> that orchestrate multi-agent pipelines across every major AI platform. A single command like <code>/dx-req</code> pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.

--- a/website/src/pages/learn/hooks.mdx
+++ b/website/src/pages/learn/hooks.mdx
@@ -118,7 +118,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
 
   <HighlightBox severity="success" title="What This Means for KAI">
     dx-core owns general hooks (branch guard, subagent log, Figma screenshots).
-    dx-aem now has its own <code>hooks.json</code> for AEM-specific hooks (Chrome DevTools screenshots).
+    dx-aem now has its own <code>hooks.json</code> for AEM full-flow hooks (Chrome DevTools screenshots, component inspection, editorial capture).
     Both plugins' hooks fire in the same session without conflict.
   </HighlightBox>
 </Section>

--- a/website/src/pages/learn/intro.mdx
+++ b/website/src/pages/learn/intro.mdx
@@ -14,7 +14,7 @@ import { stats } from '../../config/stats';
 
 <PageHero
   title="AI Crash Course"
-  subtitle="Everything you need to understand AI-assisted development in 15 minutes"
+  subtitle="Everything you need to understand enterprise AI-assisted development in 15 minutes. Same skills, same plugins — across Claude Code, GitHub Copilot CLI, and VS Code Chat."
 />
 
 <SectionHeading
@@ -204,8 +204,8 @@ import { stats } from '../../config/stats';
       title="dx-aem"
       tags={[{ label: `${stats.dxAemSkills} skills`, color: 'secondary' }, { label: `${stats.dxAemAgents} agents`, color: 'secondary' }]}
     >
-      AEM-specific -- component inspection, page verification, dialog analysis,
-      browser automation.
+      AEM full-flow -- component dialogs, JCR content, editorial QA,
+      browser automation, demo capture. The complete AEM development lifecycle.
     </ContentCard>
     <ContentCard
       icon="mdi:puzzle"

--- a/website/src/pages/reference/agents.mdx
+++ b/website/src/pages/reference/agents.mdx
@@ -134,7 +134,7 @@ import { stats } from '../../config/stats';
   badge="dx-aem"
   badgeColor="secondary"
   title="AEM Agents"
-  subtitle={`${stats.dxAemAgents} agents for AEM-specific operations`}
+  subtitle={`${stats.dxAemAgents} agents for the AEM full-flow lifecycle`}
   bg="alt"
 />
 <Section>
@@ -244,7 +244,7 @@ import { stats } from '../../config/stats';
   badge="Copilot CLI"
   badgeColor="warning"
   title="dx-aem Copilot Agents"
-  subtitle="10 agents extending DX with AEM-specific capabilities"
+  subtitle="10 agents for the AEM full-flow lifecycle"
   bg="alt"
 />
 <Section>

--- a/website/src/pages/reference/skills.mdx
+++ b/website/src/pages/reference/skills.mdx
@@ -30,7 +30,7 @@ import { stats } from '../../config/stats';
       Platform-agnostic ADO/Jira workflow: requirements, planning, execution, review, PR, bug fix, documentation, and utility.
     </ContentCard>
     <ContentCard icon="mdi:web" iconColor="bg-cyan-dark" title="dx-aem" tags={[{ label: `${stats.dxAemSkills} skills`, color: 'secondary' }]}>
-      AEM-specific verification, QA, documentation, and component reconnaissance.
+      AEM full-flow: component dialogs, JCR content, editorial QA, browser automation, demo capture, and documentation.
     </ContentCard>
     <ContentCard icon="mdi:cog" iconColor="bg-amber-500" title="dx-automation" tags={[{ label: `${stats.dxAutomationSkills} skills`, color: 'warning' }]}>
       Autonomous agent infrastructure: AWS Lambda, ADO pipelines, CloudWatch alarms.

--- a/website/src/pages/setup/index.mdx
+++ b/website/src/pages/setup/index.mdx
@@ -14,7 +14,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
 
 <PageHero
   title="Setup"
-  subtitle="Three steps to get dx running in your project. Works with Claude Code CLI and GitHub Copilot CLI."
+  subtitle="Three steps to get dx running in your project. Works with Claude Code, GitHub Copilot CLI, and VS Code Chat."
 />
 
 <Section>
@@ -41,7 +41,7 @@ import PipelineBlock from '../../components/PipelineBlock.astro';
   bg="primary"
 />
 <Section>
-  <CommandBlock label="Claude Code CLI or GitHub Copilot CLI">{`# Add marketplace (one-time)
+  <CommandBlock label="Claude Code, GitHub Copilot CLI, or VS Code Chat">{`# Add marketplace (one-time)
 /plugin marketplace add easingthemes/dx-aem-flow
 
 # Install plugins
@@ -89,7 +89,7 @@ export AEM_INSTANCES="local:http://localhost:4502:admin:admin"
 
   <div class="grid md:grid-cols-2 gap-4">
     <ContentCard icon="mdi:numeric-1-circle" iconColor="bg-brand-700" title="/dx-init">
-      Core initialization — creates <code>.ai/config.yaml</code>, convention rules, MCP config, agent templates, shared scripts. Interactive — asks about your ADO/Jira project, build commands, and base branch.
+      Core initialization — creates <code>.ai/config.yaml</code>, convention rules, MCP config, agent templates, shared scripts. Interactive — asks about your Azure DevOps or Jira project, build commands, and base branch.
       If it detects an AEM project, automatically runs <code>/aem-init</code> to append the <code>aem:</code> section, install BE/FE rules by project role, and auto-generate <code>component-index.md</code> via AEM MCP.
     </ContentCard>
     <ContentCard icon="mdi:numeric-2-circle" iconColor="bg-cyan" title="/dx-adapt">
@@ -117,7 +117,7 @@ export AEM_INSTANCES="local:http://localhost:4502:admin:admin"
         </tr>
       </thead>
       <tbody>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>.ai/config.yaml</code></td><td class="py-2 px-4">Project config (branches, ADO/Jira, build commands, AEM)</td><td class="py-2 px-4">dx-init + aem-init + dx-adapt</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>.ai/config.yaml</code></td><td class="py-2 px-4">Project config (branches, Azure DevOps/Jira, build commands, AEM)</td><td class="py-2 px-4">dx-init + aem-init + dx-adapt</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>.claude/rules/</code></td><td class="py-2 px-4">Convention rules (generic templates at this stage)</td><td class="py-2 px-4">dx-init + aem-init</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>.mcp.json</code></td><td class="py-2 px-4">MCP server configuration (ADO, Jira/Confluence, Figma, axe)</td><td class="py-2 px-4">dx-init</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>.github/agents/</code></td><td class="py-2 px-4">Copilot agent templates</td><td class="py-2 px-4">dx-init</td></tr>

--- a/website/src/pages/setup/scaffold.mdx
+++ b/website/src/pages/setup/scaffold.mdx
@@ -78,7 +78,7 @@ import CommandBlock from '../../components/CommandBlock.astro';
       </thead>
       <tbody>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--all</code></td><td class="py-2 px-4">Create everything: config, rules, templates, agents, docs, lib scripts</td></tr>
-        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--aem</code></td><td class="py-2 px-4">Include AEM-specific files (seed data, AEM rules, AEM agents)</td></tr>
+        <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--aem</code></td><td class="py-2 px-4">Include AEM full-flow files (seed data, AEM rules, AEM agents)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--copilot</code></td><td class="py-2 px-4">Include Copilot agent templates in .github/agents/</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--force</code></td><td class="py-2 px-4">Overwrite existing files (useful for upgrades)</td></tr>
         <tr class="border-b border-gray-100"><td class="py-2 px-4"><code>--quiet</code></td><td class="py-2 px-4">Suppress output (for CI/CD use)</td></tr>

--- a/website/src/pages/usage/local.mdx
+++ b/website/src/pages/usage/local.mdx
@@ -489,7 +489,7 @@ export const base = import.meta.env.BASE_URL;
       Generate the PR from your spec files with a structured description, linked work item, and proper branch setup.
     </ContentCard>
     <ContentCard icon="mdi:eye" iconColor="bg-cyan" title="Reviewing Others' PRs" tags={[{label: "/dx-pr-review", color: "secondary"}]}>
-      AI-powered code review on a teammate's PR -- architecture, correctness, accessibility, performance.
+      Structured AI code review on a teammate's PR -- architecture, correctness, accessibility, performance.
       Posts structured comments with inline code patches that can be applied directly.
     </ContentCard>
     <ContentCard icon="mdi:comment-check" iconColor="bg-emerald-600" title="Handling Feedback" tags={[{label: "/dx-pr-answer", color: "success"}]}>


### PR DESCRIPTION
Reposition KAI from generic "AI-powered development platform" to
"Enterprise AI Development Platform" with three pillars:
- Enterprise-first: governance, DoR/DoD, 6-phase verification
- Multi-platform: Claude Code + Copilot CLI + VS Code Chat everywhere
- AEM full-flow: flagship vertical, deepest AI-powered AEM tooling

Updates README.md hero, "Why This Exists", differentiators, and
dx-aem description. Updates website landing page hero, stats,
feature cards, plugin section, and engineering principles.

https://claude.ai/code/session_014xq5M8UsVBaLGk8TgFFL9Z