### PR TITLE
feat: make scaffold agent-agnostic — always generate agents and AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ AEM project knowledge (seed data) is now built into dx-aem — no separate plugi
 /dx-init
 /aem-init
 
-# Test standalone scaffold (no Claude Code needed)
+# Test standalone scaffold (bootstraps for any AI agent)
 node cli/bin/dx-scaffold.js /tmp/test-project --all
 ```
 
@@ -35,7 +35,9 @@ No compilation, linting, or automated test suite — verify skills manually by r
 
 ### Standalone CLI (`cli/`)
 
-`cli/bin/dx-scaffold.js` is a zero-dependency Node.js utility that replicates `/dx-init` + `/aem-init` output for users without Claude Code. It reads templates from `plugins/` at runtime — no bundling needed. When adding new templates or data files, the scaffold picks them up automatically (it iterates directories). Only changes to the scaffolding logic itself (new file categories, new placeholders) require updating `cli/lib/scaffold.js`.
+`cli/bin/dx-scaffold.js` is a zero-dependency Node.js utility that replicates `/dx-init` + `/aem-init` output for any AI coding agent. It reads templates from `plugins/` at runtime — no bundling needed. When adding new templates or data files, the scaffold picks them up automatically (it iterates directories). Only changes to the scaffolding logic itself (new file categories, new placeholders) require updating `cli/lib/scaffold.js`.
+
+**Always-generated files:** `.github/agents/` (agent definitions) and `AGENTS.md` (agent discovery) are always generated regardless of flags — they're consumed by Copilot CLI, VS Code Chat, Codex CLI, Windsurf, and the Copilot coding agent. The `--copilot` flag only controls extra Copilot-specific files (`copilot-instructions.md`, `.github/README.md`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ Client-specific plugins can live alongside these plugins for project-specific en
 
 ## Quick Start
 
-### With Claude Code (interactive)
+Three ways to initialize — all produce the same project structure:
+
+### Claude Code
 
 ```bash
-# 1. Install
+# 1. Install plugins
 /plugin marketplace add easingthemes/dx-aem-flow
 /plugin install dx-core@dx-aem-flow
 
-# 2. Initialize your project
+# 2. Initialize (interactive — detects your project, asks a few questions)
 /dx-init
 
 # 3. Work on a story
@@ -95,18 +97,47 @@ Client-specific plugins can live alongside these plugins for project-specific en
 /dx-pr                      # Create pull request
 ```
 
-### Without Claude Code (standalone scaffold)
+### GitHub Copilot CLI
 
-For users who don't have Claude Code, the CLI utility creates the same project structure with default values:
+```bash
+# 1. Install plugins (same format, same skills)
+/plugin install easingthemes/dx-aem-flow/dx-core
+
+# 2. Initialize (same interactive flow)
+/dx-init
+
+# 3. Work on a story — same skills, same agents
+@DxReqAll 2416553          # Full requirements workflow
+@DxPlanExecutor             # Generate and execute plan
+@DxStepAll                  # Execute all steps
+@DxCodeReview               # Code review
+@DxCommit pr                # Commit and create PR
+```
+
+### Standalone scaffold (any agent or no agent)
+
+Bootstrap the project config without installing plugins first. Works with any AI coding agent — Claude Code, Copilot CLI, Codex, or others:
 
 ```bash
 # From a clone of this repo:
-node dx/cli/bin/dx-scaffold.js /path/to/your-project --all
+node cli/bin/dx-scaffold.js /path/to/your-project --all
 
