### PR TITLE
docs(website): clarify costs page reflects tool pricing, not plugin fees

### DIFF
--- a/website/src/pages/costs.mdx
+++ b/website/src/pages/costs.mdx
@@ -12,8 +12,38 @@ import HighlightBox from '../components/HighlightBox.astro';
 
 <PageHero
   title="Costs & Pricing"
-  subtitle="Two pricing models -- fixed subscription for developers, pay-per-token for automation."
+  subtitle="What it costs to run the Agentic CLI tools that execute these workflows -- not a fee for the plugins themselves."
 />
+
+<SectionHeading
+  badge="Read First"
+  badgeColor="secondary"
+  title="These Are Tool Costs, Not Plugin Fees"
+  subtitle="The dx-aem-flow plugins are free. This page explains what the AI tools that run them cost."
+/>
+<Section>
+  <HighlightBox severity="info" title="What you are actually paying for">
+    The **dx-aem-flow plugins** (`dx-core`, `dx-aem`, `dx-hub`, `dx-automation`) are pure Markdown
+    skills, agents, and helper shell scripts. They have **no runtime, no subscription, and no per-token
+    cost** -- they are open-source workflow definitions.
+
+    To execute those workflows you run an **Agentic CLI tool** such as **Claude Code**, Copilot CLI,
+    Cursor, Codex, or similar. Those tools call large language models on your behalf, and *that* is
+    what generates the cost.
+
+    **The numbers on this page reflect:**
+    - Subscription plans for the host CLI (e.g. Claude Max for Claude Code)
+    - Per-token API pricing from the model provider (e.g. Anthropic) when running headless automation
+    - Typical token consumption patterns we observe when these plugins drive a full story
+
+    **They do not reflect:**
+    - Any fee paid to this project, its maintainers, or the plugins themselves
+    - Costs specific to your organisation's ADO / Jira / AEM infrastructure
+
+    If you switch host CLI or model provider, the cost structure changes accordingly -- the workflows
+    stay the same.
+  </HighlightBox>
+</Section>
 
 <SectionHeading
   badge="Pricing"


### PR DESCRIPTION
## Summary
- Add a "Read First" section at the top of `/costs` explaining that the `dx-aem-flow` plugins are pure Markdown + shell scripts with no runtime, subscription, or per-token cost — the figures on the page come from the host Agentic CLI (Claude Code, Copilot CLI, Cursor, Codex, …) and the model provider
- Rewrite the `PageHero` subtitle so the framing starts at first glance instead of only appearing in a later block — the previous subtitle read like the project charged $100/$200/month itself
- No changes to the existing pricing, API-model, or cost-controls sections; alternating `alt ↔ primary` backgrounds preserved

## Test plan
- [ ] `cd website && npm run dev`, open http://localhost:4321/dx-aem-flow/costs/, verify the new "Read First" section renders between the hero and the existing "Two Pricing Models" block
- [ ] Confirm bold / italic / bullet markdown inside the new `<HighlightBox>` compiles (grep the served HTML for `<strong>dx-aem-flow plugins</strong>` — already verified locally)
- [ ] Sanity-check that the section striping still alternates (no two adjacent headings with the same `bg`)
- [ ] Optional: proof-read copy; open to tightening or reverting the hero subtitle if you prefer the original