### PR TITLE
fix(dx-req,dx-dor): cap Phase 1 context — adaptive research + DoR cache (#136)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ website/.astro/
 .ai/pr-answers/
 .ai/pr-reviews/
 .ai/logs/
+.ai/cache/
 .ai/me.md
 internal/
 docs/superpowers/

--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -266,6 +266,24 @@ Override plugin default prompts without replacing the full file.
 | `auto-commit` | bool | false | Commit after each step without asking |
 | `auto-pr` | bool | false | Create PR after all steps complete |
 
+### `research`
+
+Controls Phase 4 of `/dx-req` (codebase research). Mitigates the context blow-up documented in issue #136.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `profile` | string | `auto` | `auto` \| `minimal` \| `frontend` \| `backend` \| `full`. `auto` picks the smallest profile that covers the story (see `plugins/dx-core/skills/dx-req/references/research-patterns.md`). Override per run via `DX_RESEARCH_PROFILE`. |
+| `agent-word-cap` | number | `800` | Hard cap on words per Explore-agent report. The orchestrator summarizes anything longer to ≤300 words before writing into research.md. |
+| `agent-file-cap` | number | `10` | Maximum files an Explore-agent may list in its inventory. |
+
+### `dor`
+
+Controls `/dx-dor` wiki resolution + caching. Mitigates the wiki-tree blowup from issue #136.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cache-ttl-seconds` | number | `86400` | TTL for `.ai/cache/dor-checklist.md`. Within this window, `/dx-dor` skips the wiki MCP call entirely. Set `0` to disable caching. |
+
 ## Learning Directory (auto-generated)
 
 Coordinator skills automatically create `.ai/learning/` to store run metrics and patterns. No config needed.
@@ -294,6 +312,8 @@ These environment variables are set on ADO pipeline runs and read by skills at r
 | `ADO_ORG_URL` | ADO org URL (e.g. `https://yourorg.visualstudio.com`). Used for plugin marketplace auth and cross-repo delegation. |
 | `ADO_ORG_NAME` | Short ADO org name (e.g. `myorg`). Read by `pipeline-agent.js` for org identification. Falls back to `"myorg"` if not set. |
 | `DX_MARKETPLACE_URL` | Git URL with ref for the plugin marketplace repo. Only used when `dx-aem-flow/` is not available locally (cross-repo pipelines). |
+| `DX_RESEARCH_PROFILE` | `minimal` \| `frontend` \| `backend` \| `full`. Forces the Phase 4 research profile (`/dx-req`). Overrides `research.profile` in `config.yaml`. Set to `minimal` on 200k-context models. |
+| `DX_HOOK_PROFILE` | `minimal` \| `standard` \| `strict`. Hook strictness — see "Hook Profiles" in CLAUDE.md. |
 
 ### Code-Writing Pipelines (BugFix, DevAgent, DoD-Fix)
 

--- a/plugins/dx-core/skills/dx-agent-all/SKILL.md
+++ b/plugins/dx-core/skills/dx-agent-all/SKILL.md
@@ -57,6 +57,29 @@ If the user said "autonomous", "auto", or "hands-free", use autonomous mode.
 - **Never read spec files in the main orchestrator** — trust skill return summaries
 - Keep dev-all's own context to orchestration only: phase status, short summaries, user interaction
 
+### Low-context mode (200k models)
+
+If the user is on a 200k-context model OR the env var `DX_LOW_CONTEXT=1` is set, apply these defaults before Phase 1 starts:
+
+- `DX_RESEARCH_PROFILE=minimal` (Phase 4 of `/dx-req` dispatches 2 agents instead of 4 — see issue #136)
+- `dor.cache-ttl-seconds` honored (24h cache on the DoR checklist)
+- After each phase, print: `phase <N> done — context budget: <free>/200k (used <delta>k)`. Use the harness's reported usage; do not estimate.
+
+These can also be set per-run via `/dx-agent-all <id> low-context` (the orchestrator exports the env var before invoking sub-skills).
+
+### Token instrumentation (optional)
+
+When `DX_TOKEN_TRACE=1`, write per-phase token deltas to `$SPEC_DIR/dev-all-tokens.tsv`:
+
+```
+phase	tokens_in	tokens_out	cumulative
+1-requirements	12000	48000	60000
+2-planning	2000	14000	76000
+...
+```
+
+This is the source of truth for diagnosing future context regressions — without it, "Phase X is too expensive" claims are unverifiable.
+
 ## Progress Logging
 
 Before starting the pipeline, count the total phases that will run (including optional ones that apply). Assign each phase a sequential number. Every phase log message MUST include the progress counter in `(current/total)` format.

--- a/plugins/dx-core/skills/dx-dor/SKILL.md
+++ b/plugins/dx-core/skills/dx-dor/SKILL.md
@@ -78,7 +78,9 @@ digraph dx_dor {
 ### Fetch DoR wiki
 
 - Read `references/wiki-parsing.md` for the full parsing and fallback chain logic
-- Fetch the wiki page using the URL from config (`scm.wiki-dor-url`) or Confluence (`confluence.dor-page-title`)
+- **Cache first:** check `.ai/cache/dor-checklist.md` (TTL 24h, override via `dor.cache-ttl-seconds`). If hit, skip the MCP call entirely — the checklist rarely changes and a tree-traversal `wiki_get_page` against a parent section pulls ~270kB of JSON (≈65–80k tokens) into the parent thread. This is the second-largest Phase 1 context cost (issue #136).
+- **Cache miss:** fetch the wiki page using the URL from config (`scm.wiki-dor-url` — preferred, no tree traversal) or Confluence (`confluence.dor-page-title`). If URL resolution fails, use `wiki_search` with the page title — never `wiki_get_page` against a parent section. If a tree fetch is genuinely needed, dispatch it to a subagent so the raw JSON never lands here.
+- Write the resolved body to `.ai/cache/dor-checklist.md` with metadata in `.ai/cache/dor-checklist.meta.json`
 
 ### Existing [DoRAgent] comment?
 

--- a/plugins/dx-core/skills/dx-dor/references/wiki-parsing.md
+++ b/plugins/dx-core/skills/dx-dor/references/wiki-parsing.md
@@ -2,19 +2,61 @@
 
 ## Fetch DoR Checklist
 
+The DoR checklist rarely changes between tickets, but the wiki resolution path is expensive — a tree-traversal `wiki_get_page` call against a parent section can return a ~270kB JSON blob describing every nested page (≈65–80k tokens). Issue #136 showed that landing on every `/dx-dor` run was the second-largest Phase 1 context cost. The fetch path below caches the resolved content on disk and never lets the raw tree blob reach the parent thread.
+
+### Cache-first
+
+Before any MCP call, check `.ai/cache/dor-checklist.md`:
+
+```bash
+CACHE=.ai/cache/dor-checklist.md
+META=.ai/cache/dor-checklist.meta.json
+TTL_SECONDS=86400  # 24h — checklists are stable
+
+if [ -f "$CACHE" ] && [ -f "$META" ]; then
+  AGE=$(($(date +%s) - $(stat -c %Y "$CACHE" 2>/dev/null || stat -f %m "$CACHE")))
+  if [ "$AGE" -lt "$TTL_SECONDS" ]; then
+    echo "DoR checklist cache hit ($CACHE, age ${AGE}s)"
+    # Read $CACHE and proceed to "Parse Wiki Content"
+  fi
+fi
+```
+
+`$META` records the resolved source path / page ID and last-fetched timestamp so a re-run can short-circuit. To force a refresh: `rm .ai/cache/dor-checklist.md` or pass `--no-cache` to `/dx-dor`. Override TTL via `dor.cache-ttl-seconds` in `.ai/config.yaml` (default `86400`).
+
+### Cache miss — resolve once, cache the body
+
 Read `.ai/config.yaml` and attempt each source in order:
 
 1. **ADO Wiki** — if `scm.wiki-dor-url` is configured:
    ```
    mcp__ado__wiki_get_page_content  url: <scm.wiki-dor-url>
    ```
-   If fetch fails, try next source.
+   The URL form is the cheap path — no tree traversal. Pass the **full** URL exactly as configured. If `scm.wiki-dor-url` is missing or the call fails with a path-resolution error, fall back to the search path below.
+
+   **Search fallback (issue #136 — never traverse the parent tree):**
+   ```
+   mcp__ado__wiki_search  searchText: "<DoR page title from scm.wiki-dor-page-title or 'Definition of Ready'>"
+   ```
+   Take the top hit, then call `wiki_get_page_content` with that hit's path. Do **not** call `wiki_get_page` against a parent section to enumerate children — that returns the full subtree JSON (~270kB) which is the exact failure mode #136 documents.
+
+   **If a tree fetch is genuinely unavoidable** (e.g., disambiguating multiple candidate pages), dispatch it to a subagent with this contract:
+   > "Use `mcp__ado__wiki_get_page` for path `<X>`. Return ONLY the resolved `gitItemPath` of the page whose title matches `<title>`. Do not paste the JSON tree."
+   The raw blob then stays in the subagent context and only the resolved path crosses back.
+
+   On success, write the markdown body to `.ai/cache/dor-checklist.md` and metadata to `.ai/cache/dor-checklist.meta.json`:
+   ```json
+   {"source": "ado-wiki", "url": "...", "gitItemPath": "...", "fetched_at": "<ISO-8601>"}
+   ```
+
 2. **Confluence** — if `confluence.dor-page-title` + `confluence.space-key` are configured:
    ```
    mcp__atlassian__confluence_search  cql: "title = '<dor-page-title>' AND space = '<space-key>'"
    ```
-   Extract page ID, then `mcp__atlassian__confluence_get_page  page_id: "<id>"`.
-3. **Local file** — if `.ai/rules/dor-checklist.md` exists, read it (same checkbox format as wiki).
+   Extract page ID, then `mcp__atlassian__confluence_get_page  page_id: "<id>"`. Cache the body to `.ai/cache/dor-checklist.md` with `{"source":"confluence","page_id":"<id>","fetched_at":"<ts>"}`.
+
+3. **Local file** — if `.ai/rules/dor-checklist.md` exists, read it (same checkbox format as wiki). No caching needed (already on disk).
+
 4. **None available** — print error and STOP:
    `No DoR checklist source found. Configure scm.wiki-dor-url, confluence.dor-page-title, or create .ai/rules/dor-checklist.md.`
 

--- a/plugins/dx-core/skills/dx-req/SKILL.md
+++ b/plugins/dx-core/skills/dx-req/SKILL.md
@@ -518,10 +518,16 @@ This phase spawns parallel Explore subagents for codebase searching. Read `refer
 2b. **Read AEM Component Discovery** — If `.ai/project/component-discovery.md` exists, read it. For each component named in `explain.md` or `raw-story.md`, extract its entry (dialog fields, variants, pages, authored values). Append to `$CONTEXT` as `$AEM_CONTEXT`. This enriches all 4 subagents with field semantics and variant awareness without any additional MCP calls.
 3. **Identify search targets** — component/feature names, class patterns, property names, resource types, endpoint paths, keywords
 4. **Check existing output** — if `research.md` exists, check staleness (title match, files still exist, explain.md changed). If current → skip.
-5. **Dispatch 4 parallel Explore subagents:**
-   - **Agent 1: UI Layer** — templates, views, config/dialog files, frontend components
-   - **Agent 2: Models & Data** — model/entity classes, properties, service dependencies
-   - **Agent 3: Services & API** — services, exporters, endpoints, config interfaces
+4b. **Pick a research profile** — read `references/research-patterns.md` ("Adaptive Research Scope"). Resolve in this order: `DX_RESEARCH_PROFILE` env var → `research.profile` in `.ai/config.yaml` → `auto` heuristic from share-plan.md / explain.md scope. Default `auto` selects:
+   - `minimal` for copy / config / single-property tweaks (≤3 requirements, no service or model work)
+   - `frontend` for FE-only changes
+   - `backend` for API/service-only changes
+   - `full` for Medium/Large stories or anything touching backend + frontend
+   Print: `Phase 4: research profile = <profile> (<reason>)`. This is the dominant Phase 1 context cost — picking `minimal` instead of `full` saves ~400k tokens on a typical run (issue #136).
+5. **Dispatch the agents picked by the profile, in parallel.** Always pass the per-agent output budget (≤800 words, ≤10 files, no code >5 lines, early-exit) — see `references/research-patterns.md` "Per-Agent Output Budget":
+   - **Agent 1: UI Layer** — templates, views, config/dialog files, frontend components *(skipped in `backend` profile)*
+   - **Agent 2: Models & Data** — model/entity classes, properties, service dependencies *(skipped in `minimal` profile)*
+   - **Agent 3: Services & API** — services, exporters, endpoints, config interfaces *(skipped in `minimal` and `frontend` profiles)*
    - **Agent 4: Tests & Fixtures** — test classes, fixtures, coverage gaps
 5b. **AEM Discovery Fallback** — If `component-discovery.md` is missing, stale (>7 days), or doesn't cover a component named in `explain.md`, dispatch a 5th parallel agent (inline, not a named agent file) that queries AEM QA via `mcp__plugin_dx-aem_AEM__getNodeContent` and `mcp__plugin_dx-aem_AEM__searchContent` for the missing components only. Agent receives: component names, `aem.author-url-qa`, `aem.component-path` from config. Appends results to the synthesis. This is a safety net — if aem-init was run properly, Layer 1 (step 2b) covers it.
 6. **Synthesize into research.md** — follow `.ai/templates/spec/research.md.template` (includes provenance frontmatter — use confidence `high`; downgrade to `medium` if agents failed and fell back to partial results). Merge ticket-research data. Include Existing Implementation Check (MANDATORY). **Append `## AEM Component Intelligence` section** with per-component entries from `$AEM_CONTEXT` (or Layer 2 fallback): dialog fields with labels, variants (this repo + other repos), pages, field semantics (authored values revealing what each field actually contains). If no AEM data available, omit section.

--- a/plugins/dx-core/skills/dx-req/references/research-patterns.md
+++ b/plugins/dx-core/skills/dx-req/references/research-patterns.md
@@ -69,11 +69,49 @@ Figma: [urls]
 
 If no pre-existing data is found, set `$CONTEXT` with project-level info only — subagents use broader codebase search.
 
+## Adaptive Research Scope
+
+Phase 4 used to dispatch 4 broad parallel agents unconditionally. Measured runs showed ~557k tokens of agent output landing back in the parent thread before planning even started (issue #136). To keep Phase 1 fitting in a 200k context window, the orchestrator now picks a profile *before* dispatching:
+
+| Profile | Agents dispatched | When to use |
+|---------|------------------|-------------|
+| `minimal` | Agent 1 (UI) + Agent 4 (Tests) | Markup-only / copy / config / single-property tweaks. Default for stories tagged `change-type: copy` or scope `Small` in share-plan.md. |
+| `frontend` | Agents 1, 2, 4 | FE-only changes (no service or exporter work). Skip Agent 3. |
+| `backend` | Agents 2, 3, 4 | API/service-only changes (no UI). Skip Agent 1's frontend slice. |
+| `full` | All 4 | Default for `Medium`/`Large` stories or anything touching backend + frontend. |
+
+**How to decide:** read `share-plan.md` (if Phase 5 has been run for a previous re-run) or `explain.md` and pick the smallest profile that covers the requirements. Err on the side of `minimal` for stories with ≤3 numbered requirements and no API or model changes — adding a follow-up narrow agent later is cheaper than re-running the full quartet.
+
+**Override via env var:** `DX_RESEARCH_PROFILE=full|frontend|backend|minimal` forces the profile (used by automation pipelines and the low-context mode in `docs/reference/low-context-mode.md`).
+
+**Override via config:** `.ai/config.yaml` may set `research.profile: minimal|frontend|backend|full|auto` (default `auto`). `auto` follows the table above.
+
+Print the chosen profile before dispatch: `Phase 4: research profile = <profile> (<reason>)`.
+
 ## 4 Parallel Explore Subagents
 
-Spawn **4 Explore subagents** via the Agent tool, all running in parallel. Each agent receives the search targets, the explain.md content, and `$CONTEXT` (if available) for context.
+Spawn the Explore subagents picked by the profile above via the Agent tool, all running in parallel. Each agent receives the search targets, the explain.md content, and `$CONTEXT` (if available) for context.
 
 **When `$CONTEXT` has file paths:** Agents 1 and 2 switch from **discovery mode** (grep/glob the codebase) to **analysis mode** (read known files, analyze their contents in depth). This is faster and produces richer findings.
+
+### Per-Agent Output Budget (mandatory)
+
+Every Explore-agent prompt MUST include this contract verbatim — it caps the tokens that flow back into the parent thread:
+
+> **Output budget:** report findings in **≤800 words**. List **at most 10 files** with one-line annotations. Do not paste code blocks longer than 5 lines (link to `path:line` instead). Stop searching as soon as you have located the relevant code — exhaustive enumeration of the codebase is out of scope.
+
+Concretely, append to each agent's prompt:
+
+```
+Output rules:
+- ≤800 words total.
+- ≤10 files in the inventory; one-line annotation each.
+- No code snippets >5 lines; cite `path:line` instead.
+- Early-exit: once you've found the files that answer the search targets, stop. Don't keep exploring "for completeness".
+- If a search target is clearly irrelevant to this story's scope, skip it and say so in one line.
+```
+
+If an agent returns >1200 words anyway, the orchestrator must summarize the agent's report into ≤300 words *before* writing it into research.md. The raw report stays in the subagent context only.
 
 ### Agent 1: UI Layer (Templates, Views & Config)
 
@@ -154,7 +192,9 @@ Read `.ai/templates/spec/research.md.template` and follow that structure exactly
 - **Include file paths with line numbers** — for specific findings, reference `path/to/File.ext:45` so the developer can jump straight there.
 - **Include short code snippets** — when a finding is about a specific pattern or structure, show the relevant 5-10 lines. Don't dump entire files.
 - **Mark "not found" clearly** — if searching for a component's test and none exists, say "No existing tests found" not silence.
-- **Parallel is key** — launch all 4 subagents simultaneously for speed. Don't run them sequentially.
+- **Parallel is key** — launch the dispatched subagents simultaneously for speed. Don't run them sequentially.
+- **Profile-first** — pick the smallest research profile that covers the story (see "Adaptive Research Scope" above). The default of "all 4 agents" is wrong for small stories — it's the dominant Phase 1 context cost (issue #136).
+- **Cap every agent's output** — every prompt must carry the ≤800 words / ≤10 files / no large code blocks contract. An uncapped agent can pull >150k tokens into the parent thread by itself.
 - **Never fail silently** — if an agent errors (response length limit, timeout, stale), retry once narrower, then fall back to inline Glob/Grep. Always produce research.md.
 - **Stay focused** — only report findings relevant to the story requirements. Don't catalogue the entire codebase.
 - **Findings ≠ risks** — Key Findings should be factual discoveries ("component uses show/hide config", "no exporter exists"). Don't speculate about blockers or risks — that's for plan and plan-validate.

--- a/plugins/dx-core/templates/INDEX.md.template
+++ b/plugins/dx-core/templates/INDEX.md.template
@@ -66,5 +66,6 @@ Machine-readable entry point for AI agents. All paths relative to repo root.
 | `.ai/lib/` | Shared utilities (audit.sh) | Yes |
 | `.ai/specs/` | Per-ticket output (raw-story, explain, research, implement) | No (gitignored) |
 | `.ai/pr-reviews/` | PR review session data | No (gitignored) |
+| `.ai/cache/` | Cached resources (DoR checklist, etc.) — saves tokens by avoiding refetch | No (gitignored) |
 | `.claude/rules/` | Auto-loaded coding conventions | Yes |
 | `.claude/hooks/` | Lifecycle hooks (stop-guard) | Yes |


### PR DESCRIPTION
## Summary

Closes #136. Phase 1 of `/dx-agent-all` could exhaust the context window before Phase 2 even started, forcing `/compact` mid-pipeline and breaking plan/todo continuity. Two dominant causes addressed; a third is partially mitigated.

## Changes

### 1. dx-req Phase 4 — adaptive research scope + per-agent budgets

The original Phase 4 always dispatched 4 broad parallel Explore agents. Measured runs showed ~557k tokens of agent output landing back in the parent thread before planning began.

- **New `research.profile` config** (`auto|minimal|frontend|backend|full`) + `DX_RESEARCH_PROFILE` env override.
  - `auto` (default) picks the smallest profile that covers the story.
  - `minimal` dispatches 2 agents instead of 4 (UI + Tests) — typical saving ~400k tokens for small/markup stories.
  - `frontend` skips the Services/API agent.
  - `backend` skips the UI agent.
- **Mandatory per-agent output budget** in every Explore prompt:
  - ≤800 words total.
  - ≤10 files in the inventory.
  - No code blocks >5 lines (cite `path:line` instead).
  - Early-exit when relevant code is found.
- **Hard ceiling:** if an agent returns >1200 words anyway, the orchestrator summarizes to ≤300 words *before* writing to research.md. Raw output stays in the subagent context only.

### 2. dx-dor — disk-cache the DoR checklist

Resolving the DoR checklist used to call `wiki_get_page` against a parent section, returning a ~270kB JSON tree (~65–80k tokens) on every run.

- **Cache resolved checklist body** to `.ai/cache/dor-checklist.md` with 24h TTL (override via `dor.cache-ttl-seconds`). Subsequent runs skip the wiki MCP call entirely.
- **Documented the failure mode:** never call `wiki_get_page` against a parent section. Use `wiki_get_page_content` with the configured URL (cheap path), or fall back to `wiki_search` by title.
- **If a tree fetch is genuinely unavoidable,** dispatch it to a subagent — the raw JSON stays in the subagent context, only the resolved path crosses back.

### 3. dx-agent-all — low-context mode + token instrumentation

- **Low-context mode** for 200k-context models: `DX_LOW_CONTEXT=1` (or `/dx-agent-all <id> low-context`) exports `DX_RESEARCH_PROFILE=minimal`, honors the DoR cache, and prints per-phase budget deltas.
- **Optional token trace:** `DX_TOKEN_TRACE=1` writes per-phase token deltas to `$SPEC_DIR/dev-all-tokens.tsv` so future regressions are diagnosable from data, not vibes.

## Files changed

- `plugins/dx-core/skills/dx-req/SKILL.md` — Phase 4 step 4b/5 (profile selection + budget contract)
- `plugins/dx-core/skills/dx-req/references/research-patterns.md` — Adaptive Research Scope + Per-Agent Output Budget sections
- `plugins/dx-core/skills/dx-dor/SKILL.md` — Fetch DoR wiki step (cache-first)
- `plugins/dx-core/skills/dx-dor/references/wiki-parsing.md` — Cache-first / cache-miss flow + tree-fetch warning
- `plugins/dx-core/skills/dx-agent-all/SKILL.md` — Low-context mode + token instrumentation
- `docs/reference/config-reference.md` — new `research.*` and `dor.cache-ttl-seconds` keys + `DX_RESEARCH_PROFILE` env var
- `plugins/dx-core/templates/INDEX.md.template`, `.gitignore` — `.ai/cache/` entry

## Test plan

- [ ] Run `/dx-agent-all <id>` against a small markup-only story — verify Phase 4 prints `research profile = minimal` and dispatches 2 agents.
- [ ] Run `/dx-agent-all <id>` against a Medium/Large story — verify `research profile = full` (or `frontend`/`backend` as appropriate) and 4-agent dispatch behaves as before.
- [ ] Run `/dx-dor <id>` twice in a row — second run hits cache, no wiki MCP call, completes near-instantly.
- [ ] Delete `.ai/cache/dor-checklist.md` and re-run — cache rebuilds, behavior matches first run.
- [ ] Set `DX_RESEARCH_PROFILE=minimal` and run `/dx-req` against a Large story — confirm override beats the auto-selected profile.
- [ ] Set `DX_TOKEN_TRACE=1` and run `/dx-agent-all` — verify `dev-all-tokens.tsv` is written with per-phase deltas.
- [ ] Inspect a real Phase 4 dispatch in transcript — confirm every Explore-agent prompt carries the ≤800 words / ≤10 files / no code >5 lines contract verbatim.

Refs #136.

---
_Generated by [Claude Code](https://claude.ai/code/session_013j1YLYecXR7bn561zX44Nu)_