### PR TITLE
fix(website): improve bot access — robots.txt, llms.txt, meta tags

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,30 @@
+# KAI — Enterprise AI Development Platform
+
+> Four Claude Code plugins providing 70+ skills for AI-assisted Azure DevOps and Atlassian development workflows, running across Claude Code, GitHub Copilot CLI, and VS Code Chat.
+
+## About
+
+KAI is an open-source AI development platform built as Claude Code plugins. It provides structured, config-driven workflows for the full software development lifecycle: requirements gathering, planning, implementation, code review, and pull request creation. KAI works with Azure DevOps, Atlassian (Jira/Confluence), Figma, and Adobe Experience Manager (AEM).
+
+## Plugins
+
+- **dx-core**: Platform-agnostic ADO/Jira workflow with 45 skills and 6 agents. Covers requirements, planning, execution, review, and PR creation.
+- **dx-hub**: Multi-repo orchestration with 3 skills for hub init, config, and status.
+- **dx-aem**: AEM-specific verification, QA, and demo capture with 12 skills and 6 agents.
+- **dx-automation**: Autonomous AI agents (DoR/DoD checkers, PR reviewer, BugFix agent, QA agent) running as ADO pipelines via AWS Lambda webhooks. 11 skills.
+
+## Key Features
+
+- Config-driven: all project values in `.ai/config.yaml`, no hardcoding
+- Three-layer override system: project rules > config overrides > plugin defaults
+- Model tier strategy: Opus for deep reasoning, Sonnet for execution, Haiku for lookups
+- Multi-platform: Claude Code CLI, GitHub Copilot CLI, VS Code Chat
+- MCP integrations: Azure DevOps, Atlassian, Figma, axe accessibility, AEM, Chrome DevTools
+
+## Links
+
+- Documentation: https://easingthemes.github.io/dx-aem-flow/
+- GitHub: https://github.com/easingthemes/dx-aem-flow
+- Setup Guide: https://easingthemes.github.io/dx-aem-flow/setup/
+- Skill Catalog: https://easingthemes.github.io/dx-aem-flow/reference/skills/
+- Architecture: https://easingthemes.github.io/dx-aem-flow/architecture/overview/

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,36 @@
 User-agent: *
 Allow: /
 
+# AI Agents — explicitly allowed
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# Unwanted crawlers
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
 Sitemap: https://easingthemes.github.io/dx-aem-flow/sitemap-index.xml

--- a/website/src/components/SEOHead.astro
+++ b/website/src/components/SEOHead.astro
@@ -67,7 +67,12 @@ const jsonLd = {
 <meta name="description" content={description} />
 <meta name="author" content="Dragan Filipovic" />
 <link rel="canonical" href={canonical} />
-{noindex && <meta name="robots" content="noindex, nofollow" />}
+{noindex ? (
+  <meta name="robots" content="noindex, nofollow" />
+) : (
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+)}
+<link rel="alternate" type="text/plain" href={`${siteUrl}${base}/llms.txt`} title="LLMs.txt" />
 
 <!-- Open Graph -->
 <meta property="og:type" content={ogType} />


### PR DESCRIPTION
- Update robots.txt with explicit AI bot allows (ClaudeBot, GPTBot, etc.)
  and block unwanted crawlers (Bytespider, CCBot)
- Add llms.txt for AI agent discovery following the llms.txt standard
- Add robots meta tag with full crawl permissions on all pages
- Add link rel="alternate" pointing to llms.txt for discoverability

Addresses 403 errors when AI agents try to access the documentation site.

https://claude.ai/code/session_013waCCTmSKmEz3LGEFot4P2