-# Flags: --aem (AEM files), --copilot (Copilot agents), --all (both)
+# Flags: --aem (AEM-specific files), --all (everything)
 ```
 
-Auto-detects git remote, SCM provider, project type, and base branch. Outputs ~144 files with TODO placeholders — edit `.ai/config.yaml` afterwards. See [cli/README.md](cli/README.md) for details.
+Auto-detects git remote, SCM provider, project type, and base branch. Generates config, rules, agents, and `AGENTS.md` — edit `.ai/config.yaml` to set your actual values. See [cli/README.md](cli/README.md) for details.
+
+## Agent Compatibility
+
+These plugins work across the AI coding agent ecosystem at three levels:
+
+| Level | Agents | What Works |
+|-------|--------|------------|
+| **Full workflow** | Claude Code, Copilot CLI | Plugin install, all 70+ skills, agent orchestration, hooks |
+| **Agents + rules** | VS Code Chat, Copilot coding agent, Codex CLI | `.github/agents/`, `AGENTS.md`, rules, MCP servers |
+| **Rules + MCP** | Cursor, Windsurf, Amazon Q, Cline, Continue | Coding conventions from `.claude/rules/`, MCP server configs |
+
+The scaffold generates `AGENTS.md` (read by Codex CLI, Windsurf, Copilot coding agent) and `.github/agents/` (read by VS Code Chat, Copilot CLI) so agent profiles work even without plugin installation.
 
 ## Documentation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # dx-scaffold CLI
 
-Standalone Node.js utility that creates the same project structure as `/dx-init` + `/aem-init` Claude Code skills — without requiring Claude Code.
+Standalone Node.js utility that bootstraps the same project structure as `/dx-init` + `/aem-init` skills — for any AI coding agent (Claude Code, Copilot CLI, Codex CLI, VS Code Chat, Windsurf, and others).
 
 No interactive prompts. Auto-detects environment, scaffolds all files with defaults, user edits config afterwards.
 
@@ -22,13 +22,15 @@ node cli/bin/dx-scaffold.js /path/to/project --all --force
 | Flag | Description |
 |------|-------------|
 | `--aem` | Include AEM rules, instructions, seed data |
-| `--copilot` | Include Copilot agents and instructions |
+| `--copilot` | Include extra Copilot files (`copilot-instructions.md`, `.github/README.md`) |
 | `--all` | Both `--aem` and `--copilot` |
 | `--force` | Overwrite existing files (default: skip) |
 | `--quiet` | Suppress per-file output |
 | `--help` | Show help |
 
 AEM is auto-enabled when the project has AEM markers (`pom.xml` + `ui.apps`/`ui.content`/`jcr_root`).
+
+Agent definitions (`.github/agents/`) and `AGENTS.md` are **always generated** — they're consumed by multiple agents (Copilot CLI, VS Code Chat, Codex CLI, Windsurf, Copilot coding agent).
 
 ## What It Creates
 
@@ -45,9 +47,10 @@ AEM is auto-enabled when the project has AEM markers (`pom.xml` + `ui.apps`/`ui.
 | `.ai/project/` | 5 AEM seed data files | Generated with defaults |
 | `.claude/rules/` | 11 coding convention rules | `dx-core` + `dx-aem` templates |
 | `.claude/hooks/` | 1 lifecycle hook | `dx-core/data/hooks/` |
-| `.github/agents/` | 25 Copilot agents | `dx-core` + `dx-aem` templates |
+| `.github/agents/` | 25 agent definitions | `dx-core` + `dx-aem` templates |
 | `.github/instructions/` | 8 AEM instruction docs | `dx-aem/templates/instructions/` |
 | `.mcp.json` | MCP server config | Generated |
+| `AGENTS.md` | Agent discovery (Codex, Windsurf) | Generated from `.github/agents/` |
 | `agent.index.md` | Machine-readable doc map | `dx-core/templates/INDEX.md.template` |
 
 ## Auto-Detection
@@ -66,9 +69,21 @@ The CLI detects from the target project:
 1. **Edit `.ai/config.yaml`** — replace `TODO` and `YOUR_*` placeholders with actual values
 2. **If AEM** — set author/publish URLs, QA credentials, populate `.ai/project/component-index.md`
 3. **If AEM** — fill in `.ai/project/architecture.md` and `features.md`
-4. **If Copilot** — review `.github/agents/`
 
-The scaffold output is identical to what `/dx-init` + `/aem-init` produce. Running the Claude Code init skills later will re-detect and update values (existing files are preserved by default).
+The scaffold output is identical to what `/dx-init` + `/aem-init` produce. Running the init skills later (in Claude Code or Copilot CLI) will re-detect and update values interactively (existing files are preserved by default).
+
+## Agent Compatibility
+
+| Agent | What it uses from the scaffold |
+|-------|-------------------------------|
+| **Claude Code** | Everything — plugins add skills on top |
+| **Copilot CLI** | Everything — same plugin format, same skills |
+| **VS Code Chat** | `.github/agents/`, `.claude/rules/`, `.mcp.json` |
+| **Codex CLI** | `AGENTS.md`, `.github/agents/`, `.mcp.json` |
+| **Windsurf** | `AGENTS.md` (always-on), `.mcp.json` |
+| **Cursor** | `.claude/rules/` (via settings), `.mcp.json` |
+| **Amazon Q** | `.claude/rules/` (copy to `.amazonq/rules/`), MCP |
+| **Cline** | `.claude/rules/` (copy to `.clinerules/`), MCP |
 
 ## Requirements
 

