### PR TITLE
feat: add cross-platform agent support with agent-agnostic scaffold

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,44 @@
+# Installing dx-aem-flow Skills for Codex
+
+Codex discovers skills from `.agents/skills/` directories. To use dx-aem-flow skills with Codex, symlink the plugin skill directories.
+
+## Quick Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/easingthemes/dx-aem-flow.git ~/.dx-aem-flow
+
+# Create the Codex skills directory
+mkdir -p .agents/skills
+
+# Symlink dx-core skills (recommended for all projects)
+for skill in ~/.dx-aem-flow/plugins/dx-core/skills/*/; do
+  ln -sf "$skill" ".agents/skills/$(basename "$skill")"
+done
+
+# Symlink dx-aem skills (AEM projects only)
+for skill in ~/.dx-aem-flow/plugins/dx-aem/skills/*/; do
+  ln -sf "$skill" ".agents/skills/$(basename "$skill")"
+done
+```
+
+## What You Get
+
+- **dx-core:** 45 skills for requirements, planning, execution, review, and PR workflows
+- **dx-aem:** 12 skills for AEM component verification, QA, and demo capture
+- **dx-hub:** 3 skills for multi-repo orchestration
+- **dx-automation:** 11 skills for autonomous pipeline agents
+
+## Prerequisites
+
+Skills read project config from `.ai/config.yaml`. Generate it with the standalone CLI:
+
+```bash
+node ~/.dx-aem-flow/cli/bin/dx-scaffold.js . --all
+```
+
+## Notes
+
+- Skills use the [Agent Skills](https://agentskills.io/specification) open standard (SKILL.md format)
+- MCP servers (ADO, Figma, AEM, etc.) need separate configuration in your project
+- See `AGENTS.md` in the repo root for full conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+Cross-tool agent instructions for [dx-aem-flow](https://easingthemes.github.io/dx-aem-flow) — AI-assisted Azure DevOps development workflows.
+
+> This file is the cross-platform equivalent of `CLAUDE.md`. Tools that read AGENTS.md include Codex, Copilot, Cursor, Windsurf, Zed, Jules, Gemini CLI, and others. Claude Code reads `CLAUDE.md` (which contains the full contributor guide); this file provides the essential subset for all other agents.
+
+## What This Is
+
+Four installable plugins for AI-assisted development workflows. Pure Markdown (skills, agents, rules, templates) with shell helper scripts. No build system.
+
+| Plugin | Directory | Purpose | Skills |
+|--------|-----------|---------|--------|
+| **dx-core** | `plugins/dx-core/` | Platform-agnostic ADO/Jira workflow: requirements, planning, execution, review, PR | 45 (`dx-*`) |
+| **dx-hub** | `plugins/dx-hub/` | Multi-repo orchestration | 3 (`dx-hub-*`) |
+| **dx-aem** | `plugins/dx-aem/` | AEM-specific verification, QA, demo capture | 12 (`aem-*`) |
+| **dx-automation** | `plugins/dx-automation/` | Autonomous AI agents running as ADO pipelines | 11 (`auto-*`) |
+
+## Plugin Structure
+
+Each plugin follows this layout:
+```
+plugin/
+├── .claude-plugin/plugin.json   # Plugin manifest
+├── .mcp.json                    # MCP server config
+├── agents/                      # Agent definitions (*.md with YAML frontmatter)
+├── skills/                      # Skill directories (*/SKILL.md)
+├── rules/                       # Default prompt templates
+├── hooks/                       # Lifecycle hooks
+├── data/                        # Seed files copied to project by init
+├── shared/                      # Reference files read by skills at runtime
+└── templates/                   # Init-time file templates
+```
+
+## Key Conventions
+
+### Config-Driven — Never Hardcode
+
+All project-specific values live in `.ai/config.yaml`. Skills read config at runtime. Never hardcode build commands, branch names, URLs, or org names.
+
+### Spec Directory Convention
+
+Per-ticket output goes to `.ai/specs/<id>-<slug>/` with predictable filenames (`raw-story.md`, `explain.md`, `research.md`, `implement.md`). Skills find each other's output by convention.
+
+### Three-Layer Override System
+
+```
+.ai/rules/<topic>.md  >  config.yaml overrides  >  plugin defaults (rules/*.md)
+```
+
+### Skill Format (Agent Skills standard)
+
+Skills use the [Agent Skills](https://agentskills.io/specification) open standard:
+
+```yaml
+---
+name: my-skill
+description: One-line with trigger phrases
+argument-hint: "<what user passes>"
+model: sonnet          # optional — opus | sonnet | haiku
+effort: medium         # optional — low | medium | high | max
+---
+```
+
+Skills live in `plugins/{plugin}/skills/<name>/SKILL.md`.
+
+### Agent Format
+
+```yaml
+---
+name: dx-my-agent
+description: What it does
+tools: Read, Write, Glob, Grep, Bash
+model: sonnet
+---
+```
+
+Agents live in `plugins/{plugin}/agents/<name>.md`.
+
+### MCP Servers
+
+Six MCP servers across plugins: ADO, Atlassian, Figma, axe (accessibility), AEM, Chrome DevTools.
+
+## Contributing
+
+- No hardcoded org URLs, project names, paths, build commands, or branch names
+- Skill naming: kebab-case with plugin prefix (`dx-req`, `aem-verify`, `auto-deploy`)
+- Versioning is automated via semantic-release on push to `main`
+- See `CLAUDE.md` for the full contributor guide with architecture details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ AEM project knowledge (seed data) is now built into dx-aem — no separate plugi
 /dx-init
 /aem-init
 
-# Test standalone scaffold (no Claude Code needed)
+# Test standalone scaffold (bootstraps for any AI agent)
 node cli/bin/dx-scaffold.js /tmp/test-project --all
 ```
 
@@ -35,7 +35,9 @@ No compilation, linting, or automated test suite — verify skills manually by r
 
 ### Standalone CLI (`cli/`)
 
-`cli/bin/dx-scaffold.js` is a zero-dependency Node.js utility that replicates `/dx-init` + `/aem-init` output for users without Claude Code. It reads templates from `plugins/` at runtime — no bundling needed. When adding new templates or data files, the scaffold picks them up automatically (it iterates directories). Only changes to the scaffolding logic itself (new file categories, new placeholders) require updating `cli/lib/scaffold.js`.
+`cli/bin/dx-scaffold.js` is a zero-dependency Node.js utility that replicates `/dx-init` + `/aem-init` output for any AI coding agent. It reads templates from `plugins/` at runtime — no bundling needed. When adding new templates or data files, the scaffold picks them up automatically (it iterates directories). Only changes to the scaffolding logic itself (new file categories, new placeholders) require updating `cli/lib/scaffold.js`.
+
+**Always-generated files:** `.github/agents/` (agent definitions) and `AGENTS.md` (agent discovery) are always generated regardless of flags — they're consumed by Copilot CLI, VS Code Chat, Codex CLI, Windsurf, and the Copilot coding agent. The `--copilot` flag only controls extra Copilot-specific files (`copilot-instructions.md`, `.github/README.md`).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,29 @@ No compilation, linting, or automated test suite — verify skills manually by r
 
 ## Architecture
 
+### Cross-Platform Agent Support
+
+This repo supports multiple AI coding agents:
+
+| File | Purpose | Platforms |
+|------|---------|-----------|
+| `CLAUDE.md` | Full contributor guide (primary) | Claude Code |
+| `AGENTS.md` | Cross-tool instructions (subset of CLAUDE.md) | Codex, Copilot, Cursor, Windsurf, Zed, Jules, Gemini CLI |
+| `GEMINI.md` | Gemini CLI context (references AGENTS.md) | Gemini CLI |
+| `gemini-extension.json` | Gemini extension manifest | Gemini CLI |
+| `.codex/INSTALL.md` | Codex skill symlink instructions | Codex |
+| `.claude-plugin/` | Claude Code + Copilot CLI manifests | Claude Code, Copilot CLI |
+| `.cursor-plugin/` | Cursor manifests (with explicit paths) | Cursor |
+
+When updating architecture sections in CLAUDE.md, check if AGENTS.md needs a corresponding update.
+
 ### Four-Plugin Design
 
 Plugins are independently installable. Non-AEM projects only need dx-core (+ dx-hub for multi-repo). Each plugin has:
 ```
 plugin/
 ├── .claude-plugin/plugin.json   # Plugin manifest (shared by Claude Code + Copilot CLI)
+├── .cursor-plugin/plugin.json   # Cursor manifest (with explicit skill/agent/hook paths)
 ├── .mcp.json                    # MCP server config
 ├── agents/                      # Agent definitions (*.md with YAML frontmatter)
 ├── skills/                      # Skill directories (*/SKILL.md)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,2 @@
