### PR TITLE
feat: add Key Decisions section to implementation plans

### DIFF
--- a/plugins/dx-core/data/templates/spec/implement.md.template
+++ b/plugins/dx-core/data/templates/spec/implement.md.template
@@ -22,6 +22,22 @@ If research.md has an "Existing Implementation Check" section, reference it here
 - State which requirements need new code and what existing patterns to follow
 - If a feature is already implemented, state "Extend existing <path>" not "Create new" -->
 
+## Key Decisions
+<!-- Record non-obvious design decisions made during planning.
+ONLY include decisions where alternatives existed and the choice matters.
+OMIT this section for trivial changes (single-file edits, config-only, bug fixes).
+
+### <Decision title>
+**Chosen:** <what was chosen>
+**Why:** <1-2 sentences — the deciding factor>
+**Alternatives considered:**
+- <Alternative A> — rejected because <reason>
+- <Alternative B> — rejected because <reason>
+**Affects steps:** <which step numbers depend on this decision>
+
+Keep it tight: 1-3 decisions for a medium feature. If every decision is obvious
+from the requirements, omit this section entirely. -->
+
 ## Steps
 
 ### Step 1: <Short imperative description>

--- a/plugins/dx-core/shared/format-registry.md
+++ b/plugins/dx-core/shared/format-registry.md
@@ -10,7 +10,7 @@ All Markdown spec files include provenance frontmatter — see `shared/provenanc
 | explain.md | 1.1 | dx-req (Phase 3) | Provenance, Requirements, Acceptance Criteria, Out of Scope | ≥1 requirement, no TBD |
 | research.md | 1.1 | dx-req (Phase 4) | Provenance, ≥1 of: Models, Services, Templates, Tests | ≥1 finding, valid paths |
 | dor-report.md | 1.0 | dx-req (Phase 2) | Checklist with pass/fail/unclear, Open Questions | ≥1 assessed |
-| implement.md | 2.2 | dx-plan | Provenance, Steps with Status/Files/What/Verification | Valid status values, no dupes |
+| implement.md | 2.3 | dx-plan | Provenance, Key Decisions (optional), Steps with Status/Files/What/Verification | Valid status values, no dupes |
 | share-plan.md | 1.1 | dx-req (Phase 5) | Provenance, Summary, Approach, Scope | Non-technical language |
 | triage.md | 1.0 | dx-bug-triage | Component, Scope, Root Cause Hypothesis | Component identified |
 | figma-extract.md | 1.0 | dx-figma-extract | Design Tokens, Component Mapping | ≥1 screenshot, tokens present |

--- a/plugins/dx-core/skills/dx-plan/SKILL.md
+++ b/plugins/dx-core/skills/dx-plan/SKILL.md
@@ -75,7 +75,7 @@ If `.ai/rules/plan-format.md` exists (project override), read and follow it. Oth
 
 If `.github/instructions/` (or `.ai/instructions/`) exists, read instruction files relevant to the file types in this spec — these provide detailed code examples and framework patterns for generating concrete implementation steps.
 
-### Optional: Design Exploration
+### Design Exploration & Decision Capture
 
 If this is a complex feature with multiple valid approaches, check if `superpowers:brainstorming` is available and invoke it to explore the design space before planning.
 
@@ -85,6 +85,14 @@ If this is a complex feature with multiple valid approaches, check if `superpowe
 - Are there unknowns that need spiking first?
 
 If a brainstorming spec already exists in `docs/superpowers/specs/`, read it for design context.
+
+**Decision capture:** Any non-obvious design decision surfaced during exploration MUST be recorded in the `## Key Decisions` section of `implement.md`. This includes:
+- Architecture choices (extend existing component vs create new)
+- Pattern selection (which existing pattern to follow when multiple exist)
+- Scope tradeoffs (what was deliberately excluded and why)
+- Technology choices (when research.md shows multiple viable approaches)
+
+If the change is trivial (single-file edit, config-only, straightforward bug fix) or every decision is obvious from requirements, omit the Key Decisions section.
 
 ## AEM Component Intelligence Rules
 
@@ -151,6 +159,7 @@ Read `.ai/templates/spec/implement.md.template` and follow that structure exactl
 - Steps are ordered by implementation dependency
 - Be specific about property names, types, default values, file paths with line numbers
 - Include code snippets when helpful
+- Key Decisions section: record non-obvious choices with alternatives and rationale. OMIT for trivial changes.
 - Risks section: only REAL technical risks. OMIT if none.
 
 ## 5. Status Tracking
@@ -186,6 +195,7 @@ The step-* skills update these statuses as they execute.
 
 **<Title>**
 - Steps: <count> (all pending)
+- Key decisions: <count or "none">
 - Files to modify: <count>
 - Files to create: <count>
 - Tests planned: <count> unit, manual verification included
@@ -250,6 +260,16 @@ Change set identified →
 **Discovery:** `src/core/scripts/libs/forms.js` has `validateField()` with email, text, number patterns
 **Decision:** EXTEND — add phone regex to existing `validateField()`. Don't create new util.
 **Why:** Existing utility covers >70% of need. Only a new regex pattern is needed.
+
+**Key Decision entry:**
+```markdown
+### Form validation approach
+**Chosen:** Extend existing `validateField()` in `forms.js`
+**Why:** Covers >70% of need — only a new regex pattern is required
+**Alternatives considered:**
+- New `phoneValidator.js` utility — rejected because existing utility handles all other field types; a separate file fragments validation logic
+**Affects steps:** 2
+```
 
 ### When to Create New
 **Scenario:** Need color-coded severity badge component for QA dashboard


### PR DESCRIPTION
## Summary

- `dx-plan` now captures non-obvious design decisions with alternatives and rationale directly in `implement.md`
- New `## Key Decisions` section between Approach and Steps — records WHY an approach was chosen, not just WHAT
- Section is optional — omitted for trivial changes (single-file edits, config-only, bug fixes)

Phase 2 of the context graphs initiative. Prevents re-derivation of design rationale across sessions, automation runs, and PR reviews.

## What this solves

- PR reviewers see rejected alternatives without asking
- Automation agents (dx-automation) stay aligned with original design intent across Lambda invocations
- Developers resuming after a break get instant context (3 lines vs re-reading research.md)
- `dx-step-verify` won't suggest reverting to an already-rejected approach

## Test plan

- [ ] Run `/dx-plan` on a complex ticket (5+ steps) — verify Key Decisions section appears with alternatives
- [ ] Run `/dx-plan` on a simple ticket (1-2 steps, config-only) — verify Key Decisions section is omitted
- [ ] Run `/dx-step` after planning — verify it reads implement.md correctly (Key Decisions section doesn't interfere with step parsing)
- [ ] Run `/dx-plan-validate` — verify it still passes (new section doesn't break validation)

https://claude.ai/code/session_019UScuUGPvuzYBQHjh5cNFo