### PR TITLE
feat: Phase 4 — decision nodes as structured YAML

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -93,7 +93,7 @@
 | 76 | Context graphs: key decisions in implement.md | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-2](todo-context-graphs.md#phase-2--key-decisions-in-implementmd-low-effort-high-value) — dx-plan captures alternatives + rationale |
 | 77 | Context graphs: provenance consumers | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-1b](todo-context-graphs.md#phase-1b--provenance-consumers-low-effort-high-value) — dx-plan warns on low confidence, dx-pr gates on verified, dx-step-verify flags upstream quality |
 | 78 | Context graphs: cross-ticket pattern promotion | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-3](todo-context-graphs.md#phase-3--cross-ticket-pattern-promotion-medium-effort-very-high-value) — dx-pattern-extract skill + dx-plan consumes patterns |
-| 79 | Context graphs: decision nodes as structured YAML | Medium | Open | 2026-04-05 | [todo-context-graphs.md#phase-4](todo-context-graphs.md#phase-4--decision-nodes-as-structured-yaml-medium-effort-high-value) — externalize decisions to `.ai/graph/nodes/decisions/` |
+| 79 | Context graphs: decision nodes as structured YAML | Medium | Done | 2026-04-05 | [todo-context-graphs.md#phase-4](todo-context-graphs.md#phase-4--decision-nodes-as-structured-yaml-medium-effort-high-value) — decision-schema.md + dx-plan writes YAML + dx-pattern-extract reads YAML |
 | 80 | Context graphs: full graph with edges and index | Low | Open | 2026-04-05 | [todo-context-graphs.md#phase-5](todo-context-graphs.md#phase-5--full-graph-with-edges-higher-effort-transformative) — complete edge schema, index, graph-aware coordinators |
 
-**Counts:** 80 total — 13 done, 50 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending, 1 ongoing
+**Counts:** 80 total — 14 done, 49 open, 5 blocked, 10 watch, 1 deferred, 1 decision needed, 1 pending, 1 ongoing

--- a/docs/todo/todo-context-graphs.md
+++ b/docs/todo/todo-context-graphs.md
@@ -327,12 +327,17 @@ Build the pattern promotion pipeline: findings that appear across 3+ tickets get
 - Dry-run mode for preview without writing
 - Idempotent: re-running merges new ticket evidence into existing patterns
 
-### Phase 4 — Decision Nodes as Structured YAML (Medium Effort, High Value)
+### Phase 4 — Decision Nodes as Structured YAML (Medium Effort, High Value) ✅ DONE
 
 Extract key decisions from `implement.md` into `.ai/graph/nodes/decisions/` as structured YAML with lineage edges. Currently decisions live inline in implement.md — this phase externalizes them for graph queries.
 
-**Scope:** New step in `dx-plan` that writes decision YAML files alongside `implement.md`.
-**Done-when:** `ls .ai/graph/nodes/decisions/` shows decision files after running `/dx-plan`.
+**Completed:**
+- Decision schema defined in `shared/decision-schema.md` (YAML format with lineage, tags, alternatives, trust tier)
+- `dx-plan` updated with new step 5: writes one YAML file per Key Decision to `.ai/graph/nodes/decisions/<ticket>-<slug>.yaml`
+- Content parity: YAML files contain the same information as the markdown Key Decisions section
+- `dx-pattern-extract` updated to scan decision YAML nodes as primary source (step 1a), falling back to implement.md markdown for pre-Phase 4 tickets (step 1b)
+- Matching heuristics enhanced: tags and files fields from YAML enable more reliable pattern detection than markdown parsing
+- Re-planning overwrites existing decision files and marks removed decisions as `superseded`
 
 ### Phase 5 — Full Graph With Edges (Higher Effort, Transformative)
 

--- a/plugins/dx-core/shared/decision-schema.md
+++ b/plugins/dx-core/shared/decision-schema.md
@@ -1,0 +1,135 @@
+# Decision Schema for Structured Decision Nodes
+
+Decisions are non-obvious design choices made during planning. They live in `.ai/graph/nodes/decisions/` and are produced by `dx-plan` alongside `implement.md`. They enable `dx-pattern-extract` to scan decisions as structured data (instead of parsing markdown) and future graph tools to query decision lineage across tickets.
+
+## Schema
+
+```yaml
+# .ai/graph/nodes/decisions/<ticket>-<slug>.yaml
+id: decision-<ticket>-<slug>
+type: decision
+ticket: "<ticket-id>"
+title: "Descriptive name for the decision"
+created: <ISO-8601>
+agent: dx-plan
+model: <model-tier>
+confidence: <low | medium | high>
+trust_tier: shared              # shared (single ticket) | long-term (verified or pattern-promoted)
+status: active                  # active | superseded | rejected
+
+chosen: |
+  What was chosen. 1-2 sentences.
+
+why: |
+  The deciding factor. 1-2 sentences explaining WHY this option won.
+
+alternatives:
+  - name: "<Alternative A>"
+    reason_rejected: "<Why it was rejected — 1 sentence>"
+  - name: "<Alternative B>"
+    reason_rejected: "<Why it was rejected — 1 sentence>"
+
+affects_steps:                  # Which implement.md steps depend on this decision
+  - 1
+  - 3
+
+tags:                           # For matching by dx-pattern-extract
+  - "tag1"
+  - "tag2"
+
+lineage:                        # Links to upstream spec artifacts
+  - "requirement-<ticket>-raw"
+  - "research-<ticket>"
+
+files:                          # Key files involved in this decision
+  - "path/to/relevant/file.ext"
+```
+
+## Field Rules
+
+1. **id** -- `decision-<ticket>-<slug>` where slug is kebab-case, descriptive of the decision (e.g., `decision-1234-jwt-over-sessions`, `decision-2416-extend-dropdown`).
+2. **type** -- Always `decision`.
+3. **ticket** -- The work item ID this decision belongs to.
+4. **title** -- Human-readable, 5-10 words. Describes the choice, not the ticket.
+5. **created** -- ISO-8601 timestamp of when the decision was made.
+6. **agent** -- Always `dx-plan` (the producing agent).
+7. **model** -- The model tier used during planning (`opus`, `sonnet`, `haiku`).
+8. **confidence** -- Inherits from `implement.md` provenance. Same confidence propagation rules apply (lowest input confidence is the ceiling).
+9. **trust_tier** -- `shared` when first created (visible to other agents on the same ticket). Promoted to `long-term` if the decision becomes part of a pattern via `dx-pattern-extract`.
+10. **status** -- `active` when created. Set to `superseded` if a later planning run replaces it. Set to `rejected` if the decision was reversed.
+11. **chosen** -- What was chosen. Concrete and specific (file paths, class names, config keys).
+12. **why** -- The deciding factor. Not a restatement of `chosen` -- explain the reasoning.
+13. **alternatives** -- Each rejected alternative with a one-sentence reason. Minimum 1 alternative for a non-trivial decision.
+14. **affects_steps** -- Step numbers from `implement.md` that depend on this decision. Helps trace decisions to implementation.
+15. **tags** -- Keywords for matching by `dx-pattern-extract`. Include: technology names, architectural concepts, component types, file patterns. Same purpose as pattern tags.
+16. **lineage** -- References to upstream spec artifacts that informed this decision. Use the format `<type>-<ticket>[-<detail>]` (e.g., `requirement-1234-raw`, `research-1234`). These become formal edges in Phase 5.
+17. **files** -- Key files involved in or affected by this decision. Helps `dx-pattern-extract` match decisions across tickets by file overlap.
+
+## Relationship to implement.md Key Decisions
+
+Decision YAML files are the **structured counterpart** to the `## Key Decisions` section in `implement.md`. The markdown section remains for human readability; the YAML files enable machine queries.
+
+- `dx-plan` writes both: the markdown section in `implement.md` AND the YAML files in `.ai/graph/nodes/decisions/`
+- Content is the same -- the YAML is not a subset or superset
+- If the Key Decisions section is omitted (trivial change), no YAML files are written either
+
+## How dx-pattern-extract Consumes Decisions
+
+`dx-pattern-extract` reads decision nodes as its **primary source** for identifying recurring patterns:
+
+1. Scan `.ai/graph/nodes/decisions/*.yaml` for all decision files
+2. Group by similarity: same `tags`, same `files`, same `chosen` approach
+3. Fall back to `implement.md` `## Key Decisions` markdown for tickets that predate Phase 4 (no YAML files yet)
+4. Apply the same 3-ticket promotion threshold as before
+
+Structured YAML is more reliable than markdown parsing -- field names are explicit, alternatives are already separated, and tags enable keyword matching without NLP heuristics.
+
+## Example
+
+```yaml
+id: decision-2416553-extend-layout-dropdown
+type: decision
+ticket: "2416553"
+title: "Extend existing dropdown for layout mode"
+created: 2026-04-05T14:30:00Z
+agent: dx-plan
+model: opus
+confidence: medium
+trust_tier: shared
+status: active
+
+chosen: |
+  Extend the existing layout dropdown in the card component dialog
+  rather than creating a new component or dialog field.
+
+why: |
+  The project already has a standard pattern for dialog dropdowns with
+  datasource nodes. Extending is lower risk and follows the established
+  codebase convention from 3 prior tickets.
+
+alternatives:
+  - name: "New dedicated layout component"
+    reason_rejected: "Over-engineered for a single dropdown field; fragments dialog logic across components"
+  - name: "Radio button group instead of dropdown"
+    reason_rejected: "Inconsistent with existing layout selectors in other components; dropdown is the project standard"
+
+affects_steps:
+  - 1
+  - 2
+  - 4
+
+tags:
+  - "aem"
+  - "dialog"
+  - "dropdown"
+  - "layout"
+  - "_cq_dialog"
+
+lineage:
+  - "requirement-2416553-raw"
+  - "research-2416553"
+
+files:
+  - "ui.apps/src/main/content/jcr_root/apps/project/components/card/_cq_dialog/.content.xml"
+  - "core/src/main/java/com/project/core/models/CardModel.java"
+```

--- a/plugins/dx-core/skills/dx-pattern-extract/SKILL.md
+++ b/plugins/dx-core/skills/dx-pattern-extract/SKILL.md
@@ -9,7 +9,27 @@ allowed-tools: ["read", "search", "write"]
 
 You scan all completed spec directories for recurring decisions and approaches, then promote patterns that appear in 3+ tickets to `.ai/graph/nodes/patterns/` for cross-ticket knowledge reuse.
 
-## 1. Scan Spec Directories
+## 1. Scan Decision Sources
+
+Collect decisions from two sources — structured YAML (preferred) and markdown fallback.
+
+### 1a. Decision Nodes (primary source)
+
+Scan for structured decision YAML files:
+
+```bash
+find .ai/graph/nodes/decisions/ -name "*.yaml" -type f 2>/dev/null
+```
+
+Read `shared/decision-schema.md` for the schema definition. For each decision YAML file, extract:
+- `ticket` — the work item ID
+- `chosen` — what was chosen
+- `tags` — for grouping by similarity
+- `files` — for matching by file overlap
+- `alternatives` — the rejected options (useful for understanding the pattern's scope)
+- `status` — skip decisions with `status: superseded` or `status: rejected`
+
+### 1b. Implement.md fallback (for pre-Phase 4 tickets)
 
 Find all spec directories with completed work:
 
@@ -17,7 +37,9 @@ Find all spec directories with completed work:
 find .ai/specs/ -name "implement.md" -type f 2>/dev/null
 ```
 
-For each `implement.md` found, read:
+For each `implement.md` found, check if decision YAML files already exist for that ticket (by matching the ticket ID from the spec directory name against `.ai/graph/nodes/decisions/<ticket>-*.yaml`). If YAML files exist, **skip the markdown scan** for that ticket — the YAML is the authoritative source.
+
+For tickets without decision YAML files, read from `implement.md`:
 - The `## Key Decisions` section (if present) — these are explicit design choices with alternatives
 - The `## Approach` section — the overall strategy
 - The `## Steps` section — scan step titles and file references for recurring patterns
@@ -37,8 +59,9 @@ Group the extracted decisions and approaches by similarity. Two decisions are "t
 - **Same technology approach** — e.g., multiple tickets use the same library, config pattern, or API pattern
 
 **Matching heuristics:**
-- Decisions that reference the same files or directories
-- Decisions with the same "Chosen" approach (even if wording differs)
+- Decisions that share `tags` values (from YAML) or reference the same files or directories
+- Decisions with the same `chosen` approach (from YAML) or "Chosen" text (from markdown), even if wording differs
+- Decisions with overlapping `files` lists (from YAML) — strong signal of the same pattern
 - Steps that follow the same sequence (e.g., "modify model → update dialog → update template")
 - Reused utilities or services that appear in 3+ tickets' Key Findings
 

--- a/plugins/dx-core/skills/dx-plan/SKILL.md
+++ b/plugins/dx-core/skills/dx-plan/SKILL.md
@@ -213,7 +213,41 @@ Read `.ai/templates/spec/implement.md.template` and follow that structure exactl
 - Key Decisions section: record non-obvious choices with alternatives and rationale. OMIT for trivial changes.
 - Risks section: only REAL technical risks. OMIT if none.
 
-## 5. Status Tracking
+## 5. Write Decision Nodes
+
+If `implement.md` contains a `## Key Decisions` section (i.e., non-trivial decisions were made), externalize each decision as a structured YAML file.
+
+Read `shared/decision-schema.md` for the schema definition.
+
+### When to write
+
+- If the Key Decisions section was **omitted** (trivial change) → skip this step entirely
+- If Key Decisions section **exists** → write one YAML file per decision
+
+### How to write
+
+1. Create the directory if needed:
+```bash
+mkdir -p .ai/graph/nodes/decisions
+```
+
+2. For each decision in the `## Key Decisions` section, write a YAML file to `.ai/graph/nodes/decisions/<ticket>-<slug>.yaml`:
+   - `<ticket>` is the work item ID (from spec directory name)
+   - `<slug>` is a kebab-case summary of the decision title (e.g., `extend-layout-dropdown`)
+   - Map the markdown fields to YAML: `**Chosen:**` → `chosen:`, `**Why:**` → `why:`, `**Alternatives considered:**` → `alternatives:`, `**Affects steps:**` → `affects_steps:`
+   - Set `confidence` from the same propagation logic used for `implement.md` provenance
+   - Set `trust_tier: shared`, `status: active`
+   - Populate `tags` from technology names, component types, and architectural concepts mentioned in the decision
+   - Populate `lineage` with references to the input spec files that informed this decision (e.g., `requirement-<ticket>-raw`, `research-<ticket>`)
+   - Populate `files` from files mentioned in the decision or the affected steps
+
+3. If decision YAML files already exist for this ticket (re-planning), overwrite them. Set `status: superseded` on any old decision files that are no longer in the new plan's Key Decisions section.
+
+### Content parity
+
+The YAML files contain the **same information** as the markdown Key Decisions section — they are the structured counterpart for machine consumption. Do not add or remove decisions between the two formats.
+
+## 6. Status Tracking
 
 Every step MUST have a `**Status:**` line with one of:
 - `pending` — not yet started (initial state)
@@ -223,7 +257,7 @@ Every step MUST have a `**Status:**` line with one of:
 
 The step-* skills update these statuses as they execute.
 
-## 6. Planning Principles
+## 7. Planning Principles
 
 - **Reuse before create** — if research.md's "Existing Implementation Check" shows existing code covers a requirement (✅ or ⚡), the step MUST reuse/extend that code. Never create a new utility, helper, service, or component when an existing one can be extended. If research.md doesn't have this section, search the codebase yourself before planning a "Create new" step.
 - **Every step references specific files and line numbers** from research.md
@@ -239,14 +273,14 @@ The step-* skills update these statuses as they execute.
 - **No time estimates**
 - **Scale to complexity** — simple change = 3-4 steps, complex feature = 10+
 
-## 7. Present Summary
+## 8. Present Summary
 
 ```markdown
 ## implement.md created
 
 **<Title>**
 - Steps: <count> (all pending)
-- Key decisions: <count or "none">
+- Key decisions: <count or "none"> (decision nodes written to `.ai/graph/nodes/decisions/`)
 - Files to modify: <count>
 - Files to create: <count>
 - Tests planned: <count> unit, manual verification included


### PR DESCRIPTION
## Summary

- **New `shared/decision-schema.md`** — YAML schema for decision nodes (follows pattern-schema.md conventions). Fields: id, ticket, chosen, why, alternatives, tags, lineage, files, trust_tier, status.
- **`dx-plan` updated** — New step 5 writes one YAML file per Key Decision to `.ai/graph/nodes/decisions/<ticket>-<slug>.yaml` alongside implement.md. Skipped for trivial changes. Re-planning marks stale decisions as `superseded`.
- **`dx-pattern-extract` updated** — Step 1 split into 1a (scan decision YAML as primary source) and 1b (fallback to implement.md markdown for pre-Phase 4 tickets). Matching heuristics enhanced to use YAML `tags` and `files` fields.
- **TODO docs** — Item #79 marked Done, Phase 4 completion details added.

**Backward compatible:** dx-plan still writes Key Decisions in implement.md (unchanged). YAML files are additional output. dx-pattern-extract falls back to markdown for pre-Phase 4 tickets. No executable code changed.

## Test plan

- [ ] Run `/dx-plan` on a ticket with non-trivial decisions — verify `.ai/graph/nodes/decisions/` contains YAML files matching the Key Decisions section
- [ ] Run `/dx-plan` on a trivial ticket — verify no decision YAML files are written
- [ ] Run `/dx-pattern-extract` with a mix of YAML decision nodes and legacy markdown-only tickets — verify both sources are scanned
- [ ] Re-run `/dx-plan` on same ticket — verify old decision files are overwritten, removed decisions marked `superseded`

https://claude.ai/code/session_01Uxu8LHoAtv2Ayx6DJ5ckPg