+@AGENTS.md
+@plugins/dx-core/skills/dx-help/SKILL.md

--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ Client-specific plugins can live alongside these plugins for project-specific en
 
 ## Quick Start
 
-### With Claude Code (interactive)
+Three ways to initialize — all produce the same project structure:
+
+### Claude Code
 
 ```bash
-# 1. Install
+# 1. Install plugins
 /plugin marketplace add easingthemes/dx-aem-flow
 /plugin install dx-core@dx-aem-flow
 
-# 2. Initialize your project
+# 2. Initialize (interactive — detects your project, asks a few questions)
 /dx-init
 
 # 3. Work on a story
@@ -95,18 +97,47 @@ Client-specific plugins can live alongside these plugins for project-specific en
 /dx-pr                      # Create pull request
 ```
 
-### Without Claude Code (standalone scaffold)
+### GitHub Copilot CLI
 
-For users who don't have Claude Code, the CLI utility creates the same project structure with default values:
+```bash
+# 1. Install plugins (same format, same skills)
+/plugin install easingthemes/dx-aem-flow/dx-core
+
+# 2. Initialize (same interactive flow)
+/dx-init
+
+# 3. Work on a story — same skills, same agents
+@DxReqAll 2416553          # Full requirements workflow
+@DxPlanExecutor             # Generate and execute plan
+@DxStepAll                  # Execute all steps
+@DxCodeReview               # Code review
+@DxCommit pr                # Commit and create PR
+```
+
+### Standalone scaffold (any agent or no agent)
+
+Bootstrap the project config without installing plugins first. Works with any AI coding agent — Claude Code, Copilot CLI, Codex, or others:
 
 ```bash
 # From a clone of this repo:
-node dx/cli/bin/dx-scaffold.js /path/to/your-project --all
+node cli/bin/dx-scaffold.js /path/to/your-project --all
 
-# Flags: --aem (AEM files), --copilot (Copilot agents), --all (both)
+# Flags: --aem (AEM-specific files), --all (everything)
 ```
 
-Auto-detects git remote, SCM provider, project type, and base branch. Outputs ~144 files with TODO placeholders — edit `.ai/config.yaml` afterwards. See [cli/README.md](cli/README.md) for details.
+Auto-detects git remote, SCM provider, project type, and base branch. Generates config, rules, agents, and `AGENTS.md` — edit `.ai/config.yaml` to set your actual values. See [cli/README.md](cli/README.md) for details.
+
+## Agent Compatibility
+
+These plugins work across the AI coding agent ecosystem at three levels:
+
+| Level | Agents | What Works |
+|-------|--------|------------|
+| **Full workflow** | Claude Code, Copilot CLI | Plugin install, all 70+ skills, agent orchestration, hooks |
+| **Agents + rules** | VS Code Chat, Copilot coding agent, Codex CLI | `.github/agents/`, `AGENTS.md`, rules, MCP servers |
+| **Rules + MCP** | Cursor, Windsurf, Amazon Q, Cline, Continue | Coding conventions from `.claude/rules/`, MCP server configs |
+
+The scaffold generates `AGENTS.md` (read by Codex CLI, Windsurf, Copilot coding agent) and `.github/agents/` (read by VS Code Chat, Copilot CLI) so agent profiles work even without plugin installation.
 
 ## Documentation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # dx-scaffold CLI
 
-Standalone Node.js utility that creates the same project structure as `/dx-init` + `/aem-init` Claude Code skills — without requiring Claude Code.
+Standalone Node.js utility that bootstraps the same project structure as `/dx-init` + `/aem-init` skills — for any AI coding agent (Claude Code, Copilot CLI, Codex CLI, VS Code Chat, Windsurf, and others).
 
 No interactive prompts. Auto-detects environment, scaffolds all files with defaults, user edits config afterwards.
 
@@ -22,13 +22,15 @@ node cli/bin/dx-scaffold.js /path/to/project --all --force
 | Flag | Description |
 |------|-------------|
 | `--aem` | Include AEM rules, instructions, seed data |
