### PR TITLE
docs(todo): track context-timeline hook and /fork slash command

### DIFF
--- a/docs/research/2026-04-25-platform-state-update.md
+++ b/docs/research/2026-04-25-platform-state-update.md
@@ -94,7 +94,7 @@ Earlier in window: plugin system became first-class with sub-agent addressing, t
 | Opus 4.7 xhigh tier | Claude Code | v2.1.111 | `dx-step-verify`, `dx-pr-review`, `dx-plan` |
 | Agent `mcpServers` frontmatter | Claude Code | v2.1.117 | `dx-aem` agents (isolate AEM/Chrome access) |
 | MCP tool hooks (`type: "mcp_tool"`) | Claude Code | v2.1.118 | `dx-automation` ADO/Jira automation |
-| Forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1`) | Claude Code | v2.1.117 | Pilot with `dx-ticket-analyze`, `aem-page-finder` |
+| Forked subagents (`CLAUDE_CODE_FORK_SUBAGENT=1` env var, `/fork` slash command) | Claude Code | v2.1.117 | Pilot with `dx-ticket-analyze`, `aem-page-finder`. Env var = session-wide blanket inheritance; `/fork` = surgical per-call inheritance (prefer for coordinators that mix context-heavy verifiers with stateless searchers). |
 | Hook `once` field | Claude Code | recent | One-shot init scripts |
 | HTTP hooks | Copilot CLI | v1.0.35 | `dx-automation` Lambda webhooks |
 | `${PLUGIN_ROOT}` / `${COPILOT_PLUGIN_ROOT}` env vars | Copilot CLI | v1.0.26 | Replace path-derivation hacks in hook scripts |

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -120,6 +120,9 @@
 | 92 | Update CLAUDE.md MCP-tool-naming table (Codex + Gemini rows) | Low | Open | 2026-04-25 | [2026-04-25-platform-state-update.md](../research/2026-04-25-platform-state-update.md#tier-3--new-platform-support) — Gemini uses `mcp_<server>_<tool>` (single underscore); Codex scheme TBD |
 | 93 | Remove `--additional-mcp-config` workaround from setup docs | Low | Open | 2026-04-25 | [todo-copilot-cli.md#project-mcp](todo-copilot-cli.md#project-mcp-discovery--closed-2026-04-07) — `website/src/pages/setup/copilot-cli.mdx` |
 
-**Counts:** 93 total — 17 done, 60 open, 4 blocked, 9 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing
+| 94 | Coordinator observability via `context-timeline` hook | Low | Open | 2026-04-27 | [todo-subagent-improvements.md#coordinator-observability](todo-subagent-improvements.md#coordinator-observability--context-timeline-hook) — recommend external `aitmpl.com` hook for fan-out coordinators |
+| 95 | Document `/fork` slash command alongside fork env var | Low | Open | 2026-04-27 | [todo-subagent-improvements.md#on-demand-fork](todo-subagent-improvements.md#on-demand-fork-slash-command-complement-to-env-var) — surgical per-invocation forking; complements TODO #84 |
+
+**Counts:** 95 total — 17 done, 62 open, 4 blocked, 9 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing
 
 Last platform state research: [2026-04-25-platform-state-update.md](../research/2026-04-25-platform-state-update.md)

--- a/docs/todo/todo-subagent-improvements.md
+++ b/docs/todo/todo-subagent-improvements.md
@@ -72,3 +72,26 @@ Improvements inspired by Claude Code's background agent patterns (async dispatch
 - Task subject pattern: `Phase N: <name>` → on completion update to `Phase N: <name> — PASS (key metric)` or `— FAIL (error)`
 - `dx-agent-all` already uses TaskCreate (line 115) — ensure all coordinators follow the same pattern consistently
 - Interactive mode checkpoints still use text (they're decision points)
+
+## Coordinator observability — context-timeline hook
+
+**Added:** 2026-04-27
+**Problem:** When `dx-agent-all` (or any fan-out coordinator) dispatches 5+ `context: fork` subagents, there's no real-time view of which fork is running, how much of its context window each holds, or which one is the slowest. From the TUI you see Tasks updating, but you can't tell whether a fork is stuck on an MCP call vs. genuinely working. Debugging coordinator pipelines today means reading OTel logs after the fact.
+**Scope:** `website/src/pages/setup/` (recommended hooks page), `plugins/dx-core/hooks/hooks.json` (optional pre-registration), `docs/reference/agent-catalog.md` and skill catalog notes for the 5 coordinator skills.
+**Done-when:** The `monitoring/context-timeline` hook from `aitmpl.com` is documented as a recommended optional hook for users running coordinator skills. Install command (`npx claude-code-templates@latest --hook monitoring/context-timeline`) appears in the docs site. Decision recorded on whether to ship it pre-registered in `dx-core/hooks/hooks.json` or leave it user-installed.
+**Approach:**
+- Verify the hook composes cleanly with our existing branch-guard and Stop hooks (no `PreToolUse` / `Stop` matcher conflicts).
+- If compatible, add a "Recommended hooks" section under the website setup pages — clearly marked as optional and external (`aitmpl.com` / `claude-code-templates`).
+- Most useful for fan-out coordinators (`dx-agent-all`, `dx-step-all`, `dx-bug-all`, `dx-figma-all`, `dx-pr-review-all`); not needed for single-skill runs.
+- Source: https://x.com/dani_avila7/status/2048486242321662189
+
+## On-demand `/fork` slash command (complement to env var)
+
+**Added:** 2026-04-27
+**Problem:** TODO #84 covers the `CLAUDE_CODE_FORK_SUBAGENT=1` env var (session-wide fork mode), but Claude Code v2.1.117+ also exposes a `/fork` slash command for per-invocation forking. The env var is all-or-nothing; the slash command lets a coordinator fork only the subagents that actually need parent context (e.g., a verifier reading the plan) while keeping read-heavy ones (`dx-file-resolver`, `dx-doc-searcher`) on a clean blank context.
+**Scope:** `docs/research/2026-04-25-platform-state-update.md` (current entry mentions only the env var), `plugins/dx-core/shared/subagent-contract.md` (forking guidance section).
+**Done-when:** Platform-state doc lists both `CLAUDE_CODE_FORK_SUBAGENT=1` (session-wide) and `/fork` (per-invocation) with a one-line "when to use which". `subagent-contract.md` references `/fork` as the preferred surgical option for coordinators that mix context-heavy verifiers with stateless searchers.
+**Approach:**
+- Short addition to platform-state doc capturing the trade-off (env var = blanket session inheritance; `/fork` = surgical per-call inheritance, prompt cache shared with parent).
+- When piloting #84, prefer `/fork` for `dx-step-verify` (which needs plan + research context) over the env-var approach.
+- Source: https://x.com/dani_avila7/status/2048486242321662189


### PR DESCRIPTION
## Summary

Reviewed [this X article by Daniel Avila](https://x.com/dani_avila7/status/2048486242321662189) on subagent context hygiene. Most ideas (subagent basics, Explore/Plan, frontmatter shape, `CLAUDE_CODE_FORK_SUBAGENT=1`) are already covered in `CLAUDE.md`, `subagent-contract.md`, and TODO #84. Two genuinely new items surfaced:

- **TODO #94** — recommend the external `monitoring/context-timeline` hook (`aitmpl.com`) as an optional observability tool for fan-out coordinators (`dx-agent-all`, `dx-step-all`, etc.) that dispatch 5+ `context: fork` subagents. Today there's no real-time view of which fork is running or how much context each holds.
- **TODO #95** — document the `/fork` slash command alongside the existing `CLAUDE_CODE_FORK_SUBAGENT` env var. Slash command enables surgical per-call forking; env var is session-wide. Useful for coordinators that mix context-heavy verifiers (need parent context) with stateless searchers (cleaner blank).

Also expanded the v2.1.117 row in `docs/research/2026-04-25-platform-state-update.md` to mention both forking surfaces and when each applies.

## Test plan

- [ ] `docs/todo/TODO.md` shows rows #94 and #95 with correct anchors
- [ ] Anchors in `todo-subagent-improvements.md` resolve (`#coordinator-observability--context-timeline-hook`, `#on-demand-fork-slash-command-complement-to-env-var`)
- [ ] Counts line in `TODO.md` reads "95 total — ... 62 open ..."
- [ ] No code or skill behavior changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuucZPrbEtCdvAnTwJPjF9)_