### PR TITLE
feat: add provenance consumers to dx-plan, dx-pr, and dx-step-verify

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -89,9 +89,11 @@
 | 73 | Cross-platform: shared hook platform detection | Medium | Open | 2026-04-04 | [todo-cross-platform.md#hook-detection](todo-cross-platform.md#sessionstart-hook-platform-detection-shared-script) |
 | 74 | Cross-platform: AGENTS.md ↔ CLAUDE.md sync | Low | Ongoing | 2026-04-04 | [todo-cross-platform.md#agents-sync](todo-cross-platform.md#agentsmd-maintenance--keep-in-sync-with-claudemd) |
 
-| 75 | Context graphs: provenance metadata on spec files | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-1](todo-context-graphs.md#phase-1--provenance-metadata-low-effort-high-value) — add agent/model/confidence frontmatter to spec outputs |
-| 76 | Context graphs: decision nodes with alternatives | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-2](todo-context-graphs.md#phase-2--decision-nodes-medium-effort-high-value) — record planning rationale in `.ai/graph/nodes/decisions/` |
-| 77 | Context graphs: cross-ticket pattern promotion | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-3](todo-context-graphs.md#phase-3--cross-ticket-patterns-medium-effort-very-high-value) — patterns from 3+ tickets promoted to shared knowledge |
-| 78 | Context graphs: full graph with edges and index | Low | Open | 2026-04-05 | [todo-context-graphs.md#phase-4](todo-context-graphs.md#phase-4--full-graph-with-edges-higher-effort-transformative) — complete edge schema, index, graph-aware coordinators |
+| 75 | Context graphs: provenance metadata on spec files | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-1](todo-context-graphs.md#phase-1--provenance-metadata-low-effort-high-value) — add agent/model/confidence frontmatter to spec outputs |
+| 76 | Context graphs: key decisions in implement.md | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-2](todo-context-graphs.md#phase-2--key-decisions-in-implementmd-low-effort-high-value) — dx-plan captures alternatives + rationale |
+| 77 | Context graphs: provenance consumers | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-1b](todo-context-graphs.md#phase-1b--provenance-consumers-low-effort-high-value) — dx-plan warns on low confidence, dx-pr gates on verified, dx-step-verify flags upstream quality |
+| 78 | Context graphs: cross-ticket pattern promotion | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-3](todo-context-graphs.md#phase-3--cross-ticket-patterns-medium-effort-very-high-value) — patterns from 3+ tickets promoted to shared knowledge |
+| 79 | Context graphs: decision nodes as structured YAML | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-4](todo-context-graphs.md#phase-4--decision-nodes-as-structured-yaml-medium-effort-high-value) — externalize decisions to `.ai/graph/nodes/decisions/` |
+| 80 | Context graphs: full graph with edges and index | Low | Open | 2026-04-05 | [todo-context-graphs.md#phase-5](todo-context-graphs.md#phase-5--full-graph-with-edges-higher-effort-transformative) — complete edge schema, index, graph-aware coordinators |
 
-**Counts:** 78 total — 9 done, 52 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending, 1 ongoing
+**Counts:** 80 total — 12 done, 51 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending, 1 ongoing

--- a/docs/todo/todo-context-graphs.md
+++ b/docs/todo/todo-context-graphs.md
@@ -294,27 +294,27 @@ This is the "compounding knowledge" that Karpathy describes — each ticket's le
 
 ## Implementation Approach
 
-### Phase 1 — Provenance Metadata (Low Effort, High Value)
+### Phase 1 — Provenance Metadata (Low Effort, High Value) ✅ DONE
 
 Add provenance headers to existing spec files. No new directory structure needed.
 
-```markdown
-<!-- .ai/specs/1234-auth/implement.md -->
----
-agent: dx-plan
-model: opus
-created: 2026-04-05T14:30:00Z
-confidence: high
-verified: false
----
-# Implementation Plan: Auth Layer
-...
-```
+**Completed:** Provenance schema (`shared/provenance-schema.md`), 7 producer skills emit provenance frontmatter, `dx-step-verify` sets `verified: true` on PASS, `dx-step` preserves provenance on status updates.
 
-**Scope:** Update `dx-plan`, `dx-req`, `dx-step-verify`, `dx-pr-review` to emit provenance frontmatter.
-**Done-when:** `grep -r "^agent:" .ai/specs/*/` returns provenance metadata for all spec files.
+### Phase 1b — Provenance Consumers (Low Effort, High Value) ✅ DONE
 
-### Phase 2 — Decision Nodes (Medium Effort, High Value)
+Close the feedback loop — skills that READ provenance metadata and act on it.
+
+**Completed:**
+- **dx-plan** reads `research.md`/`explain.md` provenance → warns on low confidence, notes Haiku-tier research, propagates lowest input confidence as ceiling for `implement.md`
+- **dx-pr** reads `implement.md` provenance → hard gate on `verified: false` (blocks PR creation), soft warning on low confidence, enriches PR description with provenance section
+- **dx-step-verify** reads upstream provenance → flags low-confidence inputs in pre-review output, passes confidence context to code review subagent for extra scrutiny
+- `shared/provenance-schema.md` updated with full consumer documentation (Writers vs Readers sections)
+
+### Phase 2 — Key Decisions in implement.md (Low Effort, High Value) ✅ DONE
+
+`dx-plan` captures non-obvious design decisions with alternatives and rationale in a `## Key Decisions` section of `implement.md`.
+
+### Phase 3 — Cross-Ticket Patterns (Medium Effort, Very High Value)
 
 Extend `dx-plan` to record decision rationale in `.ai/graph/nodes/decisions/`.
 
@@ -328,7 +328,14 @@ Build the pattern promotion pipeline: findings that appear across 3+ tickets get
 **Scope:** New skill `dx-pattern-extract` (Haiku tier) that scans recent spec directories for recurring decisions/patterns.
 **Done-when:** `dx-plan` queries `.ai/graph/nodes/patterns/` and references relevant patterns in its output.
 
-### Phase 4 — Full Graph With Edges (Higher Effort, Transformative)
+### Phase 4 — Decision Nodes as Structured YAML (Medium Effort, High Value)
+
+Extract key decisions from `implement.md` into `.ai/graph/nodes/decisions/` as structured YAML with lineage edges. Currently decisions live inline in implement.md — this phase externalizes them for graph queries.
+
+**Scope:** New step in `dx-plan` that writes decision YAML files alongside `implement.md`.
+**Done-when:** `ls .ai/graph/nodes/decisions/` shows decision files after running `/dx-plan`.
+
+### Phase 5 — Full Graph With Edges (Higher Effort, Transformative)
 
 Complete edge schema, index, and graph-aware query patterns in coordinator skills.
 

--- a/plugins/dx-core/shared/provenance-schema.md
+++ b/plugins/dx-core/shared/provenance-schema.md
@@ -50,9 +50,30 @@ provenance:
 
 ## Consuming Provenance
 
+### Writers (modify provenance)
+
 - **dx-step-verify** — On PASS, update `implement.md` provenance to set `verified: true`.
 - **dx-step** — When updating step status in `implement.md`, preserve the provenance frontmatter block unchanged.
-- **All other consumers** — Read provenance if useful for context (e.g., trust filtering), but do not modify it.
+
+### Readers (act on provenance, do not modify)
+
+- **dx-plan** — Reads `research.md` and `explain.md` provenance before generating a plan:
+  - Warns on `confidence: low` (suggests re-running `/dx-req`)
+  - Notes `model: haiku` research (may need higher-tier re-run for complex features)
+  - **Confidence propagation:** Uses the lowest input confidence as the ceiling for `implement.md` provenance — a plan is only as reliable as its inputs.
+
+- **dx-pr** — Reads `implement.md` provenance before creating a PR:
+  - **Hard gate:** If `verified: false`, blocks PR creation (requires `/dx-step-verify` first)
+  - **Soft warning:** If `confidence: low`, advises reviewers to scrutinize carefully
+  - **PR enrichment:** Adds a Provenance section to the PR description (confidence, verification status, model tier)
+
+- **dx-step-verify** — Reads `implement.md` and `research.md` provenance before review:
+  - Flags low-confidence upstream inputs in the pre-review output
+  - Passes upstream confidence to the code review subagent so it applies extra scrutiny to low-confidence plans
+
+### Pre-migration files
+
+Files without a `provenance:` frontmatter block (created before provenance was added) are treated as unknown confidence. Consumer skills skip provenance checks for these files — they never block on missing provenance.
 
 ## Non-Markdown Files
 

--- a/plugins/dx-core/skills/dx-plan/SKILL.md
+++ b/plugins/dx-core/skills/dx-plan/SKILL.md
@@ -26,6 +26,24 @@ Read these files from `$SPEC_DIR` (in order of importance):
 
 If `research.md` doesn't exist, warn the user: "No research.md found — run `/dx-req` first for a better plan. Proceeding with explain.md only."
 
+### Provenance Check on Inputs
+
+Read `shared/provenance-schema.md` for the schema definition.
+
+After reading each input file, parse its YAML frontmatter `provenance:` block (if present). Evaluate input quality:
+
+1. **research.md provenance:**
+   - If `confidence: low` → warn: "⚠ research.md has low confidence (degraded mode or incomplete data). Plan quality may be affected — consider re-running `/dx-req` with better search hints."
+   - If `confidence: medium` or `high` → no warning needed
+   - If no provenance block → informational: "ℹ research.md has no provenance metadata (pre-migration file). Confidence unknown."
+   - If `model: haiku` → note: "ℹ research.md was produced at Haiku tier. For complex features, consider re-running `/dx-req` at higher tier."
+
+2. **explain.md provenance:**
+   - If `confidence: low` → warn: "⚠ explain.md has low confidence. Requirements may be incomplete — verify with the original ticket."
+   - If no provenance block → skip (informational only, don't block)
+
+**Confidence propagation:** Use the *lowest* confidence from input files as the ceiling for `implement.md` provenance. If research.md is `low`, implement.md cannot be higher than `low` — regardless of planning quality, the plan is only as reliable as its inputs.
+
 Also check for Figma prototype files (from `/dx-figma-prototype`):
 - `figma-conventions.md` — discovered project conventions (design tokens, naming, patterns)
 - `prototype/index.html` — standalone HTML prototype
@@ -151,7 +169,7 @@ If research.md has no Cross-Repo Scope section or scope is "This repo only", do 
 
 Analyze all inputs and write `implement.md` in the same spec directory.
 
-Read `shared/provenance-schema.md`. Include the provenance frontmatter block at the top of `implement.md`, before the `# Implementation Plan:` heading. Use `agent: dx-plan`, confidence `medium` (planning involves synthesis). Downgrade to `low` if operating without `research.md`.
+Include the provenance frontmatter block at the top of `implement.md`, before the `# Implementation Plan:` heading. Use `agent: dx-plan`. Set confidence using the propagation rule from the Provenance Check step: the *lowest* input confidence is the ceiling, then apply the standard downgrade rule (no `research.md` → `low`). Default is `medium` when all inputs have `medium` or `high` confidence.
 
 Read `.ai/templates/spec/implement.md.template` and follow that structure exactly. Key rules:
 

--- a/plugins/dx-core/skills/dx-pr/SKILL.md
+++ b/plugins/dx-core/skills/dx-pr/SKILL.md
@@ -57,6 +57,28 @@ If any step is `pending`, `in-progress`, or `blocked`:
 - Print: "Not all steps are done. Complete remaining steps with `/dx-step` or `/dx-step-all` first."
 - STOP
 
+### Provenance Verification Check
+
+Parse `implement.md`'s YAML frontmatter `provenance:` block (if present):
+
+1. **Verified status** (hard gate):
+   - If `verified: false` → warn: "⚠ implement.md has not passed verification. Run `/dx-step-verify` before creating a PR." → STOP
+   - If `verified: true` → continue
+   - If no provenance block → skip this check (pre-migration file, no gate)
+
+2. **Confidence advisory** (soft warning, does not block):
+   - If `confidence: low` → print: "⚠ Implementation plan has low confidence — PR reviewers should scrutinize carefully."
+   - If `confidence: medium` or `high` → no warning
+
+3. **PR description enrichment:**
+   - If provenance exists, include a `### Provenance` section in the PR description:
+     ```
+     ### Provenance
+     - **Plan confidence:** <confidence>
+     - **Verified by:** dx-step-verify ✅
+     - **Model tier:** <model>
+     ```
+
 ### Branch Readiness Check
 
 If `superpowers:finishing-a-development-branch` is available, invoke it to verify branch readiness.

--- a/plugins/dx-core/skills/dx-step-verify/SKILL.md
+++ b/plugins/dx-core/skills/dx-step-verify/SKILL.md
@@ -63,6 +63,12 @@ Read from `$SPEC_DIR`:
 - `implement.md` — the full plan with all steps
 - `explain.md` — original requirements
 
+**Provenance awareness:** Parse the `provenance:` frontmatter from `implement.md` and `research.md` (if it exists). Report upstream confidence in the pre-review output:
+
+- If `implement.md` has `confidence: low` → print: "⚠ Plan was generated with low confidence — applying extra scrutiny to code review."
+- If `research.md` exists and has `confidence: low` → print: "⚠ Research had low confidence — verify file paths and patterns are correct."
+- Pass upstream confidence info to the code review subagent (in the Review Context section) so the reviewer knows to apply extra scrutiny to low-confidence plans.
+
 ### Run pre-review checks (compile/lint/test/secret/arch)
 
 Run the 5-phase pre-review gate before the expensive code review:
@@ -160,6 +166,12 @@ Use the Task tool with `dx-code-reviewer` subagent type (if available), otherwis
 ---
 
 ## Review Context
+
+### Upstream Provenance
+Plan confidence: <confidence from implement.md provenance, or "unknown" if no provenance>
+Research confidence: <confidence from research.md provenance, or "not available">
+<If any confidence is "low":>
+NOTE: Low-confidence upstream inputs — apply extra scrutiny to file paths, API usage, and pattern references that may be based on incomplete research.
 
 ### What Was Implemented
 <Summary from implement.md — list all completed steps>


### PR DESCRIPTION
Close the provenance feedback loop — skills now READ metadata that
other skills wrote, making provenance actionable rather than decorative.

- dx-plan: reads research.md/explain.md provenance, warns on low
  confidence, propagates lowest input confidence as ceiling
- dx-pr: hard gate on verified:false (blocks PR creation), soft
  warning on low confidence, enriches PR description with provenance
- dx-step-verify: passes upstream confidence to code review subagent
  for extra scrutiny on low-confidence plans
- provenance-schema.md: documented all consumers (Writers vs Readers)
- Updated context graphs roadmap: Phases 1, 1b, 2 marked done

https://claude.ai/code/session_01STVTqR12z584vRWUZSLWDS