-| `--copilot` | Include Copilot agents and instructions |
+| `--copilot` | Include extra Copilot files (`copilot-instructions.md`, `.github/README.md`) |
 | `--all` | Both `--aem` and `--copilot` |
 | `--force` | Overwrite existing files (default: skip) |
 | `--quiet` | Suppress per-file output |
 | `--help` | Show help |
 
 AEM is auto-enabled when the project has AEM markers (`pom.xml` + `ui.apps`/`ui.content`/`jcr_root`).
+
+Agent definitions (`.github/agents/`) and `AGENTS.md` are **always generated** — they're consumed by multiple agents (Copilot CLI, VS Code Chat, Codex CLI, Windsurf, Copilot coding agent).
 
 ## What It Creates
 
@@ -45,9 +47,10 @@ AEM is auto-enabled when the project has AEM markers (`pom.xml` + `ui.apps`/`ui.
 | `.ai/project/` | 5 AEM seed data files | Generated with defaults |
 | `.claude/rules/` | 11 coding convention rules | `dx-core` + `dx-aem` templates |
 | `.claude/hooks/` | 1 lifecycle hook | `dx-core/data/hooks/` |
-| `.github/agents/` | 25 Copilot agents | `dx-core` + `dx-aem` templates |
+| `.github/agents/` | 25 agent definitions | `dx-core` + `dx-aem` templates |
 | `.github/instructions/` | 8 AEM instruction docs | `dx-aem/templates/instructions/` |
 | `.mcp.json` | MCP server config | Generated |
+| `AGENTS.md` | Agent discovery (Codex, Windsurf) | Generated from `.github/agents/` |
 | `agent.index.md` | Machine-readable doc map | `dx-core/templates/INDEX.md.template` |
 
 ## Auto-Detection
@@ -66,9 +69,21 @@ The CLI detects from the target project:
 1. **Edit `.ai/config.yaml`** — replace `TODO` and `YOUR_*` placeholders with actual values
 2. **If AEM** — set author/publish URLs, QA credentials, populate `.ai/project/component-index.md`
 3. **If AEM** — fill in `.ai/project/architecture.md` and `features.md`
-4. **If Copilot** — review `.github/agents/`
 
-The scaffold output is identical to what `/dx-init` + `/aem-init` produce. Running the Claude Code init skills later will re-detect and update values (existing files are preserved by default).
+The scaffold output is identical to what `/dx-init` + `/aem-init` produce. Running the init skills later (in Claude Code or Copilot CLI) will re-detect and update values interactively (existing files are preserved by default).
+
+## Agent Compatibility
+
+| Agent | What it uses from the scaffold |
+|-------|-------------------------------|
+| **Claude Code** | Everything — plugins add skills on top |
+| **Copilot CLI** | Everything — same plugin format, same skills |
+| **VS Code Chat** | `.github/agents/`, `.claude/rules/`, `.mcp.json` |
+| **Codex CLI** | `AGENTS.md`, `.github/agents/`, `.mcp.json` |
+| **Windsurf** | `AGENTS.md` (always-on), `.mcp.json` |
+| **Cursor** | `.claude/rules/` (via settings), `.mcp.json` |
+| **Amazon Q** | `.claude/rules/` (copy to `.amazonq/rules/`), MCP |
+| **Cline** | `.claude/rules/` (copy to `.clinerules/`), MCP |
 
 ## Requirements
 

--- a/cli/bin/dx-scaffold.js
+++ b/cli/bin/dx-scaffold.js
@@ -35,43 +35,43 @@ const pluginsDir = path.resolve(__dirname, '..', '..', 'plugins');
 
 if (flags.help) {
   console.log(`
-dx-scaffold — Standalone scaffolding for dx-aem-flow plugin ecosystem
+dx-scaffold — Bootstrap project config for any AI coding agent
 
-Creates the same project structure as /dx-init + /aem-init Claude Code skills,
-configured with auto-detected or default values. No Claude Code required.
+Creates the same project structure as /dx-init + /aem-init skills.
+Works with Claude Code, Copilot CLI, Codex CLI, VS Code Chat, and others.
 
 Usage:
   dx-scaffold [target-dir] [flags]
 
 Flags:
   --aem        Include AEM-specific files (rules, instructions, seed data)
-  --copilot    Include GitHub Copilot agents and skills
+  --copilot    Include extra Copilot files (copilot-instructions.md, README)
   --all        Enable all features (--aem + --copilot)
   --force      Overwrite existing files (default: skip)
   --quiet, -q  Suppress per-file output
   --help, -h   Show this help
 
 Examples:
-  # Scaffold in current directory (base dx workflow only)
+  # Scaffold in current directory (base workflow + agents)
   node dx-scaffold.js
 
-  # Scaffold AEM project with Copilot support
+  # Full scaffold for AEM project
   node dx-scaffold.js --all
 
   # Scaffold into a specific directory
   node dx-scaffold.js /path/to/my-project --aem
 
-Output Structure:
+Output (always generated):
   .ai/config.yaml         Project configuration (SCM, build, AEM)
   .ai/project.yaml        Detected project profile
-  .ai/README.md           Workflow quick reference
   .ai/rules/              Shared AI behavior rules
-  .ai/docs/               Documentation (10 files)
   .ai/lib/                Utility shell scripts
   .ai/templates/          Output templates for skills
   .claude/rules/          Auto-loaded coding conventions
   .claude/hooks/          Lifecycle hooks
   .mcp.json               MCP server configuration
+  .github/agents/         Agent definitions (Copilot CLI, VS Code Chat, Codex)
+  AGENTS.md               Agent discovery file (Codex CLI, Windsurf, coding agent)
   agent.index.md          Machine-readable doc map
 
   With --aem:
@@ -80,9 +80,8 @@ Output Structure:
   .github/instructions/   + AEM instruction docs
 
   With --copilot:
-  .github/agents/         Copilot agent definitions
-  .github/skills/         Copilot skill templates
-  .github/copilot-instructions.md
+  .github/copilot-instructions.md   Copilot master instructions
+  .github/README.md                 GitHub AI config overview
 
 After scaffolding, edit .ai/config.yaml to set your actual values.
 `);
@@ -163,7 +162,12 @@ if (flags.aem) {
   console.log('  3. Populate .ai/project/component-index.md with your components');
   console.log('  4. Fill in .ai/project/architecture.md and features.md');
 }
-if (flags.copilot) {
-  console.log('  5. Review .github/agents/ and .github/skills/ for your Copilot setup');
-}
+console.log('');
+console.log('Works with:');
+console.log('  Claude Code   — /plugin install, then /dx-init to refine config interactively');
+console.log('  Copilot CLI   — /plugin install, then /dx-init (same plugins, same skills)');
+console.log('  VS Code Chat  — agents auto-discovered from .github/agents/');
+console.log('  Codex CLI     — reads AGENTS.md and .github/agents/ for project context');
+console.log('  Windsurf      — reads AGENTS.md as always-on instructions');
+console.log('  Others        — .claude/rules/ and .mcp.json provide conventions + MCP tools');
 console.log('');

--- a/cli/lib/scaffold.js
+++ b/cli/lib/scaffold.js
@@ -14,7 +14,7 @@ class Scaffold {
     this.dxPlugin = path.join(pluginsDir, 'dx-core');
     this.aemPlugin = path.join(pluginsDir, 'dx-aem');
     this.autoPlugin = path.join(pluginsDir, 'dx-automation');
-    this.options = options; // { aem, copilot, force }
+    this.options = options; // { aem, copilot, force, quiet }
     this.stats = { installed: 0, skipped: 0 };
     this.placeholders = {};
   }
@@ -71,8 +71,12 @@ class Scaffold {
       this.installAemProjectSeedData();
     }
 
+    // Always generate agents and AGENTS.md — consumed by Copilot CLI,
+    // VS Code Chat, Codex CLI, Windsurf, and the Copilot coding agent.
+    this.installCopilotAgents();
+    this.installAgentsMd();
+
     if (this.options.copilot) {
-      this.installCopilotAgents();
       this.installCopilotInstructions();
     }
 
@@ -91,8 +95,10 @@ class Scaffold {
     if (this.options.aem) {
       dirs.push('.ai/project');
     }
+    // Always create .github/agents/ — consumed by multiple AI agents
+    dirs.push('.github/agents');
     if (this.options.copilot) {
-      dirs.push('.github/agents', '.github/instructions');
+      dirs.push('.github/instructions');
     }
     for (const dir of dirs) {
       this.mkdirp(dir);
@@ -530,6 +536,68 @@ Each feature should include: what it does, which components are involved, key co
       const content = this.readTemplate(readmeSrc);
       this.writeFile('.github/README.md', content);
     }
+  }
+
+  // =============================================================
+  //  AGENTS.md — cross-agent discovery file
+  // =============================================================
+
+  /**
+   * Generate AGENTS.md at project root.
+   * Read by Codex CLI (primary instruction file), Windsurf (always-on),
+   * and the Copilot coding agent. Lists all available agents with
+   * invocation syntax.
+   */
+  installAgentsMd() {
+    const agentsDir = path.join(this.targetDir, '.github', 'agents');
+    if (!fs.existsSync(agentsDir)) return;
+
+    const agents = [];
+    for (const file of fs.readdirSync(agentsDir).sort()) {
+      if (!file.endsWith('.agent.md')) continue;
+      const name = file.replace('.agent.md', '');
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+      const desc = this.extractFrontmatterField(content, 'description') || '';
+      const shortDesc = desc.length > 80 ? desc.slice(0, 77) + '...' : desc;
+      agents.push({ name, desc: shortDesc });
+    }
+
+    if (agents.length === 0) return;
+
+    // Group agents by prefix
+    const dxAgents = agents.filter(a => a.name.startsWith('Dx'));
+    const aemAgents = agents.filter(a => a.name.startsWith('AEM'));
+    const otherAgents = agents.filter(a => !a.name.startsWith('Dx') && !a.name.startsWith('AEM'));
+
+    let md = `# Agents
+
+Available AI agents for this project. Invoke with \`@AgentName\` in Copilot CLI, VS Code Chat, or as subagents in Claude Code.
+
+`;
+
+    const writeTable = (title, list) => {
+      if (list.length === 0) return '';
+      let table = `## ${title}\n\n| Agent | Description | Invoke |\n|-------|-------------|--------|\n`;
+      for (const a of list) {
+        table += `| ${a.name} | ${a.desc} | \`@${a.name}\` |\n`;
+      }
+      return table + '\n';
+    };
+
+    md += writeTable('Development Workflow', dxAgents);
+    md += writeTable('AEM', aemAgents);
+    md += writeTable('Other', otherAgents);
+
+    this.writeFile('AGENTS.md', md.trimEnd() + '\n');
+  }
+
+  /**
+   * Extract a field value from YAML frontmatter in a markdown file.
+   */
+  extractFrontmatterField(content, field) {
+    const match = content.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
+    if (!match) return null;
+    return match[1].replace(/^["']|["']$/g, '').trim();
   }
 
   // =============================================================

--- a/docs/research/agent-standards-landscape-2026.md
+++ b/docs/research/agent-standards-landscape-2026.md
@@ -1,0 +1,268 @@
+# Agent Standards Landscape — April 2026
+
+Research into cross-platform AI coding agent conventions, standardization efforts, and how dx-aem-flow compares.
+
+---
+
+## 1. AGENTS.md — The Emerging Universal Standard
+
+The single biggest development since mid-2025 is **AGENTS.md**, which has become the de facto cross-tool convention file for AI coding agents.
+
+**Timeline:**
+
+- **Aug 2025:** OpenAI released the AGENTS.md spec for Codex CLI
+- **Dec 2025:** OpenAI donated AGENTS.md to the newly formed **Agentic AI Foundation (AAIF)** under the Linux Foundation. Anthropic simultaneously donated MCP; Block donated Goose.
+- **Mar 2026:** 60,000+ open-source repos use AGENTS.md; 25+ tools support it natively
+
+**Tools that natively parse AGENTS.md:** Codex CLI, GitHub Copilot (VS Code, CLI, Cloud Agent), Cursor, Windsurf, Zed, Google Jules, Gemini CLI, Amp, Factory, Devin, and others.
+
+**Format:** Plain Markdown. No required structure — just headings and prose. Scoped by directory (an AGENTS.md file applies to its directory tree and all children). Agents must obey instructions from any AGENTS.md whose scope includes files being modified.
+
+**References:** [agents.md](https://agents.md/) | [GitHub repo](https://github.com/agentsmd/agents.md) | [Linux Foundation AAIF](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation)
+
+### Claude Code Position on AGENTS.md
+
+- Claude Code reads `CLAUDE.md` with **primary precedence**
+- AGENTS.md is supported as a **fallback** (read if CLAUDE.md is absent)
+- [Feature request #6235](https://github.com/anthropics/claude-code/issues/6235) with 3,000+ upvotes requests full AGENTS.md support, but Anthropic has not committed to parity
+- CLAUDE.md has features AGENTS.md lacks: `@import` syntax for composing instructions, recursive imports, Cowork integration, memory system hooks
+
+**Practical guidance:** Maintain both files. CLAUDE.md for Claude-specific features; AGENTS.md for cross-tool compatibility.
+
+---
+
+## 2. Agent Skills — Anthropic's Open Standard (Now Cross-Platform)
+
+**Agent Skills** is an open specification created by Anthropic and released in **December 2025** at [agentskills.io](https://agentskills.io/specification).
+
+- A skill = a directory with a `SKILL.md` file (YAML frontmatter + Markdown body)
+- Frontmatter fields: `name`, `description`, `argument-hint`, `model`, `effort`, `context`, `agent`, `paths`
+- **Progressive disclosure:** L1 metadata (~100 tokens) loads at startup; L2 full instructions (<5,000 tokens) load only when selected
+- Adopted by: **Codex, Copilot (VS Code + CLI + Cloud Agent), Cursor, Goose, Amp, OpenCode**
+
+Codex stores skills in `.agents/skills/`, Claude Code uses `.claude/skills/`. The spec itself is platform-neutral.
+
+**References:** [agentskills.io](https://agentskills.io/specification) | [anthropics/skills on GitHub](https://github.com/anthropics/skills)
+
+---
+
+## 3. Platform-by-Platform Conventions
+
+### OpenAI Codex
+
+| Convention | Location | Purpose |
+|---|---|---|
+| `AGENTS.md` | Repo root + subdirectories | Project instructions |
+| Skills | `.agents/skills/<name>/SKILL.md` | Reusable workflows |
+| Config | `codex.json` or CLI flags | `project_doc_max_bytes`, sandbox settings |
+| Agents SDK | Python SDK | Build custom agents |
+
+### GitHub Copilot (VS Code, CLI, Cloud Agent)
+
+| Convention | Location | Purpose |
+|---|---|---|
+| `copilot-instructions.md` | `.github/copilot-instructions.md` | Project-wide coding standards |
+| `.instructions.md` files | Anywhere in repo | Scoped rules for specific file types/dirs |
+| `AGENTS.md` | Repo root | Cross-tool agent instructions (supported since late 2025) |
+| Custom agents | `.github/agents/<name>.agent.md` | Agent profiles with YAML frontmatter |
+| Skills | `.github/skills/<name>/SKILL.md` | Agent Skills spec (full support) |
+| Hooks | `.github/hooks/hooks.json` | Lifecycle hooks: `preToolUse`, `postToolUse`, etc. |
+| Plugins | `.github/plugins/` | Bundle MCP servers, agents, skills, and hooks |
+| Setup steps | `copilot-setup-steps.yml` | Environment setup for cloud coding agent |
+
+Copilot CLI went GA in **February 2026**.
+
+### Cursor
+
+| Convention | Location | Purpose |
+|---|---|---|
+| `.cursorrules` (legacy) | Repo root | **Deprecated**, not loaded in Agent mode |
+| `.cursor/rules/*.mdc` | `.cursor/rules/` | Modular rules with YAML frontmatter (globs, `alwaysApply`) |
+| `AGENTS.md` | Repo root | Supported natively as of late 2025 |
+| Agent Skills | `.cursor/skills/` | SKILL.md spec adopted |
+
+### Windsurf
+
+| Convention | Location | Purpose |
+|---|---|---|
+| `.windsurfrules` | Repo root | Project-level rules |
+| `.windsurf/rules/` | `.windsurf/rules/` | Structured rules directory |
+| `AGENTS.md` (root) | Repo root | Always-on rules in Cascade system prompt |
+| `AGENTS.md` (subdirs) | Subdirectories | Glob-scoped rules, applied when editing files in that dir |
+
+### Gemini CLI
+
+- Reads `GEMINI.md` as primary context file
+- Supports extensions via `gemini-extension.json` manifest
+- Does not support subagents — skills fall back to sequential execution
+
+---
+
+## 4. Model Context Protocol (MCP) — Industry Standard
+
+MCP has unequivocally won as the universal tool-integration protocol:
+
+- **97M+ monthly SDK downloads** as of early 2026
+- Backed by Anthropic, OpenAI, Google, and Microsoft
+- Donated to the Linux Foundation's AAIF in December 2025
+- Adopted across: Claude Code, ChatGPT, Codex, Copilot, Cursor, Windsurf, Gemini, and enterprise tools
+- The same `.mcp.json` configuration works across platforms with minor differences in tool name prefixing
+
+**References:** [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25) | ["Why MCP Won" — The New Stack](https://thenewstack.io/why-the-model-context-protocol-won/)
+
+---
+
+## 5. Agent2Agent Protocol (A2A) — Google's Interop Standard
+
+A2A addresses agent-to-agent communication (complementary to MCP's agent-to-tool):
+
+- **Announced:** April 2025 by Google with 50+ partners
+- **Donated:** June 2025 to the Linux Foundation
+- Uses HTTP, SSE, and JSON-RPC
+- Key concepts: Agent Cards (JSON capability discovery), task lifecycle, context sharing
+- Partners: Atlassian, Box, Langchain, MongoDB, PayPal, Salesforce, SAP
+
+A2A and MCP are **complementary**: MCP connects agents to tools/data; A2A connects agents to other agents.
+
+---
+
+## 6. Convergence Summary
+
+| Layer | Standard | Status | Governance |
+|---|---|---|---|
+| **Project instructions** | AGENTS.md | De facto standard (60K+ repos, 25+ tools). Claude reads as fallback. | AAIF / Linux Foundation |
+| **Skills** | Agent Skills (SKILL.md) | Open standard. Adopted by Codex, Copilot, Cursor, Claude Code, others. | Anthropic (open spec) |
+| **Tool integration** | MCP | Industry standard (97M+ downloads). Universal adoption. | AAIF / Linux Foundation |
+| **Agent-to-agent** | A2A | Growing enterprise adoption. Complementary to MCP. | Linux Foundation |
+| **Hooks** | No universal standard | Claude (`hooks.json`), Copilot (`.github/hooks/`), Cursor (own format). Similar but not standardized. | Platform-specific |
+| **Plugins** | No universal standard | Claude (`plugin.json`), Copilot (agent plugins), Cursor (none interoperable). | Platform-specific |
+| **Editor rules** | Platform-specific | CLAUDE.md, `.cursor/rules/*.mdc`, `.windsurfrules`, `copilot-instructions.md`. AGENTS.md is the lowest common denominator. | Platform-specific |
+
+**What is real and shipping:** AGENTS.md, Agent Skills, MCP, and A2A are all shipping and governed by open foundations. Cross-platform skills work today.
+
+**What remains fragmented:** Hooks, plugins, and editor-specific rule formats. No standardization effort for these yet.
+
+---
+
+## 7. How superpowers Handles Multi-Platform (6 Platforms)
+
+[obra/superpowers](https://github.com/obra/superpowers) is a methodology-focused Claude Code plugin (v5.0.7, 135k stars) supporting **Claude Code, Cursor, Copilot CLI, Gemini CLI, Codex, and OpenCode**.
+
+### Strategy: Separate Manifests Per Platform
+
+| Platform | Manifest Location | Notes |
+|----------|------------------|-------|
+| **Claude Code** | `.claude-plugin/plugin.json` | Minimal — omits `skills`/`agents`/`hooks` fields (auto-discovery) |
+| **Cursor** | `.cursor-plugin/plugin.json` | Includes explicit paths: `"skills": "./skills/"`, `"hooks": "./hooks/hooks-cursor.json"` |
+| **Gemini CLI** | `gemini-extension.json` | Points to `GEMINI.md` context file |
+| **Codex** | `.codex/INSTALL.md` | Clone-and-symlink approach |
+| **OpenCode** | `.opencode/plugins/superpowers.js` | JS plugin entry point with hooks |
+| **Copilot CLI** | Shared marketplace | Same `.claude-plugin/plugin.json` + `hooks.json` |
+
+### Runtime Platform Detection (SessionStart Hook)
+
+The `hooks/session-start` bash script detects the platform via environment variables and returns the correct JSON format:
+
+```bash
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    # Cursor: uses additional_context (snake_case)
+    printf '{ "additional_context": "%s" }'
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+    # Claude Code: uses hookSpecificOutput.additionalContext (nested)
+    printf '{ "hookSpecificOutput": { ... "additionalContext": "%s" } }'
+else
+    # Copilot CLI or unknown: uses additionalContext (top-level, SDK standard)
+    printf '{ "additionalContext": "%s" }'
+fi
+```
+
+Environment variables: `CURSOR_PLUGIN_ROOT`, `CLAUDE_PLUGIN_ROOT`, `COPILOT_CLI`
+
+### Separate Hook Configs Per Platform
+
+**`hooks.json`** (Claude Code / Copilot CLI): PascalCase events, nested hooks array, matchers
+**`hooks-cursor.json`** (Cursor): `version: 1` schema, camelCase events, simpler format
+
+### Tool Name Translation
+
+Skills are written using Claude Code tool names. Platform-specific reference docs map them:
+
+- **Gemini:** `Read` → `read_file`, `Write` → `write_file`, `Skill` → `activate_skill`
+- **OpenCode:** JS plugin auto-maps (`TodoWrite` → `todowrite`, `Task` → `@mention`)
+
+### Key Design Decisions
+
+1. **Skills as pure methodology** — no platform-specific tool calls or model requirements in skill content
+2. **Separate manifests per platform** in dedicated dotfile directories
+3. **Runtime detection** via environment variables in shared hook scripts
+4. **Tool name translation** via reference docs rather than abstraction layers
+5. **Graceful degradation** — document what doesn't work on lesser platforms, provide fallbacks
+6. **Zero config** — skills are self-contained, no `.ai/config.yaml` equivalent
+
+---
+
+## 8. How dx-aem-flow Compares
+
+### Current Cross-Platform Approach
+
+| Aspect | dx-aem-flow | superpowers |
+|--------|-------------|-------------|
+| **Platforms** | 3 (Claude Code, Copilot CLI, VS Code Chat) | 6 (+ Cursor, Gemini, Codex, OpenCode) |
+| **Manifests** | Single `plugin.json` shared by Claude Code + Copilot CLI | Separate manifest per platform |
+| **Hook format** | Same format, separate install locations | Separate hook files per platform |
+| **Skill complexity** | Rich frontmatter (model, effort, context, agent, paths) | Minimal frontmatter (name, description only) |
+| **Config** | Config-driven (`.ai/config.yaml`) | Zero config — self-contained methodology |
+| **MCP servers** | 6 MCP servers across plugins | None |
+| **Subagents** | Named agents with context fork | Graceful degradation docs |
+
+### What We Already Do Well
+
+1. **SKILL.md format is the open standard** — our skills are already in the format adopted industry-wide
+2. **Config-driven approach** avoids hardcoding — more portable than it appears
+3. **Three-layer override system** is more sophisticated than any competitor
+4. **Plugin marketplace** with independent installability
+5. **Soft-dependency pattern** for superpowers integration already in 6 skills
+
+### Gaps / Opportunities
+
+| Gap | Current State | Opportunity |
+|-----|--------------|-------------|
+| **AGENTS.md** | Only have CLAUDE.md | Add AGENTS.md for cross-tool discovery (Codex, Cursor, Windsurf users) |
+| **Cursor support** | Not supported | Add `.cursor-plugin/plugin.json` following superpowers pattern |
+| **Gemini CLI support** | Not supported | Add `gemini-extension.json` + `GEMINI.md` |
+| **Codex support** | Not supported | Add `.codex/INSTALL.md` with symlink instructions |
+| **Hook platform detection** | Separate install locations | Consider superpowers-style env var detection in shared scripts |
+| **Tool name portability** | Full MCP-prefixed names (Claude-specific) | Add reference docs mapping tool names per platform |
+| **Hooks standardization** | No industry standard yet | Track — this is the next frontier likely to be standardized |
+| **Plugin format** | No industry standard yet | Our `plugin.json` is close to what Copilot adopted |
+
+### Priority Recommendations
+
+1. **Add AGENTS.md** (low effort, high value) — 60K+ repos, 25+ tools read it. Can coexist with CLAUDE.md.
+2. **Add `.cursor-plugin/plugin.json`** (low effort) — Cursor has significant market share and already supports SKILL.md.
+3. **Add Gemini CLI support** (low effort) — `gemini-extension.json` + `GEMINI.md` with `@`-references.
+4. **Add `.codex/INSTALL.md`** (trivial) — symlink instructions for Codex users.
+5. **Add tool name reference docs** (medium effort) — map MCP-prefixed tool names to platform equivalents.
+6. **Track hooks standardization** — hooks are the last major fragmented area. Position to adopt whatever standard emerges.
+
+---
+
+## 9. The Big Picture
+
+Three layers of the AI agent stack are now standardized under open governance:
+
+```
+┌─────────────────────────────────────────┐
+│  AGENTS.md — Project Instructions       │  ← AAIF / Linux Foundation
+├─────────────────────────────────────────┤
+│  Agent Skills (SKILL.md) — Workflows    │  ← Anthropic (open spec)
+├─────────────────────────────────────────┤
+│  MCP — Tool Integration                 │  ← AAIF / Linux Foundation
+├─────────────────────────────────────────┤
+│  A2A — Agent-to-Agent Communication     │  ← Linux Foundation
+└─────────────────────────────────────────┘
+```
+
+Two layers remain fragmented: **hooks** and **plugins/marketplace**. These are likely the next standardization targets but no concrete efforts exist yet.
+
+dx-aem-flow's architecture — config-driven skills, plugin manifests, hook system, MCP integration — is well-positioned. The SKILL.md format we use IS the standard. The main gap is platform reach (3 vs 6+ platforms), addressable with modest effort following superpowers' pattern.

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -82,4 +82,11 @@
 | 67 | Harness design: externalized grading rubrics | Medium | Open | 2026-04-04 | [todo-harness-design.md#grading-criteria](todo-harness-design.md#6-grading-criteria-for-subjective-quality) — `.ai/rules/code-quality-rubric.md` for project-specific thresholds |
 | 68 | Harness design: sprint contract / plan testability review | Medium | Open | 2026-04-04 | [todo-harness-design.md#sprint-contracts](todo-harness-design.md#2-sprint-contracts-pre-agreed-definition-of-done) — evaluator reviews plan done-criteria before execution |
 
-**Counts:** 68 total — 9 done, 42 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending
+| 69 | Cross-platform: Cursor hooks-cursor.json | Medium | Open | 2026-04-04 | [todo-cross-platform.md#cursor-hooks](todo-cross-platform.md#cursor-hookscursorjson-for-dx-core-and-dx-aem) |
+| 70 | Cross-platform: tool name reference docs | Low | Open | 2026-04-04 | [todo-cross-platform.md#tool-names](todo-cross-platform.md#tool-name-reference-docs-for-non-claude-platforms) |
+| 71 | Cross-platform: Cursor marketplace registration | Low | Open | 2026-04-04 | [todo-cross-platform.md#cursor-marketplace](todo-cross-platform.md#cursor-plugin-marketplace-registration) |
+| 72 | Cross-platform: OpenCode plugin support | Low | Open | 2026-04-04 | [todo-cross-platform.md#opencode](todo-cross-platform.md#opencode-plugin-support) |
+| 73 | Cross-platform: shared hook platform detection | Medium | Open | 2026-04-04 | [todo-cross-platform.md#hook-detection](todo-cross-platform.md#sessionstart-hook-platform-detection-shared-script) |
+| 74 | Cross-platform: AGENTS.md ↔ CLAUDE.md sync | Low | Ongoing | 2026-04-04 | [todo-cross-platform.md#agents-sync](todo-cross-platform.md#agentsmd-maintenance--keep-in-sync-with-claudemd) |
+
+**Counts:** 74 total — 9 done, 48 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending, 1 ongoing

--- a/docs/todo/todo-cross-platform.md
+++ b/docs/todo/todo-cross-platform.md
@@ -1,0 +1,51 @@
+# Cross-Platform Agent Support
+
+Tracking expansion from 3 platforms (Claude Code, Copilot CLI, VS Code Chat) to 6+ platforms. Based on [agent standards research](../research/agent-standards-landscape-2026.md).
+
+## Cursor hooks-cursor.json for dx-core and dx-aem
+
+**Added:** 2026-04-04
+**Problem:** Cursor requires a separate `hooks-cursor.json` with its own schema (camelCase events, `version: 1`, simpler format). The `.cursor-plugin/plugin.json` manifests reference `./hooks/hooks-cursor.json` but the files don't exist yet. Cursor plugin install will work (skills/agents discovered) but hooks won't fire.
+**Scope:** `plugins/dx-core/hooks/hooks-cursor.json`, `plugins/dx-aem/hooks/hooks-cursor.json`
+**Done-when:** `ls plugins/dx-core/hooks/hooks-cursor.json plugins/dx-aem/hooks/hooks-cursor.json` returns both files, and each contains `sessionStart` (camelCase) hooks matching the Claude Code equivalents.
+**Approach:** Follow superpowers pattern. Cursor hooks use `version: 1`, camelCase event names (`sessionStart` not `SessionStart`), simpler command format. Detect platform via `$CURSOR_PLUGIN_ROOT` env var. The session-start hook script needs a platform detection block (see superpowers `hooks/session-start` for reference).
+
+## Tool name reference docs for non-Claude platforms
+
+**Added:** 2026-04-04
+**Problem:** Skills reference MCP tools with Claude Code's prefixed naming (`mcp__plugin_dx-core_figma__get_screenshot`). Other platforms use different tool resolution. Codex, Cursor, and Gemini CLI users need a translation reference.
+**Scope:** New file: `docs/reference/tool-name-mapping.md` or per-plugin `shared/tool-names-<platform>.md`
+**Done-when:** A reference doc exists mapping all MCP tool names used in skills to their platform equivalents (at minimum Codex and Cursor).
+**Approach:** Follow superpowers pattern — they use `skills/using-superpowers/references/gemini-tools.md` to map Claude tool names to Gemini equivalents. Create a similar reference. Low priority since LLMs on all platforms can resolve prefixed names via context, but useful for documentation.
+
+## Cursor plugin marketplace registration
+
+**Added:** 2026-04-04
+**Problem:** Cursor has a growing plugin ecosystem but dx-aem-flow isn't registered. The `.cursor-plugin/plugin.json` manifests are in place but not discoverable via Cursor's plugin marketplace.
+**Scope:** Cursor marketplace registration process (external).
+**Done-when:** `dx-core` appears in Cursor's plugin browser.
+**Approach:** Investigate Cursor's plugin submission process. May require a `.cursor-plugin/` at repo root level (marketplace equivalent). Low priority — manual clone + symlink works today.
+
+## OpenCode plugin support
+
+**Added:** 2026-04-04
+**Problem:** OpenCode is a growing open-source AI coding tool that supports JS-based plugins. superpowers supports it via `.opencode/plugins/superpowers.js`. We don't have OpenCode support.
+**Scope:** New directory: `.opencode/` with plugin entry point.
+**Done-when:** `.opencode/plugins/dx-core.js` exists and bootstraps skill discovery for OpenCode.
+**Approach:** Low priority. Follow superpowers pattern — JS entry point with `experimental.chat.system.transform` hook to inject context and `config` hook to register skills directory.
+
+## SessionStart hook platform detection (shared script)
+
+**Added:** 2026-04-04
+**Problem:** Currently our hooks are platform-specific by installation location (plugin hooks.json for Claude Code, .github/hooks/ for Copilot CLI). superpowers uses a single shared script with runtime platform detection via env vars (`CLAUDE_PLUGIN_ROOT`, `CURSOR_PLUGIN_ROOT`, `COPILOT_CLI`). This is more maintainable for 4+ platforms.
+**Scope:** `plugins/dx-core/hooks/scripts/session-start.sh`, `plugins/dx-aem/hooks/scripts/session-start.sh`
+**Done-when:** Hook scripts detect the current platform via env vars and return the correct JSON response format for each platform.
+**Approach:** Add platform detection block to existing session-start scripts. Three response formats: Claude Code (nested `hookSpecificOutput.additionalContext`), Cursor (`additional_context` snake_case), Copilot CLI (`additionalContext` top-level). Reference: superpowers `hooks/session-start`.
+
+## AGENTS.md maintenance — keep in sync with CLAUDE.md
+
+**Added:** 2026-04-04
+**Problem:** `AGENTS.md` is a cross-platform subset of `CLAUDE.md`. When CLAUDE.md changes (new skills, architecture updates), AGENTS.md may fall out of sync.
+**Scope:** Root `AGENTS.md` and `CLAUDE.md`.
+**Done-when:** N/A — ongoing maintenance task. Check periodically that key sections (plugin table, conventions, skill format) match.
+**Approach:** When updating CLAUDE.md architecture sections, check if AGENTS.md needs corresponding updates. AGENTS.md should remain a concise subset, not a full copy.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "dx-aem-flow",
+  "description": "AI-assisted Azure DevOps development workflows — requirements, planning, execution, review, and PR management",
+  "version": "2.88.0",
+  "contextFileName": "GEMINI.md"
+}

--- a/plugins/dx-aem/.cursor-plugin/plugin.json
+++ b/plugins/dx-aem/.cursor-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "dx-aem",
+  "description": "AEM component verification, dialog inspection, demo capture, QA automation, and multi-platform project knowledge for Adobe Experience Manager projects",
+  "version": "2.88.0",
+  "author": {
+    "name": "Dragan Filipovic"
+  },
+  "homepage": "https://easingthemes.github.io/dx-aem-flow",
+  "repository": "https://github.com/easingthemes/dx-aem-flow",
+  "license": "MIT",
+  "logo": "./assets/logo.png",
+  "keywords": ["aem", "adobe", "component", "dialog", "verification", "qa", "seed-data", "multi-platform"],
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "hooks": "./hooks/hooks-cursor.json"
+}

--- a/plugins/dx-automation/.cursor-plugin/plugin.json
+++ b/plugins/dx-automation/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "dx-automation",
+  "description": "Autonomous AI agents for ADO workflows — Definition of Ready checker, Definition of Done checker, DoD fixer, PR reviewer, PR answerer. Runs as ADO pipelines triggered by AWS Lambda webhooks.",
+  "version": "2.88.0",
+  "author": {
+    "name": "Dragan Filipovic"
+  },
+  "homepage": "https://easingthemes.github.io/dx-aem-flow",
+  "repository": "https://github.com/easingthemes/dx-aem-flow",
+  "license": "MIT",
+  "logo": "./assets/logo.png",
+  "keywords": ["ado", "aws", "lambda", "automation", "ai-agents", "dor", "pr-review"],
+  "skills": "./skills/"
+}

--- a/plugins/dx-core/.cursor-plugin/plugin.json
+++ b/plugins/dx-core/.cursor-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "dx-core",
+  "description": "Full-stack development workflow for Azure DevOps projects — requirements, planning, execution, review, bug fixes, and PR management",
+  "version": "2.88.0",
+  "author": {
+    "name": "Dragan Filipovic"
+  },
+  "homepage": "https://easingthemes.github.io/dx-aem-flow",
+  "repository": "https://github.com/easingthemes/dx-aem-flow",
+  "license": "MIT",
+  "logo": "./assets/logo.png",
+  "keywords": ["ado", "azure-devops", "workflow", "code-review", "planning", "execution"],
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "hooks": "./hooks/hooks-cursor.json"
+}

--- a/plugins/dx-hub/.cursor-plugin/plugin.json
+++ b/plugins/dx-hub/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "dx-hub",
+  "description": "Multi-repo hub orchestration — run dx skills across sibling repositories from a single hub directory.",
+  "version": "2.55.3",
+  "author": {
+    "name": "Dragan Filipovic"
+  },
+  "homepage": "https://easingthemes.github.io/dx-aem-flow",
+  "repository": "https://github.com/easingthemes/dx-aem-flow",
+  "license": "MIT",
+  "logo": "./assets/logo.png",
+  "keywords": ["multi-repo", "hub", "orchestration"],
+  "skills": "./skills/"
+}


### PR DESCRIPTION
## Summary

- Research agent standards landscape (AGENTS.md, Agent Skills, MCP, A2A) and document findings
- Add cross-platform support files: AGENTS.md, `.cursor-plugin/` manifests, GEMINI.md, `.codex/INSTALL.md`
- Make scaffold CLI agent-agnostic — always generate `.github/agents/` and `AGENTS.md` (no longer gated behind `--copilot`)
- Add `installAgentsMd()` to scaffold.js — generates AGENTS.md from installed `.agent.md` files
- Rewrite README Quick Start with three equal paths: Claude Code, Copilot CLI, standalone scaffold
- Add agent compatibility matrix to README
- Update CLAUDE.md with cross-platform support table
- Add 6 cross-platform TODOs (Cursor hooks, tool name mapping, etc.)

Incorporates scaffold changes from #99.

## Test plan
- [ ] Verify `node cli/bin/dx-scaffold.js /tmp/test --all` generates `AGENTS.md` and `.github/agents/`
- [ ] Verify AGENTS.md at repo root accurately reflects CLAUDE.md subset
- [ ] Verify `.cursor-plugin/plugin.json` files have correct paths for each plugin
- [ ] Verify `gemini-extension.json` references GEMINI.md correctly
- [ ] Check README compatibility matrix renders correctly

https://claude.ai/code/session_01KmdbqE6yZ6nGhuXVq1hqAF