### PR TITLE
feat: add component reuse discovery to Figma design-to-code flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Four Claude Code plugins for AI-assisted Azure DevOps development workflows. There is no build system — plugins are pure Markdown (skills, agents, rules, templates) with shell helper scripts.
 
-- **dx-core** (`plugins/dx-core/`) — Platform-agnostic ADO/Jira workflow: requirements → planning → execution → review → PR. Works with any tech stack. 45 skills (`dx-*`), 6 agents. 15 Copilot agent templates (incl. coordinators).
+- **dx-core** (`plugins/dx-core/`) — Platform-agnostic ADO/Jira workflow: requirements → planning → execution → review → PR. Works with any tech stack. 45 skills (`dx-*`), 7 agents. 15 Copilot agent templates (incl. coordinators).
 - **dx-hub** (`plugins/dx-hub/`) — Multi-repo orchestration: hub init, config, status. 3 skills (`dx-hub-*`).
 - **dx-aem** (`plugins/dx-aem/`) — AEM-specific verification, QA, and demo capture. Includes AEM project knowledge (seed data). Requires dx. 12 skills (`aem-*`), 6 agents.
 - **dx-automation** (`plugins/dx-automation/`) — Autonomous AI agents (DoR checker, DoD checker, DoD fixer, PR reviewer, PR answerer, BugFix agent, QA agent, DevAgent, DOCAgent, Estimation) running 24/7 as ADO pipelines triggered by AWS Lambda webhooks. Requires dx. 11 skills (`auto-*`).

