### PR TITLE
fix(dx-core): detect truncated ADO image attachments + auto-discover lib files

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -129,7 +129,8 @@
 | 100 | Pilot `claude_code.skill_activated` OTel event | Low | Open | 2026-05-01 | [2026-05-01-platform-state-update.md](../research/2026-05-01-platform-state-update.md#newly-opened--changed) — Claude Code v2.1.126 OTel event with `invocation_trigger` (`user-slash`/`claude-proactive`/`nested-skill`); useful telemetry for `dx-automation` |
 | 101 | Update `cli-vs-chat.mdx` for VS Code 1.118 (skill-isolated subagents) | Low | **Done** | 2026-05-01 | [2026-05-01-platform-state-update.md](../research/2026-05-01-platform-state-update.md#newly-closed) — `context: fork` row updated from "Ignored" to "Experimental (1.118+)"; hooks row updated to 29 events |
 | 102 | Audit `mcp__github__` references vs ADO auto-disable (Copilot v1.0.40) | Low | Open | 2026-05-01 | [todo-copilot-cli.md#prompt-mode-gates-v1040](todo-copilot-cli.md#prompt-mode-gates-v1040) — Copilot v1.0.40 auto-disables GitHub MCP on detected ADO repos; verify `dx-automation` skills do not break |
+| 103 | ADO MCP `wit_get_work_item_attachment` truncates >75 KB attachments | High | Blocked (upstream) | 2026-05-04 | [todo-bugs.md#ado-mcp-wit_get_work_item_attachment-truncates-large-attachments](todo-bugs.md#ado-mcp-wit_get_work_item_attachment-truncates-large-attachments) — silent base64 truncation produces files that pass header checks but 400 on Anthropic full decode. Mitigated locally in `validate-image.sh` v2 (structural decode); upstream fix needed in `microsoft/azure-devops-mcp` |
 
-**Counts:** 102 total — 18 done, 67 open, 4 blocked, 10 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing, 1 re-test
+**Counts:** 103 total — 18 done, 68 open, 5 blocked, 10 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing, 1 re-test
 
 Last platform state research: [2026-05-01-platform-state-update.md](../research/2026-05-01-platform-state-update.md) (delta to [2026-04-25-platform-state-update.md](../research/2026-04-25-platform-state-update.md))

--- a/docs/todo/todo-bugs.md
+++ b/docs/todo/todo-bugs.md
@@ -33,6 +33,14 @@
 **Done-when:** `grep -n "DoRAgent\|BEFORE posting\|fetch.*comment.*search" plugins/dx-core/skills/dx-dor/SKILL.md plugins/dx-core/skills/dx-dor/references/comment-format.md` shows explicit instructions to (a) use `[DoRAgent]` signature and (b) fetch existing comments before posting.
 **Approach:** Standardize on `[DoRAgent]` signature in dx-dor skill and comment-format.md reference. The signature detection and comment-checking flow are now in the standalone `/dx-dor` skill.
 
+## ADO MCP `wit_get_work_item_attachment` truncates large attachments
+
+**Added:** 2026-05-04
+**Problem:** `mcp__ado__wit_get_work_item_attachment` silently truncates the base64 payload for some attachments above ~75 KB. The returned bytes decode to a file whose IHDR/dimensions/MIME look correct (so `file --mime-type`, `file -b`, and `PIL.Image.open()` all pass) but whose IDAT stream is incomplete (no IEND chunk). When that file is loaded via the Read tool, Anthropic's vision API does a full decode and returns `API Error: 400 — Could not process image`, aborting the whole turn. Reproducible: WI 2490722 attachment `47ead4d5-723c-413c-8aa2-afe8414ecf1d` returns 74967 bytes; clean MCP fetch and agent-improvised decode produce the same SHA256, so truncation is upstream of any client code. Likely cause: a JSON-RPC message-size cap inside `@azure-devops/mcp` truncating Resource blobs before base64-encoding.
+**Scope:** `@azure-devops/mcp` (microsoft/azure-devops-mcp). Local mitigation lives in `plugins/dx-core/data/lib/validate-image.sh` (PNG/JPEG/GIF/WebP structural decode that catches truncation before Read).
+**Done-when:** A 100 KB+ ADO attachment fetched via `mcp__ado__wit_get_work_item_attachment` returns the full byte stream — `bash plugins/dx-core/data/lib/validate-image.sh <saved-file>` exits 0 with `ok:` rather than `skip: truncated: ...`. Until then, the validator quarantines truncated files into INDEX.md's `## Skipped` section so dx-req can complete.
+**Approach:** File issue against `microsoft/azure-devops-mcp`. Until upstream fix lands, defense-in-depth in the validator is sufficient — affected attachments get skipped rather than 400-ing the turn. Optional follow-up: add a REST-API fallback in `fetch-raw-story.js` that re-fetches with curl + ADO PAT when MCP returns truncated bytes.
+
 ## Subagent Hooks — RESOLVED 2026-04-25
 
 **Added:** 2026-03-03

--- a/plugins/dx-core/data/lib/validate-image.sh
+++ b/plugins/dx-core/data/lib/validate-image.sh
@@ -18,9 +18,17 @@
 #   * files larger than 5 MB after decode
 #   * dimensions that exceed 8000 px on either side, or are 0
 #   * empty or unreadable files
+#   * files that fail a structural decode (truncated stream, corrupt
+#     chunk CRC, missing terminator) — header-only checks (`file`) miss
+#     these because IHDR can be intact while IDAT is incomplete. Observed
+#     failure mode: the ADO MCP (`wit_get_work_item_attachment`) silently
+#     truncates large attachments, producing a file that passes MIME and
+#     dimension checks but trips Anthropic's full-decode pass with
+#     `API Error: 400 — Could not process image`.
 #
-# Pure POSIX tools — uses `file` (always present) for MIME and dimension
-# detection. ImageMagick is not required.
+# Uses `file` (always present) for MIME and dimensions, plus python3
+# stdlib (always present on macOS/Linux) for the structural decode.
+# ImageMagick is not required.
 #
 # Usage:
 #   validate-image.sh <path>
@@ -85,6 +93,79 @@ if [[ -n "$DIMS" ]]; then
   fi
   if (( W > 8000 || H > 8000 )); then
     echo "skip: dimensions ${W}x${H} exceed 8000 px on a side" >&2
+    exit 1
+  fi
+fi
+
+# 4. Structural integrity — walk the file's container format end-to-end so
+#    truncation or corruption inside the data stream is caught before the
+#    file ever reaches the Read tool. `file -b` only inspects the header,
+#    so a half-downloaded PNG with a valid IHDR but a missing IEND will
+#    pass steps 1-3. Skipped if python3 is unavailable (fail open — match
+#    the historical behavior so this script never becomes harder to install).
+if command -v python3 >/dev/null 2>&1; then
+  # Use `if !` so set -e doesn't kill the script before we report the reason.
+  REASON=""
+  if ! REASON=$(python3 - "$FILE" "$MIME" 2>&1 <<'PY'
+import sys, struct, zlib
+
+path, mime = sys.argv[1], sys.argv[2]
+with open(path, 'rb') as f:
+    data = f.read()
+
+def fail(msg):
+    print(msg)
+    sys.exit(1)
+
+if mime == 'image/png':
+    if data[:8] != b'\x89PNG\r\n\x1a\n':
+        fail("corrupt: PNG signature missing")
+    i = 8
+    seen_iend = False
+    while i < len(data):
+        if i + 12 > len(data):
+            fail(f"truncated: incomplete chunk header at offset {i}")
+        length = struct.unpack(">I", data[i:i+4])[0]
+        ctype = data[i+4:i+8]
+        ctype_s = ctype.decode('ascii', errors='replace')
+        end = i + 8 + length + 4
+        if end > len(data):
+            fail(f"truncated: {ctype_s} chunk length {length} would overrun file (have {len(data)-i-8} of {length+4} bytes)")
+        crc_stored = struct.unpack(">I", data[i+8+length:i+12+length])[0]
+        crc_calc = zlib.crc32(data[i+4:i+8+length]) & 0xffffffff
+        if crc_stored != crc_calc:
+            fail(f"corrupt: bad CRC in {ctype_s} chunk")
+        if ctype == b'IEND':
+            seen_iend = True
+            break
+        i = end
+    if not seen_iend:
+        fail("truncated: no IEND chunk")
+
+elif mime == 'image/jpeg':
+    if data[:2] != b'\xff\xd8':
+        fail("corrupt: JPEG missing SOI marker")
+    if data[-2:] != b'\xff\xd9':
+        fail("truncated: JPEG missing EOI marker")
+
+elif mime == 'image/gif':
+    if data[:6] not in (b'GIF87a', b'GIF89a'):
+        fail("corrupt: GIF header missing")
+    if data[-1:] != b'\x3b':
+        fail("truncated: GIF missing trailer (0x3B)")
+
+elif mime == 'image/webp':
+    if data[:4] != b'RIFF' or data[8:12] != b'WEBP':
+        fail("corrupt: WebP RIFF header missing")
+    riff_size = struct.unpack("<I", data[4:8])[0]
+    if riff_size != len(data) - 8:
+        fail(f"truncated: WebP RIFF size {riff_size} vs payload {len(data)-8}")
+
+# unknown MIMEs were filtered upstream; nothing to check here
+sys.exit(0)
+PY
+  ); then
+    echo "skip: ${REASON:-integrity check failed}" >&2
     exit 1
   fi
 fi

--- a/plugins/dx-core/data/lib/validate-image.test.sh
+++ b/plugins/dx-core/data/lib/validate-image.test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Tests for validate-image.sh. Run with:
+#   bash plugins/dx-core/data/lib/validate-image.test.sh
+#
+# No framework — exits 0 on success, 1 on first failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="$SCRIPT_DIR/validate-image.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3" stderr="$4"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  ok: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+    echo "    expected exit=$expected, got exit=$actual"
+    [[ -n "$stderr" ]] && echo "    stderr: $stderr"
+  fi
+}
+
+# --- Fixtures: synthesize PNGs via python stdlib (no third-party deps) ---
+
+python3 - "$TMPDIR" <<'PY'
+import sys, struct, zlib, os
+
+td = sys.argv[1]
+
+def make_png(width, height):
+    """Build a minimal valid PNG (single-color rectangle)."""
+    sig = b'\x89PNG\r\n\x1a\n'
+    def chunk(ctype, data):
+        return struct.pack(">I", len(data)) + ctype + data + struct.pack(">I", zlib.crc32(ctype + data) & 0xffffffff)
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)  # 8-bit RGB
+    raw = b''
+    for _ in range(height):
+        raw += b'\x00' + b'\xff\x00\x00' * width  # filter + red pixels
+    idat = zlib.compress(raw, 9)
+    return sig + chunk(b'IHDR', ihdr) + chunk(b'IDAT', idat) + chunk(b'IEND', b'')
+
+# valid small PNG
+valid = make_png(2, 2)
+with open(os.path.join(td, "valid.png"), "wb") as f:
+    f.write(valid)
+
+# truncated PNG — chop last 12 bytes (removes IEND chunk entirely)
+with open(os.path.join(td, "truncated-no-iend.png"), "wb") as f:
+    f.write(valid[:-12])
+
+# truncated PNG — chop mid-IDAT (removes 5 bytes from end before IEND)
+with open(os.path.join(td, "truncated-mid-idat.png"), "wb") as f:
+    f.write(valid[:-17])
+
+# corrupted PNG — flip one byte in IDAT to break CRC
+corrupted = bytearray(valid)
+# flip byte at offset ~30 (inside IDAT data)
+corrupted[30] ^= 0xff
+with open(os.path.join(td, "corrupted-crc.png"), "wb") as f:
+    f.write(bytes(corrupted))
+
+print("fixtures written")
+PY
+
+echo "=== validate-image.sh tests ==="
+
+echo "[1] Valid PNG → exit 0"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/valid.png" 2>&1); ST=$?
+assert_exit "valid PNG passes" 0 $ST "$OUT"
+
+echo "[2] PNG with no IEND chunk → exit 1 (truncated)"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/truncated-no-iend.png" 2>&1); ST=$?
+assert_exit "no-IEND PNG rejected" 1 $ST "$OUT"
+if [[ "$OUT" != *truncat* ]] && [[ "$OUT" != *IEND* ]]; then
+  echo "    NOTE: stderr should mention truncation/IEND, got: $OUT"
+fi
+
+echo "[3] PNG with mid-IDAT truncation → exit 1"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/truncated-mid-idat.png" 2>&1); ST=$?
+assert_exit "mid-IDAT truncation rejected" 1 $ST "$OUT"
+
+echo "[4] PNG with bad chunk CRC → exit 1"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/corrupted-crc.png" 2>&1); ST=$?
+assert_exit "CRC-corrupt PNG rejected" 1 $ST "$OUT"
+
+echo "[5] Empty file → exit 1"
+: > "$TMPDIR/empty.png"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/empty.png" 2>&1); ST=$?
+assert_exit "empty file rejected" 1 $ST "$OUT"
+
+echo "[6] Non-existent file → exit 2"
+OUT=$(bash "$VALIDATOR" "$TMPDIR/nope.png" 2>&1); ST=$?
+assert_exit "missing file → usage error" 2 $ST "$OUT"
+
+echo "[7] No argument → exit 2"
+OUT=$(bash "$VALIDATOR" 2>&1); ST=$?
+assert_exit "no arg → usage error" 2 $ST "$OUT"
+
+echo
+echo "=== ${PASS} passed, ${FAIL} failed ==="
+exit $(( FAIL > 0 ? 1 : 0 ))

--- a/plugins/dx-core/skills/dx-doctor/SKILL.md
+++ b/plugins/dx-core/skills/dx-doctor/SKILL.md
@@ -87,24 +87,21 @@ Glob: "**/skills/dx-doctor/SKILL.md"
 ```
 Navigate up 3 levels from the skill directory to get the dx plugin root.
 
-Compare installed files against plugin source:
+**Discovery (do NOT hardcode the file list — every new utility script in `<dx-plugin>/data/lib/` must be picked up automatically).** Glob `<dx-plugin>/data/lib/*.sh` and `<dx-plugin>/data/lib/*.js`. From the result set, exclude:
+- Test files: `*.test.sh`, `*.test.js`
+- Anything under `<dx-plugin>/data/lib/fixtures/`
 
-| Installed | Plugin Source |
-|-----------|-------------|
-| `.ai/lib/audit.sh` | `<dx-plugin>/data/lib/audit.sh` |
-| `.ai/lib/dx-common.sh` | `<dx-plugin>/data/lib/dx-common.sh` |
-| `.ai/lib/pre-review-checks.sh` | `<dx-plugin>/data/lib/pre-review-checks.sh` |
-| `.ai/lib/plan-metadata.sh` | `<dx-plugin>/data/lib/plan-metadata.sh` |
-| `.ai/lib/gather-context.sh` | `<dx-plugin>/data/lib/gather-context.sh` |
-| `.ai/lib/ensure-feature-branch.sh` | `<dx-plugin>/data/lib/ensure-feature-branch.sh` |
-| `.ai/lib/queue-pipeline.sh` | `<dx-plugin>/data/lib/queue-pipeline.sh` |
-| `.claude/hooks/stop-guard.sh` | `<dx-plugin>/data/hooks/stop-guard.sh` |
+The remaining files form the utility manifest — each is expected to live at `.ai/lib/<basename>`.
+
+Plus one fixed entry from a different plugin directory:
+- `.ai/lib/<basename>` ← `<dx-plugin>/data/lib/<basename>` (one row per discovered file)
+- `.claude/hooks/stop-guard.sh` ← `<dx-plugin>/data/hooks/stop-guard.sh` (always check)
 
 For each:
 1. If installed file is missing → `✗ MISSING`
 2. If installed file exists, Read both files and compare content:
    - Identical → `✓ up to date`
-   - Different only in **comment lines** (lines starting with `#`) where the change is a genericized example name (e.g., plugin uses `myai-dedupe` but project uses `kai-dedupe`) → `✓ up to date (project-specific examples)`. Plugin templates use generic placeholder names in code comments; consumer projects replace these with real infrastructure names. This is NOT staleness.
+   - Different only in **comment lines** (lines starting with `#` for shell, `//` or `/* */` for JS) where the change is a genericized example name (e.g., plugin uses `myai-dedupe` but project uses `kai-dedupe`) → `✓ up to date (project-specific examples)`. Plugin templates use generic placeholder names in code comments; consumer projects replace these with real infrastructure names. This is NOT staleness.
    - Different in **functional code** (non-comment lines) → `⚠ STALE (plugin version updated — run /dx-upgrade)`
 
 ### 1e. (Removed — .ai/docs/ no longer managed by plugins)

--- a/plugins/dx-core/skills/dx-req/SKILL.md
+++ b/plugins/dx-core/skills/dx-req/SKILL.md
@@ -288,7 +288,7 @@ The MCP returns the file as a base64 `blob`. Decode and write to `$SPEC_DIR/imag
 bash .ai/lib/validate-image.sh "$SPEC_DIR/images/<filename>"
 ```
 
-The script checks MIME (must be `image/png`, `image/jpeg`, `image/gif`, or `image/webp`), file size (≤ 5 MB), and dimensions (≤ 8000 px on a side, > 0 px). Exit 0 = safe to Read in step 8e. Exit 1 = unsafe — record the file in `INDEX.md` with status `skipped: <reason from stderr>` and **do not Read it in step 8e**. Exit 2 = usage error (treat as skip).
+The script checks MIME (must be `image/png`, `image/jpeg`, `image/gif`, or `image/webp`), file size (≤ 5 MB), dimensions (≤ 8000 px on a side, > 0 px), AND structural integrity — it walks the container's chunks/markers (PNG IHDR→IEND with CRCs, JPEG SOI/EOI, GIF trailer, WebP RIFF size) to catch truncated streams that header-only checks miss. The ADO MCP `wit_get_work_item_attachment` tool has been observed silently truncating large attachments around 75 KB — the file passes MIME/dimension checks because IHDR is intact but Anthropic's full-decode pass returns 400; the structural check rejects it before Read sees it. Exit 0 = safe to Read in step 8e. Exit 1 = unsafe — record the file in `INDEX.md` with status `skipped: <reason from stderr>` and **do not Read it in step 8e**. Exit 2 = usage error (treat as skip).
 
 This validator is the load-bearing fix for the "Could not process image" 400 errors: any file that fails validation here MUST NOT reach step 8e's Read call, because once that Read attaches the bytes to the conversation, the API call fails as a whole and the session is blocked. If in doubt, skip — a missing description is fixable; a blocked turn is not.
 

--- a/plugins/dx-core/skills/dx-upgrade/SKILL.md
+++ b/plugins/dx-core/skills/dx-upgrade/SKILL.md
@@ -101,20 +101,12 @@ These are plugin-owned files — update without asking.
 
 ### 3a. Utility Scripts
 
-For each stale or missing script:
+**Discovery (mirrors dx-doctor section 1d — never hardcode the file list).** Glob `<dx-plugin>/data/lib/*.sh` and `<dx-plugin>/data/lib/*.js`, excluding `*.test.sh`, `*.test.js`, and anything under `<dx-plugin>/data/lib/fixtures/`. The remaining files plus the always-present hook form the utility manifest:
 
-| Installed | Plugin Source | Post-copy |
-|-----------|-------------|-----------|
-| `.ai/lib/audit.sh` | `<dx-plugin>/data/lib/audit.sh` | `chmod +x` |
-| `.ai/lib/dx-common.sh` | `<dx-plugin>/data/lib/dx-common.sh` | `chmod +x` |
-| `.ai/lib/pre-review-checks.sh` | `<dx-plugin>/data/lib/pre-review-checks.sh` | `chmod +x` |
-| `.ai/lib/plan-metadata.sh` | `<dx-plugin>/data/lib/plan-metadata.sh` | `chmod +x` |
-| `.ai/lib/gather-context.sh` | `<dx-plugin>/data/lib/gather-context.sh` | `chmod +x` |
-| `.ai/lib/ensure-feature-branch.sh` | `<dx-plugin>/data/lib/ensure-feature-branch.sh` | `chmod +x` |
-| `.ai/lib/queue-pipeline.sh` | `<dx-plugin>/data/lib/queue-pipeline.sh` | `chmod +x` |
-| `.claude/hooks/stop-guard.sh` | `<dx-plugin>/data/hooks/stop-guard.sh` | `chmod +x` |
+- `.ai/lib/<basename>` ← `<dx-plugin>/data/lib/<basename>` (one entry per discovered file)
+- `.claude/hooks/stop-guard.sh` ← `<dx-plugin>/data/hooks/stop-guard.sh`
 
-Read the plugin source file, Write to the installed location.
+For each entry that dx-doctor reported as stale or missing, Read the plugin source file and Write it to the installed location. Then `chmod +x` only on `*.sh` files (do NOT chmod `*.js` — Node entry points are invoked via `node` and don't need the executable bit).
 
 **Comment-only differences:** If dx-doctor reported the script as `✓ up to date (project-specific examples)` — meaning the only differences are in comment lines where the project uses real infrastructure names (e.g., `kai-dedupe`) instead of the plugin's generic placeholders (e.g., `myai-dedupe`) — do NOT overwrite. The project-specific names are intentional and correct. Only update scripts that have functional code changes.
 


### PR DESCRIPTION
## Summary

- **Truncation detection in `validate-image.sh`** — adds a structural decode pass (PNG IHDR→IEND with CRCs, JPEG SOI/EOI, GIF trailer, WebP RIFF size) that catches MCP-truncated attachments which header-only checks miss. Anthropic's vision API does a full decode and 400s on truncated PNGs; this rejects them before the Read tool sees them.
- **Auto-discovery in `dx-doctor` §1d and `dx-upgrade` §3a** — replaces hardcoded 7-row tables with `glob <dx-plugin>/data/lib/*.{sh,js}` (excluding `*.test.*` and `fixtures/`). Picks up 13 files instead of 7, including six that were silently absent before. Future lib additions propagate without skill edits.
- **TODO #103** — logs the upstream `wit_get_work_item_attachment` truncation as a blocked-on-`microsoft/azure-devops-mcp` issue.

## Background

Encountered when running `/dx-core:dx-agent-all` against ADO WI 2490722 in a consumer repo. Phase 1 hit `API Error: 400 — Could not process image` and aborted. Investigation showed two bugs:

1. ADO MCP `wit_get_work_item_attachment` returns truncated bytes for ~75 KB+ attachments. Confirmed reproducible: a clean MCP fetch and an agent-improvised decode produced the identical 74967-byte file (same SHA256). The file has a valid PNG signature, correct IHDR, and `file --mime-type` reports `image/png`, but the 5th IDAT chunk header claims 16384 bytes with only 9249 actually present and there is no IEND. The `validate-image.sh` from #138 only checked MIME + size + dimensions (all header-only) so it passed the file through to Read, which 400'd.
2. The consumer's `.ai/lib/` was missing `validate-image.sh` entirely. `dx-doctor` and `dx-upgrade` both used a hardcoded 7-row table that never got updated when #138 added the new lib files, so `/dx-doctor` reported "all clean" and `/dx-upgrade` installed nothing.

## Test plan

- [x] `bash plugins/dx-core/data/lib/validate-image.test.sh` — 7 cases pass (valid PNG, no-IEND, mid-IDAT, bad CRC, empty, missing arg, no arg)
- [x] `bash plugins/dx-core/data/lib/validate-image.sh <user's truncated PNG>` exits 1 with `skip: truncated: IDAT chunk length 16384 would overrun file (have 9249 of 16388 bytes)`
- [x] Same script on a known-good PNG exits 0 with `ok: image/png, ...`
- [x] Auto-discovery surfaces 13 files (was 7); `*.test.*` and `fixtures/` correctly excluded
- [ ] Re-run `/dx-agent-all` against WI 2490722 in consumer repo — Phase 1 should complete with the truncated image quarantined into `INDEX.md ## Skipped` and a placeholder in `images.md`
- [ ] `/dx-upgrade dx` in a consumer pinned to the previous plugin version should now install the missing lib files and report them as updated

## Files

- `plugins/dx-core/data/lib/validate-image.sh` — added structural integrity step 4
- `plugins/dx-core/data/lib/validate-image.test.sh` — new TDD suite
- `plugins/dx-core/skills/dx-req/SKILL.md` — step 8b: documents new validator scope + the MCP truncation pattern
- `plugins/dx-core/skills/dx-doctor/SKILL.md` — §1d: auto-discovery
- `plugins/dx-core/skills/dx-upgrade/SKILL.md` — §3a: auto-discovery + chmod +x scoped to `.sh`
- `docs/todo/TODO.md` + `docs/todo/todo-bugs.md` — entry #103