### PR TITLE
feat(website): add comprehensive SEO — meta tags, OG, sitemap, structured data

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,9 +2,10 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import tailwind from '@astrojs/tailwind';
 import icon from 'astro-icon';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  integrations: [mdx(), tailwind(), icon()],
+  integrations: [mdx(), tailwind(), icon(), sitemap()],
   site: 'https://easingthemes.github.io',
   base: '/dx-aem-flow',
   redirects: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^4.2.0",
+        "@astrojs/sitemap": "^3.7.2",
         "@astrojs/tailwind": "^6.0.2",
         "@iconify-json/mdi": "^1.2.3",
         "@tailwindcss/typography": "^0.5.16",
@@ -132,6 +133,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -1842,11 +1863,18 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -1876,7 +1904,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2043,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.18.1.tgz",
       "integrity": "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.6",
@@ -2280,7 +2306,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3861,7 +3886,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5495,7 +5519,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6114,7 +6137,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
       "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6271,6 +6293,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -6310,6 +6366,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -6448,7 +6510,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6684,7 +6745,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -7704,7 +7764,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -7778,7 +7837,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.2.0",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/tailwind": "^6.0.2",
     "@iconify-json/mdi": "^1.2.3",
     "@tailwindcss/typography": "^0.5.16",

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://easingthemes.github.io/dx-aem-flow/sitemap-index.xml

--- a/website/src/components/SEOHead.astro
+++ b/website/src/components/SEOHead.astro
@@ -1,0 +1,88 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+  canonicalUrl?: string;
+  ogImage?: string;
+  ogType?: string;
+  noindex?: boolean;
+}
+
+const {
+  title,
+  description = 'KAI — Enterprise AI Development Platform. 70+ skills for Azure DevOps and Atlassian, running across Claude Code, GitHub Copilot CLI, and VS Code Chat.',
+  canonicalUrl,
+  ogImage,
+  ogType = 'website',
+  noindex = false,
+} = Astro.props;
+
+const siteUrl = 'https://easingthemes.github.io';
+const base = '/dx-aem-flow';
+const fullTitle = `${title} — KAI`;
+const canonical = canonicalUrl || `${siteUrl}${Astro.url.pathname}`;
+const ogImageUrl = ogImage
+  ? `${siteUrl}${base}${ogImage}`
+  : `${siteUrl}${base}/kai-logo.svg`;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      name: 'KAI',
+      description: 'Enterprise AI Development Platform',
+      url: `${siteUrl}${base}/`,
+    },
+    {
+      '@type': 'SoftwareApplication',
+      name: 'KAI',
+      applicationCategory: 'DeveloperApplication',
+      description: 'AI-powered development platform with 70+ skills for Azure DevOps and Atlassian workflows.',
+      operatingSystem: 'Cross-platform',
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: Astro.url.pathname
+        .replace(base, '')
+        .split('/')
+        .filter(Boolean)
+        .map((segment, index, arr) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          name: segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' '),
+          item: `${siteUrl}${base}/${arr.slice(0, index + 1).join('/')}/`,
+        })),
+    },
+  ],
+};
+---
+
+<!-- Primary Meta Tags -->
+<meta name="description" content={description} />
+<meta name="author" content="Dragan Filipovic" />
+<link rel="canonical" href={canonical} />
+{noindex && <meta name="robots" content="noindex, nofollow" />}
+
+<!-- Open Graph -->
+<meta property="og:type" content={ogType} />
+<meta property="og:url" content={canonical} />
+<meta property="og:title" content={fullTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={ogImageUrl} />
+<meta property="og:site_name" content="KAI" />
+<meta property="og:locale" content="en_US" />
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={fullTitle} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImageUrl} />
+
+<!-- JSON-LD Structured Data -->
+<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,12 +1,18 @@
 ---
 import '../styles/global.css';
 import { Icon } from 'astro-icon/components';
+import SEOHead from '../components/SEOHead.astro';
 
 interface Props {
   title?: string;
+  description?: string;
 }
 
-const { title = 'KAI' } = Astro.props;
+// MDX layout: passes frontmatter via Astro.props.frontmatter
+// Direct component usage passes via Astro.props directly
+const frontmatter = (Astro.props as any).frontmatter;
+const title = frontmatter?.title ?? Astro.props.title ?? 'KAI';
+const description = frontmatter?.description ?? Astro.props.description;
 const base = import.meta.env.BASE_URL;
 const currentPath = Astro.url.pathname;
 