--- a/docs/reference/agent-catalog.md
+++ b/docs/reference/agent-catalog.md
@@ -102,8 +102,6 @@ Analyzes Figma extraction to identify UI building blocks (buttons, images, cards
 
 ---
 
----
-
 > **Note:** The `dx-step-executor` agent has been removed. Coordinators now invoke skills directly via the Skill tool instead of delegating to an executor agent. Model tiering is now handled via `model:` frontmatter on individual skills (e.g., `model: opus` on dx-plan, dx-step-verify, dx-pr-review; `model: sonnet` on dx-step, dx-req, dx-step-fix; `model: haiku` on dx-ticket-analyze, dx-help).
 
 ---

--- a/docs/reference/agent-catalog.md
+++ b/docs/reference/agent-catalog.md
@@ -1,6 +1,6 @@
 # Agent Catalog
 
-## dx plugin — 6 agents
+## dx plugin — 7 agents
 
 ### dx-code-reviewer
 
@@ -86,6 +86,19 @@ Discovers CSS/SCSS conventions from the consumer project — variables, breakpoi
 | **Tools** | Read, Glob, Grep |
 
 Discovers HTML and accessibility conventions from the consumer project — semantic patterns, component structure, ARIA usage, keyboard handling. Reads `.claude/rules/fe-javascript.md`, `.claude/rules/accessibility.md`, and other convention rules. Returns structured convention data for prototype generation.
+
+---
+
+### dx-figma-components
+
+| Property | Value |
+|----------|-------|
+| **Model** | Haiku |
+| **File** | `plugins/dx-core/agents/dx-figma-components.md` |
+| **Used by** | `/dx-figma-prototype` |
+| **Tools** | Read, Glob, Grep |
+
+Analyzes Figma extraction to identify UI building blocks (buttons, images, cards, forms, etc.) and searches the codebase for existing components that can be reused. Produces a Component Reuse Map categorizing each Figma element as reuse-as-is, extend, compose, or create-new — ensuring implementation prioritizes reuse of atomic components (button, image, icon, link, input) over creating new ones.
 
 ---
 

--- a/plugins/dx-core/agents/dx-figma-components.md
+++ b/plugins/dx-core/agents/dx-figma-components.md
@@ -37,28 +37,43 @@ Build a list of UI building blocks found in the design. Categorize each:
 | **Organism** | header, footer, hero, navigation, form, product-list, carousel |
 | **Layout** | grid, container, section, sidebar, modal, tabs, accordion |
 
-### Step 2: Read Project Config
+### Step 2: Read Project Config & Discover Component Paths
 
 Read `.ai/config.yaml` for:
-- `frontend.components-dir` — where components live
+- `frontend.components-dir` — where frontend components live
 - `frontend.framework` — technology stack hints
+- `components.base-path` — project-specific component root (if set)
+
+Also check `.claude/rules/` for any rules that describe project structure (e.g., `fe-javascript.md`, `naming.md`).
+
+**Build a component search path list** from config. If config values are present, use them as primary search roots. If not configured, discover paths heuristically:
+```
+Glob: **/components/**  (head_limit: 30)
+Glob: **/src/**/*.{tsx,jsx,vue,svelte,hbs,html,htm}  (head_limit: 30)
+```
+
+The discovered paths tell you where this project keeps its components — use those paths for all subsequent searches.
 
 ### Step 3: Search for Existing Components
 
-For each UI building block identified in Step 1, search the codebase:
+For each UI building block identified in Step 1, search the codebase using the paths discovered in Step 2.
 
-**3a. Direct name search:**
+**3a. Direct name search** (use discovered component roots, not hardcoded paths):
 ```
-Glob: **/components/**/*button*  (for "button" building block)
-Glob: **/components/**/*card*    (for "card" building block)
-Glob: **/components/**/*hero*    (for "hero" building block)
+Glob: <components-dir>/**/*button*  (for "button" building block)
+Glob: <components-dir>/**/*card*    (for "card" building block)
+Glob: <components-dir>/**/*hero*    (for "hero" building block)
+```
+
+If no `components-dir` is known, fall back to broad search:
+```
+Glob: **/*button*.{js,ts,jsx,tsx,hbs,html,htm,vue,svelte}
+Glob: **/*card*.{js,ts,jsx,tsx,hbs,html,htm,vue,svelte}
 ```
 
 **3b. Broader component inventory:**
 ```
-Glob: **/components/**/           (list all component directories)
-Glob: **/ui.frontend/**/components/**/*.{js,ts,jsx,tsx,hbs,html}
-Glob: **/ui.apps/**/components/**
+Glob: <components-dir>/**/          (list all component directories)
 ```
 
 Scan component directory names and file names for matches against the building blocks list.

--- a/plugins/dx-core/agents/dx-figma-components.md
+++ b/plugins/dx-core/agents/dx-figma-components.md
@@ -1,0 +1,148 @@
+---
+name: dx-figma-components
+description: Analyzes Figma extraction to identify UI building blocks (buttons, images, cards, forms, etc.) and searches the codebase for existing components that can be reused. Used by dx-figma-prototype.
+tools: Read, Glob, Grep
+model: haiku
+user-invocable: false
+maxTurns: 25
+---
+
+You are a component reuse discovery agent. You analyze a Figma design extraction to identify all UI building blocks and map each to existing codebase components that should be reused instead of rebuilt.
+
+## Why This Matters
+
+Figma designs are composed of multiple UI elements — buttons, images, cards, form inputs, headings, navigation, icons, etc. Most of these already exist in the codebase as implemented components. Rebuilding them wastes effort and creates inconsistency. This agent ensures every existing component is identified so implementation composes from what exists rather than building from scratch.
+
+## What You Receive
+
+- **spec_dir** — path to the spec directory (e.g., `.ai/specs/12345-slug/`)
+- **figma_extract** — content summary or path to figma-extract.md
+
+## Discovery Procedure
+
+### Step 1: Read Figma Extraction
+
+Read `<spec_dir>/figma-extract.md` and identify every distinct UI element in the design. Look at:
+
+- **Reference Code** section — HTML structure shows component hierarchy
+- **Design Tokens** section — hints at what visual patterns are used
+- **Annotations** — designer notes about component behavior
+
+Build a list of UI building blocks found in the design. Categorize each:
+
+| Category | Examples |
+|----------|----------|
+| **Atomic** | button, link, image, icon, input, label, badge, tag, divider |
+| **Molecule** | card, media-object, form-field (label+input+error), breadcrumb, pagination |
+| **Organism** | header, footer, hero, navigation, form, product-list, carousel |
+| **Layout** | grid, container, section, sidebar, modal, tabs, accordion |
+
+### Step 2: Read Project Config
+
+Read `.ai/config.yaml` for:
+- `frontend.components-dir` — where components live
+- `frontend.framework` — technology stack hints
+
+### Step 3: Search for Existing Components
+
+For each UI building block identified in Step 1, search the codebase:
+
+**3a. Direct name search:**
+```
+Glob: **/components/**/*button*  (for "button" building block)
+Glob: **/components/**/*card*    (for "card" building block)
+Glob: **/components/**/*hero*    (for "hero" building block)
+```
+
+**3b. Broader component inventory:**
+```
+Glob: **/components/**/           (list all component directories)
+Glob: **/ui.frontend/**/components/**/*.{js,ts,jsx,tsx,hbs,html}
+Glob: **/ui.apps/**/components/**
+```
+
+Scan component directory names and file names for matches against the building blocks list.
+
+**3c. CSS/class name search** (for components that may not have a directory):
+```
+Grep: class.*btn|class.*button    (button patterns)
+Grep: class.*card                 (card patterns)
+Grep: class.*image|class.*img     (image patterns)
+```
+
+**3d. Template/markup search:**
+```
+Grep: <button|<a.*class.*btn     (button elements)
+Grep: <img|<picture|<figure       (image elements)
+Grep: <nav|<header|<footer        (navigation elements)
+```
+
+### Step 4: Analyze Each Match
+
+For each existing component found, read the first 50-80 lines to understand:
+- **What it does** — its purpose and visual output
+- **Props/API** — what configuration it accepts (dialog fields, props, slots)
+- **Variants** — what variations exist (sizes, colors, states)
+- **Extensibility** — can it be extended or composed with other components?
+
+### Step 5: Build Reuse Map
+
+For each Figma building block, determine the reuse strategy:
+
+| Strategy | When | Action |
+|----------|------|--------|
+| **Reuse as-is** | Existing component matches exactly | Reference component path, note which variant/config to use |
+| **Extend** | Existing component covers 70%+ but needs a new variant or minor addition | Reference component path, note what to add |
+| **Compose** | The Figma element is built from multiple existing atomic components | List the components to compose together |
+| **Create new** | No existing component matches and no composition makes sense | Mark as new, note what existing patterns to follow |
+
+## Return Format
+
+```markdown
+### Component Reuse Map
+
+**Design decomposition:** <count> UI building blocks identified in Figma design
+**Existing matches:** <count> can be reused or extended
+**New required:** <count> need to be created
+
+#### Reuse (existing components — use as-is)
+
+| Figma Element | Existing Component | Path | Config/Variant | Notes |
+|---------------|-------------------|------|----------------|-------|
+| Primary Button | Button | `<path>` | `variant="primary"` | Exact match |
+| Hero Image | Image | `<path>` | `aspect="16:9"` | Use responsive variant |
+
+#### Extend (existing components — add variant or minor changes)
+
+| Figma Element | Existing Component | Path | What to Add | Notes |
+|---------------|-------------------|------|-------------|-------|
+| Icon Button | Button | `<path>` | Add `icon-only` variant | 90% match, needs icon slot |
+
+#### Compose (build from existing atomic components)
+
+| Figma Element | Composition | Components Used |
+|---------------|-------------|-----------------|
+| Product Card | Card + Image + Button + Badge | `<paths>` |
+| Hero Section | Container + Image + Heading + Button | `<paths>` |
+
+#### Create New (no existing match)
+
+| Figma Element | Category | Nearest Existing | Follow Pattern From |
+|---------------|----------|-----------------|---------------------|
+| Rating Stars | atomic | (none) | `<similar component path>` |
+
+#### Source References
+- Components directory: `<path>`
+- Matching components examined: `<count>`
+- Total components in codebase: `<count>`
+```
+
+## Rules
+
+- **Bias toward reuse** — when in doubt, prefer "extend" over "create new". Atomic components (button, image, icon, link, input) should almost ALWAYS be reused.
+- **Discover, don't assume** — read actual component files to confirm capabilities before claiming a match
+- **Be specific** — include exact file paths, variant names, and configuration needed
+- **Check deeply** — don't just match by name. A "card" in the codebase might be a completely different pattern than the Figma "card"
+- **Composition is preferred** — building a new organism from existing atoms/molecules is better than creating everything from scratch
+- **Handle missing gracefully** — if no components directory exists, report "No component library found" with paths searched
+- **Include all building blocks** — don't skip "obvious" ones like buttons or images. Those are the most important to reuse.

--- a/plugins/dx-core/skills/dx-figma-prototype/SKILL.md
+++ b/plugins/dx-core/skills/dx-figma-prototype/SKILL.md
@@ -36,7 +36,7 @@ If the script exits with error, ask the user for the work item ID.
 
 ## 4. Phase A — Conventions Research
 
-Launch two subagents in parallel using the Agent tool:
+Launch three subagents in parallel using the Agent tool:
 
 **Subagent 1 — Styles (dx-figma-styles):**
 ```
@@ -64,7 +64,22 @@ Agent tool:
     Return the full Markup Conventions report.
 ```
 
-**Wait for both to complete.** Combine results into `$SPEC_DIR/figma-conventions.md`:
+**Subagent 3 — Component Reuse (dx-figma-components):**
+```
+Agent tool:
+  subagent_type: dx-core:dx-figma-components
+  prompt: |
+    Analyze the Figma design and find existing codebase components to reuse.
+    spec_dir: <$SPEC_DIR>
+
+    Figma design reference (from figma-extract.md):
+    <paste the Reference Code section and component name from figma-extract.md>
+
+    Identify every UI building block in the design (buttons, images, cards, inputs, etc.)
+    and search the codebase for existing components that match. Return the Component Reuse Map.
+```
+
+**Wait for all three to complete.** Combine results into `$SPEC_DIR/figma-conventions.md`:
 
 ```markdown
 # Project Conventions (auto-discovered)
@@ -75,6 +90,8 @@ Agent tool:
 <Styles Conventions section from dx-figma-styles agent>
 
 <Markup Conventions section from dx-figma-markup agent>
+
+<Component Reuse Map section from dx-figma-components agent>
 ```
 
 ## 5. Phase B — Scaffold & Generate Prototype
@@ -120,7 +137,20 @@ This creates `prototype/index.html` (from template), empty `styles.css`, and emp
 
 **IMPORTANT:** Do NOT modify the scaffold structure (`.prototype-wrapper`, `.prototype-compare`, `.prototype-compare-col` elements or the inline `<style>` block). Only replace the two `{{...}}` placeholders with content. The comparison layout is provided by the template — do not reinvent it.
 
-### 5d. Generation Rules
+### 5d. Component Reuse Rule
+
+**Before generating any HTML/CSS, consult the Component Reuse Map in `figma-conventions.md`.**
+
+The Figma design is composed of multiple UI building blocks — buttons, images, cards, form inputs, etc. Most of these already exist in the codebase. The prototype must reflect the reuse strategy:
+
+- **Reuse as-is:** Use the existing component's class names, HTML structure, and variant configuration exactly as documented in the reuse map. Do NOT reinvent button styles, image wrappers, or other atomic components.
+- **Extend:** Use the existing component's structure and add the identified missing variant or modification. Add a CSS comment marking the extension: `/* EXTEND: <component> — added <what> */`
+- **Compose:** Assemble the Figma element from the listed existing components. The prototype HTML should reflect the composition hierarchy (e.g., Card wrapping Image + Button).
+- **Create new:** Only for elements explicitly marked "Create New" in the reuse map. Follow the nearest existing component's patterns.
+
+This ensures the prototype is grounded in the actual component library and implementation can reuse existing code rather than rebuilding from scratch.
+
+### 5e. Generation Rules
 
 **CSS (`prototype/styles.css`):**
 - Flat CSS (not SCSS) — no build system needed
@@ -199,7 +229,7 @@ Skip if: design is very simple (< 3 visual elements).
 
 ## Error Handling
 
-- **Subagent failure:** If one convention research agent fails, proceed with whatever the other returned. Note the gap in figma-conventions.md.
+- **Subagent failure:** If one convention research agent fails, proceed with whatever the others returned. Note the gap in figma-conventions.md. If the component reuse agent fails, proceed without the reuse map — the prototype will still work but implementation may miss reuse opportunities.
 - **No conventions found:** If neither agent finds anything (bare project with no rules/components), generate the prototype using Figma reference code directly with a warning.
 - **Token mapping impossible:** If project has no discoverable design tokens, use Figma values directly and flag all as "no project equivalent."
 

--- a/plugins/dx-core/skills/dx-plan/SKILL.md
+++ b/plugins/dx-core/skills/dx-plan/SKILL.md
@@ -34,6 +34,13 @@ Also check for Figma prototype files (from `/dx-figma-prototype`):
 
 If prototype files exist, the plan MUST reference them. Implementation steps should adapt the prototype into project-native code rather than building from scratch.
 
+**Component Reuse Map:** If `figma-conventions.md` contains a `### Component Reuse Map` section, the plan MUST respect it:
+- Components marked **Reuse as-is** → plan step says "Use existing `<component>` at `<path>`" — NO new file creation
+- Components marked **Extend** → plan step modifies the existing component file, adding the identified variant
+- Components marked **Compose** → plan step assembles from listed existing components — NO new wrapper when composition suffices
+- Components marked **Create new** → plan step creates a new component following the nearest existing pattern
+- **Atomic components (button, image, icon, link, input, badge) should ALWAYS be reused.** A plan step that recreates an existing atomic component is a plan defect.
+
 ## Hub Mode Check
 
 Read `shared/hub-dispatch.md` for hub detection logic.


### PR DESCRIPTION
After Figma extraction, a new dx-figma-components agent now analyzes the
design to identify all UI building blocks (buttons, images, cards, etc.)
and maps them to existing codebase components. This ensures atomic
components are always reused and new components are composed from existing
ones rather than rebuilt from scratch.

Changes:
- New agent: dx-figma-components (Haiku, read-only codebase search)
- dx-figma-prototype: launches component reuse agent in parallel with
  styles/markup agents, adds reuse rule to prototype generation
- dx-plan: enforces Component Reuse Map during implementation planning
- Agent catalog updated with new agent entry

https://claude.ai/code/session_012cgLhqM3CK5tCvYshHsJnA