--- a/cli/bin/dx-scaffold.js
+++ b/cli/bin/dx-scaffold.js
@@ -35,43 +35,43 @@ const pluginsDir = path.resolve(__dirname, '..', '..', 'plugins');
 
 if (flags.help) {
   console.log(`
-dx-scaffold — Standalone scaffolding for dx-aem-flow plugin ecosystem
+dx-scaffold — Bootstrap project config for any AI coding agent
 
-Creates the same project structure as /dx-init + /aem-init Claude Code skills,
-configured with auto-detected or default values. No Claude Code required.
+Creates the same project structure as /dx-init + /aem-init skills.
+Works with Claude Code, Copilot CLI, Codex CLI, VS Code Chat, and others.
 
 Usage:
   dx-scaffold [target-dir] [flags]
 
 Flags:
   --aem        Include AEM-specific files (rules, instructions, seed data)
-  --copilot    Include GitHub Copilot agents and skills
+  --copilot    Include extra Copilot files (copilot-instructions.md, README)
   --all        Enable all features (--aem + --copilot)
   --force      Overwrite existing files (default: skip)
   --quiet, -q  Suppress per-file output
   --help, -h   Show this help
 
 Examples:
-  # Scaffold in current directory (base dx workflow only)
+  # Scaffold in current directory (base workflow + agents)
   node dx-scaffold.js
 
-  # Scaffold AEM project with Copilot support
+  # Full scaffold for AEM project
   node dx-scaffold.js --all
 
   # Scaffold into a specific directory
   node dx-scaffold.js /path/to/my-project --aem
 
-Output Structure:
+Output (always generated):
   .ai/config.yaml         Project configuration (SCM, build, AEM)
   .ai/project.yaml        Detected project profile
-  .ai/README.md           Workflow quick reference
   .ai/rules/              Shared AI behavior rules
-  .ai/docs/               Documentation (10 files)
   .ai/lib/                Utility shell scripts
   .ai/templates/          Output templates for skills
   .claude/rules/          Auto-loaded coding conventions
   .claude/hooks/          Lifecycle hooks
   .mcp.json               MCP server configuration
+  .github/agents/         Agent definitions (Copilot CLI, VS Code Chat, Codex)
+  AGENTS.md               Agent discovery file (Codex CLI, Windsurf, coding agent)
   agent.index.md          Machine-readable doc map
 
   With --aem:
@@ -80,9 +80,8 @@ Output Structure:
   .github/instructions/   + AEM instruction docs
 
   With --copilot:
-  .github/agents/         Copilot agent definitions
-  .github/skills/         Copilot skill templates
-  .github/copilot-instructions.md
+  .github/copilot-instructions.md   Copilot master instructions
+  .github/README.md                 GitHub AI config overview
 
 After scaffolding, edit .ai/config.yaml to set your actual values.
 `);
@@ -163,7 +162,12 @@ if (flags.aem) {
   console.log('  3. Populate .ai/project/component-index.md with your components');
   console.log('  4. Fill in .ai/project/architecture.md and features.md');
 }
-if (flags.copilot) {
-  console.log('  5. Review .github/agents/ and .github/skills/ for your Copilot setup');
-}
+console.log('');
+console.log('Works with:');
+console.log('  Claude Code   — /plugin install, then /dx-init to refine config interactively');
+console.log('  Copilot CLI   — /plugin install, then /dx-init (same plugins, same skills)');
+console.log('  VS Code Chat  — agents auto-discovered from .github/agents/');
+console.log('  Codex CLI     — reads AGENTS.md and .github/agents/ for project context');
+console.log('  Windsurf      — reads AGENTS.md as always-on instructions');
+console.log('  Others        — .claude/rules/ and .mcp.json provide conventions + MCP tools');
 console.log('');

--- a/cli/lib/scaffold.js
+++ b/cli/lib/scaffold.js
@@ -14,7 +14,7 @@ class Scaffold {
     this.dxPlugin = path.join(pluginsDir, 'dx-core');
     this.aemPlugin = path.join(pluginsDir, 'dx-aem');
     this.autoPlugin = path.join(pluginsDir, 'dx-automation');
-    this.options = options; // { aem, copilot, force }
+    this.options = options; // { aem, copilot, force, quiet }
     this.stats = { installed: 0, skipped: 0 };
     this.placeholders = {};
   }
@@ -71,8 +71,12 @@ class Scaffold {
       this.installAemProjectSeedData();
     }
 
+    // Always generate agents and AGENTS.md — consumed by Copilot CLI,
+    // VS Code Chat, Codex CLI, Windsurf, and the Copilot coding agent.
+    this.installCopilotAgents();
+    this.installAgentsMd();
+
     if (this.options.copilot) {
-      this.installCopilotAgents();
       this.installCopilotInstructions();
     }
 
@@ -91,8 +95,10 @@ class Scaffold {
     if (this.options.aem) {
       dirs.push('.ai/project');
     }
+    // Always create .github/agents/ — consumed by multiple AI agents
+    dirs.push('.github/agents');
     if (this.options.copilot) {
-      dirs.push('.github/agents', '.github/instructions');
+      dirs.push('.github/instructions');
     }
     for (const dir of dirs) {
       this.mkdirp(dir);
@@ -530,6 +536,68 @@ Each feature should include: what it does, which components are involved, key co
       const content = this.readTemplate(readmeSrc);
       this.writeFile('.github/README.md', content);
     }
+  }
+
+  // =============================================================
+  //  AGENTS.md — cross-agent discovery file
+  // =============================================================
+
+  /**
+   * Generate AGENTS.md at project root.
+   * Read by Codex CLI (primary instruction file), Windsurf (always-on),
+   * and the Copilot coding agent. Lists all available agents with
+   * invocation syntax.
+   */
+  installAgentsMd() {
+    const agentsDir = path.join(this.targetDir, '.github', 'agents');
+    if (!fs.existsSync(agentsDir)) return;
+
+    const agents = [];
+    for (const file of fs.readdirSync(agentsDir).sort()) {
+      if (!file.endsWith('.agent.md')) continue;
+      const name = file.replace('.agent.md', '');
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+      const desc = this.extractFrontmatterField(content, 'description') || '';
+      const shortDesc = desc.length > 80 ? desc.slice(0, 77) + '...' : desc;
+      agents.push({ name, desc: shortDesc });
+    }
+
+    if (agents.length === 0) return;
+
+    // Group agents by prefix
+    const dxAgents = agents.filter(a => a.name.startsWith('Dx'));
+    const aemAgents = agents.filter(a => a.name.startsWith('AEM'));
+    const otherAgents = agents.filter(a => !a.name.startsWith('Dx') && !a.name.startsWith('AEM'));
+
+    let md = `# Agents
+
+Available AI agents for this project. Invoke with \`@AgentName\` in Copilot CLI, VS Code Chat, or as subagents in Claude Code.
+
+`;
+
+    const writeTable = (title, list) => {
+      if (list.length === 0) return '';
+      let table = `## ${title}\n\n| Agent | Description | Invoke |\n|-------|-------------|--------|\n`;
+      for (const a of list) {
+        table += `| ${a.name} | ${a.desc} | \`@${a.name}\` |\n`;
+      }
+      return table + '\n';
+    };
+
+    md += writeTable('Development Workflow', dxAgents);
+    md += writeTable('AEM', aemAgents);
+    md += writeTable('Other', otherAgents);
+
+    this.writeFile('AGENTS.md', md.trimEnd() + '\n');
+  }
+
+  /**
+   * Extract a field value from YAML frontmatter in a markdown file.
+   */
+  extractFrontmatterField(content, field) {
+    const match = content.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
+    if (!match) return null;
+    return match[1].replace(/^["']|["']$/g, '').trim();
   }
 
   // =============================================================


### PR DESCRIPTION
The scaffold was framed as "Without Claude Code" which implied plugins
work without an agent. Since these are agent orchestration plugins,
reframe the scaffold as a bootstrap for any AI coding agent.

Changes:
- Always generate .github/agents/ and AGENTS.md (no longer gated
  behind --copilot flag) — consumed by Copilot CLI, VS Code Chat,
  Codex CLI, Windsurf, and the Copilot coding agent
- Add installAgentsMd() to scaffold.js — generates AGENTS.md from
  installed .agent.md files, grouped by prefix (Dx/AEM)
- Rewrite README Quick Start to show three equal paths: Claude Code,
  Copilot CLI, and standalone scaffold
- Add agent compatibility matrix to README showing three tiers:
  full workflow, agents+rules, rules+MCP
- Update CLI help text, cli/README.md, and CLAUDE.md to reflect
  the multi-agent positioning

https://claude.ai/code/session_01CuEmypyeRjNXx7njvrdfPQ