@@ -45,6 +51,7 @@ function isActive(item: any): boolean {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
     <title>{title} — KAI</title>
+    <SEOHead title={title} description={description} />
   </head>
   <body class="min-h-screen flex flex-col bg-white text-gray-800 font-sans">
     <!-- Nav -->

--- a/website/src/layouts/SidebarLayout.astro
+++ b/website/src/layouts/SidebarLayout.astro
@@ -4,6 +4,7 @@ import BaseLayout from './BaseLayout.astro';
 interface Props {
   title?: string;
   sidebar?: string;
+  description?: string;
 }
 
 // MDX layout: passes frontmatter via Astro.props.frontmatter
@@ -11,6 +12,7 @@ interface Props {
 const frontmatter = (Astro.props as any).frontmatter;
 const title = frontmatter?.title ?? Astro.props.title;
 const sidebar = frontmatter?.sidebar ?? Astro.props.sidebar;
+const description = frontmatter?.description ?? Astro.props.description;
 const base = import.meta.env.BASE_URL;
 const currentPath = Astro.url.pathname;
 
@@ -79,7 +81,7 @@ const sidebars: Record<string, { label: string; path: string }[]> = {
 const links = sidebar ? sidebars[sidebar] : [];
 ---
 
-<BaseLayout title={title}>
+<BaseLayout title={title} description={description}>
   {links.length > 0 ? (
     <div class="flex">
       <aside class="hidden lg:block w-60 flex-shrink-0 border-r border-gray-200 bg-white">

--- a/website/src/pages/architecture/automation-infra.mdx
+++ b/website/src/pages/architecture/automation-infra.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Automation Infrastructure
 sidebar: architecture
+description: "KAI automation infrastructure — AWS Lambda webhooks, ADO pipeline triggers, and deployment architecture for autonomous agents."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/automation.mdx
+++ b/website/src/pages/architecture/automation.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Automation -- 24/7 Autonomous Agents
 sidebar: architecture
+description: "KAI 24/7 autonomous agents — DoR checker, DoD checker, PR reviewer, and more running as ADO pipelines via AWS Lambda."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/cross-agent.mdx
+++ b/website/src/pages/architecture/cross-agent.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Cross-Agent Communication
 sidebar: architecture
+description: "Cross-agent communication in KAI — how agents coordinate, share context, and hand off work in complex workflows."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/cross-repo.mdx
+++ b/website/src/pages/architecture/cross-repo.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Cross-Repo Architecture
 sidebar: architecture
+description: "Cross-repository architecture in KAI — how skills and agents work across multiple repos with shared configuration."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/data-flow.mdx
+++ b/website/src/pages/architecture/data-flow.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Data Flow
 sidebar: architecture
+description: "How data flows through KAI — from ticket input through skill execution, spec file generation, and PR output."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/hub.mdx
+++ b/website/src/pages/architecture/hub.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Multi-Repo Hub
 sidebar: architecture
+description: "KAI multi-repo hub — orchestrate AI workflows across multiple repositories with centralized status and configuration."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/learning.mdx
+++ b/website/src/pages/architecture/learning.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Learning & Feedback
 sidebar: architecture
+description: "KAI learning and feedback system — how AI agents improve through conversation history, project context, and team patterns."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/overview.mdx
+++ b/website/src/pages/architecture/overview.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Architecture & Internals
 sidebar: architecture
+description: "KAI architecture deep dive — four-plugin design, config-driven approach, spec directory conventions, and three-layer override system."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/architecture/self-healing.mdx
+++ b/website/src/pages/architecture/self-healing.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Self-Healing
 sidebar: architecture
+description: "KAI self-healing architecture — automatic error detection, retry logic, and fix verification for resilient AI workflows."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/contributing/authoring.mdx
+++ b/website/src/pages/contributing/authoring.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Authoring Guide
 sidebar: contributing
+description: "Guide to authoring KAI skills and agents — templates, naming conventions, frontmatter schema, and best practices."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/contributing/technical-ref.mdx
+++ b/website/src/pages/contributing/technical-ref.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Technical Reference
 sidebar: contributing
+description: "Technical reference for KAI contributors — plugin manifest format, hook system, MCP tool naming, and internal conventions."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/contributing/wiki-format.mdx
+++ b/website/src/pages/contributing/wiki-format.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Wiki Format
 sidebar: contributing
+description: "KAI wiki format specification — structured documentation format for skills, agents, and architecture pages."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/costs.mdx
+++ b/website/src/pages/costs.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/BaseLayout.astro
 title: Costs
+description: "Understand KAI platform costs including AI token usage, API pricing, and cost optimization strategies for enterprise development workflows."
 ---
 
 import PageHero from '../components/PageHero.astro';

--- a/website/src/pages/demo/index.mdx
+++ b/website/src/pages/demo/index.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: KAI Development Platform
 sidebar: demo
+description: "Live demo scripts and walkthroughs showing KAI in action — from ticket analysis to PR creation with AI-assisted development."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/BaseLayout.astro
-title: Home
+title: Enterprise AI Development Platform
+description: "KAI is an enterprise AI development platform with 70+ skills for Azure DevOps and Atlassian. Run identical workflows across Claude Code, Copilot CLI, and VS Code Chat."
 ---
 
 import PageHero from '../components/PageHero.astro';

--- a/website/src/pages/learn/agents.mdx
+++ b/website/src/pages/learn/agents.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Agents
 sidebar: learn
+description: "Learn about KAI agents — specialized AI personas with focused tools and instructions for code review, file search, and more."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/cli-vs-chat.mdx
+++ b/website/src/pages/learn/cli-vs-chat.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: CLI vs Chat
 sidebar: learn
+description: "Compare Claude Code CLI, GitHub Copilot CLI, and VS Code Chat — platform differences, capabilities, and when to use each."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/hooks.mdx
+++ b/website/src/pages/learn/hooks.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Hooks
 sidebar: learn
+description: "Learn about KAI hooks — event-driven shell scripts that run before or after AI tool calls for safety guards and automation."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/intro.mdx
+++ b/website/src/pages/learn/intro.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: AI Crash Course
 sidebar: learn
+description: "AI crash course for developers — understand prompts, context windows, tokens, and how AI coding assistants work under the hood."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/mcps.mdx
+++ b/website/src/pages/learn/mcps.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: MCP Servers
 sidebar: learn
+description: "Learn about MCP servers in KAI — connect AI assistants to Azure DevOps, AEM, Figma, and browser automation tools."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/prompts.mdx
+++ b/website/src/pages/learn/prompts.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Prompts & Rules
 sidebar: learn
+description: "Learn about prompts and rules in KAI — how to write effective instructions and configure AI behavior with the three-layer override system."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/skills.mdx
+++ b/website/src/pages/learn/skills.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Skills
 sidebar: learn
+description: "Learn about KAI skills — reusable AI task definitions that work identically across Claude Code, Copilot CLI, and VS Code Chat."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/tips.mdx
+++ b/website/src/pages/learn/tips.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Tips & Best Practices
 sidebar: learn
+description: "Tips and best practices for getting the most out of KAI — prompt engineering, context management, and workflow optimization."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/learn/tldr.astro
+++ b/website/src/pages/learn/tldr.astro
@@ -38,7 +38,7 @@ const badgeColors = ['primary', 'secondary', 'warning', 'error', 'success', 'inf
 const base = import.meta.env.BASE_URL;
 ---
 
-<SidebarLayout title="TLDR" sidebar="learn">
+<SidebarLayout title="TLDR" sidebar="learn" description={`Browse ${tips.length} agentic AI tips organized by week — from AI basics to production patterns with KAI skills and agents.`}>
   <PageHero
     title={`TLDR — ${tips.length} Agentic AI Tips`}
     subtitle="One tip per day. From basics to production patterns. Built from 78 skills and 3 plugins."

--- a/website/src/pages/learn/tldr/[id].astro
+++ b/website/src/pages/learn/tldr/[id].astro
@@ -26,7 +26,7 @@ function parsePoint(text: string) {
 }
 ---
 
-<SidebarLayout title={title} sidebar="learn">
+<SidebarLayout title={title} sidebar="learn" description={overview || `Learn about ${title} — agentic AI tip #${order ?? ''} from the KAI development platform.`}>
   <PageHero title={title} subtitle={`Day ${order ?? '?'} · Week ${week ?? '?'} · ${category}`} />
 
   <Section>

--- a/website/src/pages/reference/agents.mdx
+++ b/website/src/pages/reference/agents.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Agent Catalog
 sidebar: reference
+description: "Catalog of KAI agents — specialized AI personas for code review, file resolution, documentation search, and AEM inspection."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/reference/commands.mdx
+++ b/website/src/pages/reference/commands.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Command Quick Reference
 sidebar: reference
+description: "Quick reference for all KAI slash commands — skill invocations, arguments, and common usage patterns across platforms."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/reference/config.mdx
+++ b/website/src/pages/reference/config.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Config Reference
 sidebar: reference
+description: "Complete .ai/config.yaml reference — all configuration fields for project settings, SCM, build commands, and AEM integration."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/reference/coordinators.mdx
+++ b/website/src/pages/reference/coordinators.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Coordinators
 sidebar: reference
+description: "KAI coordinator skills reference — multi-step orchestrators that chain skills together for end-to-end workflows."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/reference/skills.mdx
+++ b/website/src/pages/reference/skills.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Skill Catalog
 sidebar: reference
+description: "Complete catalog of 70+ KAI skills — descriptions, arguments, and usage for dx-core, dx-aem, dx-hub, and dx-automation plugins."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/claude-code.mdx
+++ b/website/src/pages/setup/claude-code.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: "Claude Code Details"
 sidebar: setup
+description: "Set up KAI plugins with Claude Code CLI — installation, configuration, and platform-specific details for AI-assisted development."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/copilot-cli.mdx
+++ b/website/src/pages/setup/copilot-cli.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: "Copilot CLI Details"
 sidebar: setup
+description: "Set up KAI plugins with GitHub Copilot CLI — installation steps, agent configuration, and platform-specific integration details."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/index.mdx
+++ b/website/src/pages/setup/index.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Setup
 sidebar: setup
+description: "Get started with KAI — install plugins for Claude Code, GitHub Copilot CLI, or VS Code Chat and configure your project in minutes."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/scaffold.mdx
+++ b/website/src/pages/setup/scaffold.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: "Setup: Standalone Scaffold"
 sidebar: setup
+description: "Use the standalone CLI scaffold to set up KAI project structure without Claude Code — zero-dependency Node.js utility."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/seed-data.mdx
+++ b/website/src/pages/setup/seed-data.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Seed Data
 sidebar: setup
+description: "Learn about KAI seed data — pre-built AEM project knowledge, component libraries, and configuration templates for project onboarding."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/setup/vscode-chat.mdx
+++ b/website/src/pages/setup/vscode-chat.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: "VS Code Chat"
 sidebar: setup
+description: "Configure KAI agents in VS Code Chat — setup instructions for using AI development skills directly in your editor."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/accessibility.mdx
+++ b/website/src/pages/usage/accessibility.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Accessibility Testing
 sidebar: usage
+description: "Automated accessibility testing with KAI — axe-core integration, WCAG compliance checks, and remediation guidance for web projects."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/ado.mdx
+++ b/website/src/pages/usage/ado.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: ADO Integration
 sidebar: usage
+description: "Azure DevOps integration with KAI — work item management, PR automation, pipeline status, and end-to-end ADO workflow support."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/aem.mdx
+++ b/website/src/pages/usage/aem.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: AEM Verification & QA
 sidebar: usage
+description: "AEM verification and QA workflows with KAI — component inspection, content validation, and automated quality assurance for AEM projects."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/bug-flow.mdx
+++ b/website/src/pages/usage/bug-flow.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Bug Fix Flow
 sidebar: usage
+description: "AI-assisted bug fix workflow with KAI — automated root cause analysis, fix implementation, and verification for faster resolution."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/dor-dod.mdx
+++ b/website/src/pages/usage/dor-dod.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: DoR & DoD
 sidebar: usage
+description: "Definition of Ready and Definition of Done quality gates with KAI — automated checks ensuring work items meet team standards."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/figma.mdx
+++ b/website/src/pages/usage/figma.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Figma-to-Code Pipeline
 sidebar: usage
+description: "Convert Figma designs to production code with KAI — automated design token extraction, component generation, and accessibility checks."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/index.mdx
+++ b/website/src/pages/usage/index.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Usage
 sidebar: usage
+description: "Explore KAI usage workflows — local development, Figma-to-code, bug fixes, AEM verification, ADO integration, and quality gates."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/local.mdx
+++ b/website/src/pages/usage/local.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Local Workflow
 sidebar: usage
+description: "Step-by-step guide to the KAI local development workflow — from ticket analysis through planning, implementation, and PR creation."
 ---
 
 import PageHero from '../../components/PageHero.astro';

--- a/website/src/pages/usage/plugin-vs-consumer.mdx
+++ b/website/src/pages/usage/plugin-vs-consumer.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/SidebarLayout.astro
 title: Plugin vs Consumer Responsibilities
 sidebar: usage
+description: "Understand the separation between KAI plugin code and consumer project responsibilities — what ships with plugins vs what projects own."
 ---
 
 import PageHero from '../../components/PageHero.astro';


### PR DESCRIPTION
- Create SEOHead component with meta descriptions, Open Graph, Twitter Cards,
  canonical URLs, and JSON-LD structured data (WebSite, SoftwareApplication,
  BreadcrumbList schemas)
- Add @astrojs/sitemap integration for automatic sitemap.xml generation
- Add robots.txt with sitemap reference
- Add unique meta descriptions to all 43 MDX pages and 2 dynamic .astro pages
- Fix BaseLayout frontmatter passthrough for MDX pages (title/description)
- Update home page title from generic "Home" to "Enterprise AI Development Platform"

https://claude.ai/code/session_01HBwQyJeiWeeA2QaJ6sRsVt