### PR TITLE
Add few-shot classification examples to code reviewer agent

### DIFF
--- a/plugins/dx-aem/templates/rules/be/be-htl.md.template
+++ b/plugins/dx-aem/templates/rules/be/be-htl.md.template
@@ -82,8 +82,8 @@ Use HTL conditionals, not JavaScript:
 <!--/* Always use data-sly-text for dynamic content */-->
 <h1 data-sly-text="${model.title}">Default Title</h1>
 
-<!--/* For HTML content (use with caution) */-->
-<div data-sly-unescape="${model.htmlContent}"></div>
+<!--/* For rich text / HTML content (use with caution) */-->
+<div>${model.htmlContent @ context='html'}</div>
 
 <!--/* Provide meaningful default values */-->
 <h2 data-sly-text="${model.title || 'Default Title'}">Default Title</h2>
@@ -131,10 +131,10 @@ Use HTL conditionals, not JavaScript:
 <!--/* Always use data-sly-text for user content to prevent XSS */-->
 <h2 data-sly-text="${model.userTitle}">Safe Title</h2>
 
-<!--/* Only use data-sly-unescape for trusted content */-->
-<div data-sly-unescape="${model.trustedHtmlContent}"></div>
+<!--/* Use context='html' for trusted rich text — sanitizes but allows markup */-->
+<div>${model.trustedHtmlContent @ context='html'}</div>
 
-<!--/* Never use context="unsafe" with user input */-->
+<!--/* Never use context='unsafe' with user input — it disables ALL filtering */-->
 ```
 
 ## 9. Performance and Optimization

--- a/plugins/dx-core/agents/dx-code-reviewer.md
+++ b/plugins/dx-core/agents/dx-code-reviewer.md
@@ -54,17 +54,17 @@ public String getData(Map<String, Object> authInfo, String path) {
 **Verdict: REPORT — confidence 90**
 Severity: Critical | Issue: ResourceResolver leak — service resolver never closed | Why: Service resolvers are not request-scoped and will never be auto-closed. Each leak holds a JCR session until the pool is exhausted, causing production outages. | Fix: Wrap in try-with-resources: `try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(authInfo)) { ... }`. Confidence is 90 not 100 because the resolver could theoretically be closed by a caller not visible in the diff.
 
-**Example 2 — DROP (confidence: 35): `data-sly-unescape` on RTE-authored content**
+**Example 2 — DROP (confidence: 35): `@ context='html'` on RTE-authored content**
 
 ```html
 <div class="cmp-text__content"
