### PR TITLE
fix(dx-init): stop scaffold from installing orphan cross-repo.md to .ai/rules/

### DIFF
--- a/cli/lib/scaffold.js
+++ b/cli/lib/scaffold.js
@@ -275,6 +275,10 @@ class Scaffold {
     for (const file of fs.readdirSync(rulesDir)) {
       if (!file.endsWith('.template')) continue;
       if (file.startsWith('universal-')) continue; // handled separately
+      // Skip cross-repo.md — installed by dx-init Step 8d to .claude/rules/
+      // with {{REPOS_TABLE}} substitution. CLI scaffold has no Step 8d
+      // equivalent; users run /dx-init in Claude Code to install it.
+      if (file === 'cross-repo.md.template') continue;
       const name = file.replace('.template', '');
       this.copyFile(path.join(rulesDir, file), `.ai/rules/${name}`);
     }

--- a/plugins/dx-core/skills/dx-init/scripts/scaffold.sh
+++ b/plugins/dx-core/skills/dx-init/scripts/scaffold.sh
@@ -113,6 +113,9 @@ for f in "$PLUGIN_DIR"/templates/rules/*.template; do
   name="$(basename "$f" .template)"
   # Skip universal-* (handled below)
   case "$name" in universal-*) continue ;; esac
+  # Skip cross-repo.md — installed by dx-init Step 8d to .claude/rules/
+  # with {{REPOS_TABLE}} substitution from config.yaml repos:
+  [ "$name" = "cross-repo.md" ] && continue
   install_rule "$f" ".ai/rules/$name" ".ai/rules/$name"
 done
 


### PR DESCRIPTION
## Summary
- Both `scaffold.sh` and `cli/lib/scaffold.js` bulk-copy every `templates/rules/*.template` into `.ai/rules/`. That loop incorrectly picks up `cross-repo.md.template`, producing a generic, unsubstituted `.ai/rules/cross-repo.md` that no skill ever reads — it has `paths: ["**/*"]` frontmatter (always-on rule, belongs in `.claude/rules/`) and a `{{REPOS_TABLE}}` placeholder the bulk loops don't substitute.
- `dx-init` Step 8d already installs `cross-repo.md` correctly to `.claude/rules/` with `REPOS_TABLE` filled from `config.yaml repos:` and smart-merges user customizations.
- Skip the template in both bulk loops so Step 8d remains the sole installer. The Node CLI has no Step 8d equivalent; users run `/dx-init` in Claude Code to get the rule.

## Test plan
- [x] Run `plugins/dx-core/skills/dx-init/scripts/scaffold.sh` in a clean dir — `.ai/rules/` contains only `plan-format.md`, `pr-answer.md`, `pr-review.md`, `pragmatism.md` (no `cross-repo.md`)
- [x] Run `node cli/bin/dx-scaffold.js /tmp/test --all` — same result for `.ai/rules/`
- [x] `grep -rn "\.ai/rules/cross-repo" plugins/ cli/` returns zero hits (no skill reads from the wrong location)
- [ ] Verify `/dx-init` Step 8d still produces `.claude/rules/cross-repo.md` with substituted `REPOS_TABLE` in a real init run