### PR TITLE
feat: add devcontainer config for Codespaces and Copilot CLI on mobile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,6 @@
       ]
     }
   },
-  "postCreateCommand": "cd website && npm install",
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && gh extension install github/gh-copilot && cd website && npm install",
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,6 @@
       ]
     }
   },
-  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && gh extension install github/gh-copilot && cd website && npm install",
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code @github/copilot && cd website && npm install",
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "dx-aem-flow",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.copilot",
+        "github.copilot-chat"
+      ]
+    }
+  },
+  "postCreateCommand": "cd website && npm install",
+  "remoteUser": "node"
+}


### PR DESCRIPTION
Enables launching Codespaces from the repo with Node.js 22, GitHub CLI,
and Copilot extensions pre-configured.

https://claude.ai/code/session_01GTF5jVaoNFsNLfmQXMUzMh