### PR TITLE
fix(dx-pr-review): cast PR vote via MCP instead of claiming manual

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,28 +14,28 @@
       "name": "dx-core",
       "source": "./plugins/dx-core",
       "description": "Full-stack development workflow for Azure DevOps projects — requirements, planning, execution, review, bug fixes, and PR management",
-      "version": "2.104.0",
+      "version": "2.104.1",
       "author": { "name": "Dragan Filipovic" }
     },
     {
       "name": "dx-aem",
       "source": "./plugins/dx-aem",
       "description": "AEM component verification, dialog inspection, demo capture, QA automation, and multi-platform project knowledge for Adobe Experience Manager projects",
-      "version": "2.104.0",
+      "version": "2.104.1",
       "author": { "name": "Dragan Filipovic" }
     },
     {
       "name": "dx-hub",
       "source": "./plugins/dx-hub",
       "description": "Multi-repo hub orchestration — run dx skills across sibling repositories from a single hub directory",
-      "version": "2.104.0",
+      "version": "2.104.1",
       "author": { "name": "Dragan Filipovic" }
     },
     {
       "name": "dx-automation",
       "source": "./plugins/dx-automation",
       "description": "Autonomous AI agents for ADO workflows — Definition of Ready checker, Definition of Done checker, DoD fixer, PR reviewer, PR answerer. Runs as ADO pipelines triggered by AWS Lambda webhooks.",
-      "version": "2.104.0",
+      "version": "2.104.1",
       "author": { "name": "Dragan Filipovic" }
     }
   ]

--- a/plugins/dx-aem/.claude-plugin/plugin.json
+++ b/plugins/dx-aem/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx-aem",
   "description": "AEM component verification, dialog inspection, demo capture, QA automation, and multi-platform project knowledge for Adobe Experience Manager projects",
-  "version": "2.104.0",
+  "version": "2.104.1",
   "author": {
     "name": "Dragan Filipovic"
   },

--- a/plugins/dx-automation/.claude-plugin/plugin.json
+++ b/plugins/dx-automation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx-automation",
   "description": "Autonomous AI agents for ADO workflows — Definition of Ready checker, Definition of Done checker, DoD fixer, PR reviewer, PR answerer. Runs as ADO pipelines triggered by AWS Lambda webhooks.",
-  "version": "2.104.0",
+  "version": "2.104.1",
   "author": {
     "name": "Dragan Filipovic"
   },

--- a/plugins/dx-core/.claude-plugin/plugin.json
+++ b/plugins/dx-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dx-core",
   "description": "Full-stack development workflow for Azure DevOps projects — requirements, planning, execution, review, bug fixes, and PR management",
-  "version": "2.104.0",
+  "version": "2.104.1",
   "author": {
     "name": "Dragan Filipovic"
   },

--- a/plugins/dx-core/skills/dx-pr-review/SKILL.md
+++ b/plugins/dx-core/skills/dx-pr-review/SKILL.md
@@ -650,6 +650,26 @@ AskUserQuestion(
 )
 ```
 
+Map the user's choice to the `vote` enum and cast it via MCP:
+
+| Option | `vote` enum | ADO integer |
+|---|---|---|
+| Approve — no critical issues | `Approved` | 10 |
+| Approve with suggestions — minor improvements | `ApprovedWithSuggestions` | 5 |
+| Request changes — critical issues | `WaitingForAuthor` | -5 |
+| (reject variant, if needed) | `Rejected` | -10 |
+| (clear vote) | `NoVote` | 0 |
+| Skip voting — comments only | *(no-op — do not call the tool)* | — |
+
+```
+mcp__ado__repo_vote_pull_request
+  repositoryId: "<repo ID>"
+  pullRequestId: <PR ID>
+  vote: "<Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote>"
+```
+
+The tool auto-adds the caller as a reviewer if not already one. If the user picks **Skip voting — comments only**, do not call the tool.
+
 Never auto-approve or auto-decline without explicit user confirmation.
 
 ---
@@ -853,6 +873,7 @@ Write `.ai/pr-reviews/pr-<id>.md`:
 **Last reviewed:** <ISO date>
 **Review commit:** <SHA>
 **Status:** reviewed | follow-up-needed | complete
+**Vote:** <Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote | skipped> — set via `mcp__ado__repo_vote_pull_request`
 
 ## My Threads
 

--- a/plugins/dx-core/skills/dx-pr-review/references/post-findings.md
+++ b/plugins/dx-core/skills/dx-pr-review/references/post-findings.md
@@ -146,22 +146,26 @@ git apply pr-fixes.patch
 
 Determine vote from the verdict in the findings:
 
-| Verdict | Vote |
-|---------|------|
-| `approved` | Approve (10) |
-| `approved-with-suggestions` | Approve with suggestions (5) |
-| `changes-requested` | Wait for author (-5) |
+| Verdict | `vote` enum | ADO integer |
+|---------|-------------|-------------|
+| `approved` | `Approved` | 10 |
+| `approved-with-suggestions` | `ApprovedWithSuggestions` | 5 |
+| `changes-requested` | `WaitingForAuthor` | -5 |
+| `rejected` *(explicit block)* | `Rejected` | -10 |
+| *(clear existing vote)* | `NoVote` | 0 |
+
+Cast the vote via MCP (the tool auto-adds the caller as a reviewer if not already one):
 
 ```
-mcp__ado__repo_update_pull_request_reviewers
+mcp__ado__repo_vote_pull_request
   repositoryId: "<repo ID>"
   pullRequestId: <PR ID>
-  vote: <vote value>
+  vote: "<Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote>"
 ```
 
-**In interactive mode** (user invoked directly): use `AskUserQuestion` to confirm the vote before setting it.
+**In interactive mode** (user invoked directly): use `AskUserQuestion` to confirm the vote, map the choice to the enum, then call `repo_vote_pull_request`.
 
-**In automation** (pipeline context — detected by prompt containing "analyze only" or "save results", or by being chained after `/dx-pr-review`): set the vote automatically based on the verdict. Do NOT call `AskUserQuestion`.
+**In automation** (pipeline context — detected by prompt containing "analyze only" or "save results", or by being chained after `/dx-pr-review`): cast the vote automatically based on the verdict. Do NOT call `AskUserQuestion`.
 
 ## 7. Update Session
 


### PR DESCRIPTION
## Summary
- Wire `dx-pr-review` step 9 and `post-findings.md` step 6 to actually cast the PR vote via `mcp__ado__repo_vote_pull_request` after user confirmation (previously asked but never called the tool).
- Replace stale `repo_update_pull_request_reviewers` usage in the post-findings path; add vote enum ↔ integer mapping table (Approved=10, ApprovedWithSuggestions=5, WaitingForAuthor=-5, Rejected=-10, NoVote=0).
- Record cast vote in the session-file template (`**Vote:** <value> — set via mcp__ado__repo_vote_pull_request`).
- Patch-bump to 2.104.1 across dx-core, dx-aem, dx-automation plugin manifests and marketplace.json.

## Test plan
- [ ] Run `/dx-pr-review <id>` on a test PR, confirm vote prompt → vote is actually set in ADO.
- [ ] Run `/dx-pr-review-all` pipeline path → verdict auto-casts vote without prompting.
- [ ] Choose "Skip voting — comments only" → no vote cast.
- [ ] `grep -r "set manually in ADO\|can't set vote\|does NOT support setting vote" plugins/` returns nothing.