-     data-sly-use.model="com.site.models.TextComponent"
-     data-sly-unescape="${model.richText}">
+     data-sly-use.model="com.site.models.TextComponent">
+    <p>${model.richText @ context='html'}</p>
 </div>
 ```
 
 **Verdict: DROP — confidence 35**
-Reasoning: `data-sly-unescape` looks like an XSS vector, but this is the documented HTL pattern for rendering rich text authored in AEM's RTE (see `be-htl.md` rule). The content is trusted author input from the dialog, not user-generated. Flagging this would be a false positive that erodes developer trust in the reviewer.
+Reasoning: `@ context='html'` disables HTL's auto-escaping, which looks like an XSS vector. But this is the standard HTL pattern for rendering rich text authored in AEM's RTE. The content is trusted author input from the dialog, not user-generated. Flagging this would be a false positive that erodes developer trust in the reviewer.
 
 **Example 3 — REPORT (confidence: 85, Important): Fetch failure silently returns null**
 

--- a/plugins/dx-core/agents/dx-code-reviewer.md
+++ b/plugins/dx-core/agents/dx-code-reviewer.md
@@ -34,6 +34,70 @@ For each reported issue, you MUST include:
 - Why it matters (the actual risk in production)
 - Concrete fix instructions
 
+## Classification Examples
+
+These examples show how to apply confidence scoring in ambiguous cases. Concrete examples outperform abstract rules for nuanced classification — study the reasoning, not just the verdict.
+
+**Example 1 — REPORT (confidence: 90, Critical): Unclosed service ResourceResolver**
+
+```java
+@Reference
+private ResourceResolverFactory resolverFactory;
+
+public String getData(Map<String, Object> authInfo, String path) {
+    ResourceResolver resolver = resolverFactory.getServiceResourceResolver(authInfo);
+    Resource resource = resolver.getResource(path);
+    return resource.getValueMap().get("title", String.class);
+}
+```
+
+**Verdict: REPORT — confidence 90**
+Severity: Critical | Issue: ResourceResolver leak — service resolver never closed | Why: Service resolvers are not request-scoped and will never be auto-closed. Each leak holds a JCR session until the pool is exhausted, causing production outages. | Fix: Wrap in try-with-resources: `try (ResourceResolver resolver = resolverFactory.getServiceResourceResolver(authInfo)) { ... }`. Confidence is 90 not 100 because the resolver could theoretically be closed by a caller not visible in the diff.
+
+**Example 2 — DROP (confidence: 35): `data-sly-unescape` on RTE-authored content**
+
+```html
+<div class="cmp-text__content"
+     data-sly-use.model="com.site.models.TextComponent"
+     data-sly-unescape="${model.richText}">
+</div>
+```
+
+**Verdict: DROP — confidence 35**
+Reasoning: `data-sly-unescape` looks like an XSS vector, but this is the documented HTL pattern for rendering rich text authored in AEM's RTE (see `be-htl.md` rule). The content is trusted author input from the dialog, not user-generated. Flagging this would be a false positive that erodes developer trust in the reviewer.
+
+**Example 3 — REPORT (confidence: 85, Important): `@ChildResource` without null check**
+
+```java
+@ChildResource
+private Resource imageResource;
+
+@PostConstruct
+private void init() {
+    ValueMap imageProps = imageResource.getValueMap();
+    this.altText = imageProps.get("alt", String.class);
+}
+```
+
+**Verdict: REPORT — confidence 85**
+Severity: Important | Issue: NPE on optional child resource — `imageResource` used without null check | Why: Unlike `@ValueMapValue`, `@ChildResource` returns null when the JCR node doesn't exist. Content authors frequently skip optional content blocks, so this will NPE in production. The `be-sling-models` rule requires defensive null checks on injected values. | Fix: Add null guard: `if (imageResource != null) { ... }` or add `@inject(optional = true)` with explicit null handling. Confidence is 85 because `@Required` or `DefaultInjectionStrategy.OPTIONAL` at the class level would change the behavior.
+
+**Example 4 — DROP (confidence: 40): Empty catch in clientlib progressive enhancement**
+
+```javascript
+setRefs() {
+    try {
+        this.countdown = this.el.querySelector(this.selectors.countdown);
+        this.countdown.classList.add(this.classes.active);
+    } catch (e) {
+        /* optional enhancement — degrade gracefully */
+    }
+}
+```
+
+**Verdict: DROP — confidence 40**
+Reasoning: An empty catch block normally signals a swallowed error, but in clientlib JS for progressive enhancement this is intentional — the component degrades gracefully if the optional DOM element doesn't exist. The comment documents the intent. This is different from swallowing a network or data-mutation error, where silent failure would corrupt state.
+
 ## Your Review Process
 
 ### 1. Read Project Conventions

--- a/plugins/dx-core/agents/dx-code-reviewer.md
+++ b/plugins/dx-core/agents/dx-code-reviewer.md
@@ -66,37 +66,31 @@ Severity: Critical | Issue: ResourceResolver leak — service resolver never clo
 **Verdict: DROP — confidence 35**
 Reasoning: `data-sly-unescape` looks like an XSS vector, but this is the documented HTL pattern for rendering rich text authored in AEM's RTE (see `be-htl.md` rule). The content is trusted author input from the dialog, not user-generated. Flagging this would be a false positive that erodes developer trust in the reviewer.
 
-**Example 3 — REPORT (confidence: 85, Important): `@ChildResource` without null check**
-
-```java
-@ChildResource
-private Resource imageResource;
-
-@PostConstruct
-private void init() {
-    ValueMap imageProps = imageResource.getValueMap();
-    this.altText = imageProps.get("alt", String.class);
-}
-```
-
-**Verdict: REPORT — confidence 85**
-Severity: Important | Issue: NPE on optional child resource — `imageResource` used without null check | Why: Unlike `@ValueMapValue`, `@ChildResource` returns null when the JCR node doesn't exist. Content authors frequently skip optional content blocks, so this will NPE in production. The `be-sling-models` rule requires defensive null checks on injected values. | Fix: Add null guard: `if (imageResource != null) { ... }` or add `@inject(optional = true)` with explicit null handling. Confidence is 85 because `@Required` or `DefaultInjectionStrategy.OPTIONAL` at the class level would change the behavior.
-
-**Example 4 — DROP (confidence: 40): Empty catch in clientlib progressive enhancement**
+**Example 3 — REPORT (confidence: 85, Important): Fetch failure silently returns null**
 
 ```javascript
-setRefs() {
+async function getConfig(url) {
     try {
-        this.countdown = this.el.querySelector(this.selectors.countdown);
-        this.countdown.classList.add(this.classes.active);
-    } catch (e) {
-        /* optional enhancement — degrade gracefully */
+        const response = await fetch(url);
+        return await response.json();
+    } catch (error) {
+        console.error('Config fetch failed:', url);
+        return null;
     }
 }
 ```
 
+**Verdict: REPORT — confidence 85**
+Severity: Important | Issue: Silent null return on fetch failure — callers likely don't guard against it | Why: Returning `null` from a function whose callers expect an object causes cascading `TypeError: cannot read property of null` in production. The `console.error` is invisible to monitoring. | Fix: Either throw so callers can handle the failure, or return a well-documented default object. Confidence is 85 not higher because the callers might already null-check — verify call sites before reporting.
+
+**Example 4 — DROP (confidence: 40): Optional chaining on internal API response**
+
+```typescript
+const userName = response.data?.user?.profile?.displayName || 'Unknown';
+```
+
 **Verdict: DROP — confidence 40**
-Reasoning: An empty catch block normally signals a swallowed error, but in clientlib JS for progressive enhancement this is intentional — the component degrades gracefully if the optional DOM element doesn't exist. The comment documents the intent. This is different from swallowing a network or data-mutation error, where silent failure would corrupt state.
+Reasoning: Excessive optional chaining looks like the developer doesn't trust their own API contract, but this is a defensive pattern for data that crosses a system boundary (API response). The fallback `'Unknown'` handles the edge case gracefully. Flagging this as "unnecessary null checks" would be wrong — the API shape could change, and the cost of the extra `?.` operators is zero.
 
 ## Your Review Process
 


### PR DESCRIPTION
## Summary

- Add 4 few-shot input→output examples to `dx-code-reviewer.md` demonstrating confidence-based classification for ambiguous cases (2 generic + 2 AEM)
- Fix invalid `data-sly-unescape` HTL syntax in `be-htl.md.template` — replaced with correct `@ context='html'` pattern

## Examples added

| # | Verdict | Domain | Scenario |
|---|---------|--------|----------|
| 1 | REPORT 90 | AEM | Unclosed service ResourceResolver |
| 2 | DROP 35 | AEM | `@ context='html'` on trusted RTE content |
| 3 | REPORT 85 | Generic | Fetch failure silently returns null |
| 4 | DROP 40 | Generic | Optional chaining on API response |

## Bug fix

`data-sly-unescape` is not a valid HTL attribute — removed all 3 occurrences from `be-htl.md.template` and replaced with `${expr @ context='html'}`.

## Test plan

- [ ] Verify `dx-code-reviewer.md` reads cleanly — examples sit between confidence table and review process
- [ ] Verify no references to `data-sly-unescape` remain in repo
- [ ] Run `/aem-init` and confirm `be-htl.md` template renders correctly

https://claude.ai/code/session_01N6Gkqq3oiZpAkgJgNCCMS4