### PR TITLE
feat(dx-simple): relax contract — page-url only required, model decides path

### DIFF
--- a/plugins/dx-automation/data/scripts/pipeline-agent.js
+++ b/plugins/dx-automation/data/scripts/pipeline-agent.js
@@ -201,6 +201,26 @@ let lastLogTime = Date.now();
 // Set of tool_use IDs we've already logged via stream_event (to avoid double-logging)
 const streamedToolIds = new Set();
 
+// Track final-text verdict so the pipeline can fail when the agent's Return
+// block says fail/warn. The skill's contract emits:
+//   verdict: pass | warn | fail
+// in its closing message. We tail the last assistant text chunks and match
+// the first such line.
+let lastAssistantText = "";
+function captureAssistantText(text) {
+  if (!text) return;
+  lastAssistantText += text;
+  // Keep the buffer bounded — the verdict is always near the end.
+  if (lastAssistantText.length > 16000) {
+    lastAssistantText = lastAssistantText.slice(-16000);
+  }
+}
+function detectVerdict() {
+  if (!lastAssistantText) return null;
+  const match = lastAssistantText.match(/^\s*verdict:\s*(pass|warn|fail)\b/im);
+  return match ? match[1].toLowerCase() : null;
+}
+
 // ToolSearch loop detection — catch agents stuck searching for unavailable tools
 let consecutiveToolSearches = 0;
 const MAX_CONSECUTIVE_TOOL_SEARCHES = 6;
@@ -326,6 +346,9 @@ if (process.env.CLAUDE_MODEL) {
             // Flush any pending tool before text
             flushTool();
             log.write(prefix() + delta.text);
+            // Capture top-level assistant text (not subagent text) so we can
+            // detect the final `verdict: ...` line emitted by the skill.
+            if (!isSubagent) captureAssistantText(delta.text);
           } else if (delta && delta.type === "input_json_delta") {
             currentToolInput += delta.partial_json || "";
           }
@@ -359,10 +382,15 @@ if (process.env.CLAUDE_MODEL) {
               const inp = formatToolInput(block.name, block.input);
               log.write(inp ? `${prefix()}-> ${block.name}: ${inp}\n` : `${prefix()}-> ${block.name}\n`);
             }
-          } else if (block.type === "text" && !streamedToolIds.size && message.parent_tool_use_id) {
-            // Subagent text that wasn't streamed — show it
+          } else if (block.type === "text") {
             const text = block.text || "";
-            if (text.trim()) log.write(prefix() + text + "\n");
+            if (!streamedToolIds.size && message.parent_tool_use_id && text.trim()) {
+              // Subagent text that wasn't streamed — show it
+              log.write(prefix() + text + "\n");
+            }
+            // Always capture top-level assistant text for verdict detection
+            // (in case includePartialMessages is off and we never saw deltas).
+            if (!message.parent_tool_use_id) captureAssistantText(text);
           }
         }
 
@@ -409,6 +437,19 @@ if (process.env.CLAUDE_MODEL) {
 
         if (message.subtype !== "success") {
           process.exit(1);
+        }
+
+        // Verdict-based exit: skills that declare a Return contract (e.g.
+        // /dx-simple) emit `verdict: pass|warn|fail` in their final message.
+        // Pipelines must fail when the agent reports a failed verdict, even
+        // if the SDK itself terminated cleanly. `warn` exits 0 with a notice.
+        const verdict = detectVerdict();
+        if (verdict === "fail") {
+          log.write(`\n!! verdict: fail — exiting non-zero so the pipeline reflects the agent outcome.\n`);
+          process.exit(1);
+        }
+        if (verdict === "warn") {
+          log.write(`\n!! verdict: warn — pipeline succeeds, review the agent report.\n`);
         }
 
       } else if (type === "rate_limit_event") {

--- a/plugins/dx-automation/skills/auto-init/SKILL.md
+++ b/plugins/dx-automation/skills/auto-init/SKILL.md
@@ -179,28 +179,24 @@ Document in the generated `infra.json`:
 {
   "simpleAgent": {
     "qaAemUrl": "<from prompt>",
-    "pipelineVariables": ["AEM_QA_URL", "AEM_QA_USER", "AEM_QA_PASSWORD"],
-    "allowlistConfigPath": ".ai/config.yaml#dx-simple.allowed-resource-types"
+    "pipelineVariables": ["AEM_QA_URL", "AEM_QA_USER", "AEM_QA_PASSWORD"]
   }
 }
 ```
 
-### After /auto-init completes — add dx-simple block to .ai/config.yaml
+### Optional — tune `/dx-simple` in `.ai/config.yaml`
 
-If the user opted into SimpleAgent, instruct them to add this block to `.ai/config.yaml`:
+`/dx-simple` runs out of the box on any component once SimpleAgent is enabled.
+For faster compile cycles or a custom cost ceiling, add an optional block to
+`.ai/config.yaml`:
 
 ```yaml
 dx-simple:
-  allowed-resource-types:
-    # Add resource types here that are eligible for auto-tweaks.
-    # Use "*" to allow any (NOT recommended for production).
-    # - mysite/components/hero
-    # - mysite/components/cta
   cost-ceiling-usd: 2.0
   build-compile-fast: "mvn compile -pl ui.frontend,core -am"
 ```
 
-Until at least one resource type is allowlisted, `/dx-simple` will reject all runs.
+Both keys are optional — defaults are applied when the block is absent.
 
 ## Phase 2: Scaffold
 

--- a/plugins/dx-core/skills/dx-simple/SKILL.md
+++ b/plugins/dx-core/skills/dx-simple/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dx-simple
-description: Apply a small AEM change (a11y label, color, spacing, copy, css-class, icon) by splitting work into authoring (JCR writes) and code (file edits → PR) paths. Use after the ADO story contains a structured ```simple``` block. Trigger on "simple change", "small tweak", "apply tweak".
+description: Apply a small AEM change (a11y label, color, spacing, copy, css-class, icon, focus trap, or other small behavior tweak) by splitting work into authoring (JCR writes) and code (file edits → PR) paths. Reads the ADO story directly — a structured ```simple``` block is recommended but optional. Trigger on "simple change", "small tweak", "apply tweak".
 argument-hint: "<ADO Work Item ID or full URL>"
 allowed-tools: ["read", "edit", "search", "write", "agent"]
 model: sonnet
@@ -79,14 +79,13 @@ touch .ai/run-context/orchestrating.flag
 | `simple-progress.md` | initialized in pre-flight; updated per phase | Phase status table |
 | `report.md` | Phase 7 (rendered from template) | Final human-readable report |
 
-## Confidence model (gates G1–G9)
+## Confidence model (gates G1, G3–G9)
 
-This skill enforces 9 confidence gates. **Any gate failure → rollback authoring (if applied) + ADO comment + exit non-zero.** Track scores in `$SPEC_DIR/confidence.json`; the final report quotes them.
+This skill enforces 8 confidence gates. **Any gate failure → rollback authoring (if applied) + ADO comment + verdict: fail (pipeline exits non-zero).** Track scores in `$SPEC_DIR/confidence.json`; the final report quotes them.
 
 | Gate | Phase | Threshold |
 |---|---|---|
 | G1 Locator match | 1 | exactly 1 DOM match for component-locator |
-| G2 Allowlist | 1 | resource-type in `.ai/config.yaml > dx-simple.allowed-resource-types` |
 | G3 Classification | 2 | high or medium |
 | G4 Per-file edit confidence | 3b | ≥ 0.85 |
 | G5 Visual non-target identical | 5 | ≥ 99% |
@@ -95,14 +94,17 @@ This skill enforces 9 confidence gates. **Any gate failure → rollback authorin
 | G8 Cost | global | ≤ $2 (configurable) |
 | G9 Time | global | ≤ 12 min |
 
+> **Note:** G2 (resource-type allowlist) was removed — the skill now runs on
+> any component. The G* numbering is preserved for backwards compatibility
+> with existing reports.
+
 ## Flow
 
 ```dot
 digraph dx_simple {
     "Preflight + spec dir" [shape=box];
-    "Phase 1: Fetch + parse simple block" [shape=box];
+    "Phase 1: Fetch + extract change details" [shape=box];
     "G1: locator match exactly 1?" [shape=diamond];
-    "G2: resource-type allowlisted?" [shape=diamond];
     "Phase 2: Classify (parallel subagents)" [shape=box];
     "G3: classification high or medium?" [shape=diamond];
     "Phase 3a: Apply authoring writes" [shape=box];
@@ -121,16 +123,16 @@ digraph dx_simple {
     "Phase 7: Write report + ADO comment" [shape=doublecircle];
     "ABORT: Rollback + comment + exit" [shape=doublecircle];
 
-    "Preflight + spec dir" -> "Phase 1: Fetch + parse simple block";
-    "Phase 1: Fetch + parse simple block" -> "G1: locator match exactly 1?";
+    "Preflight + spec dir" -> "Phase 1: Fetch + extract change details";
+    "Phase 1: Fetch + extract change details" -> "G1: locator match exactly 1?";
     "G1: locator match exactly 1?" -> "ABORT: Rollback + comment + exit" [label="no"];
-    "G1: locator match exactly 1?" -> "G2: resource-type allowlisted?" [label="yes"];
-    "G2: resource-type allowlisted?" -> "ABORT: Rollback + comment + exit" [label="no"];
-    "G2: resource-type allowlisted?" -> "Phase 2: Classify (parallel subagents)" [label="yes"];
+    "G1: locator match exactly 1?" -> "Phase 2: Classify (parallel subagents)" [label="yes"];
     "Phase 2: Classify (parallel subagents)" -> "G3: classification high or medium?";
-    "G3: classification high or medium?" -> "Phase 3a: Apply authoring writes" [label="high or medium → authoring"];
-    "G3: classification high or medium?" -> "Phase 3b: Apply code edits" [label="low → code fallback"];
-    "Phase 3a: Apply authoring writes" -> "Phase 5: Visual verify";
+    "G3: classification high or medium?" -> "ABORT: Rollback + comment + exit" [label="no — abort"];
+    "G3: classification high or medium?" -> "Phase 3a: Apply authoring writes" [label="yes — if authoring items"];
+    "G3: classification high or medium?" -> "Phase 3b: Apply code edits" [label="yes — if code items"];
+    "Phase 3a: Apply authoring writes" -> "Phase 5: Visual verify" [label="if no code items"];
+    "Phase 3a: Apply authoring writes" -> "G4: per-file edit confidence ≥85%?" [label="if code items also queued"];
     "Phase 3b: Apply code edits" -> "G4: per-file edit confidence ≥85%?";
     "G4: per-file edit confidence ≥85%?" -> "ABORT: Rollback + comment + exit" [label="no"];
     "G4: per-file edit confidence ≥85%?" -> "Scope-check ok?" [label="yes"];
@@ -154,7 +156,7 @@ digraph dx_simple {
 
 ## Node Details
 
-### Phase 1: Fetch + parse simple block
+### Phase 1: Fetch + extract change details
 
 1. Fetch the work item:
    ```
@@ -162,16 +164,46 @@ digraph dx_simple {
    ```
    Write the description + comments to `$SPEC_DIR/raw-story.md` with provenance frontmatter.
 
-2. Parse the `simple` block:
+2. Parse the `simple` block (recommended but not required):
    ```bash
    bash $CLAUDE_PLUGIN_ROOT/skills/dx-simple/scripts/parse-simple-block.sh \
         "$SPEC_DIR/raw-story.md" "$SPEC_DIR/simple-block.yaml"
    ```
-   - Exit 2 (missing) → post the template at `$CLAUDE_PLUGIN_ROOT/skills/dx-simple/templates/simple-block.md.tmpl` as an ADO comment. STOP.
-   - Exit 3 (malformed) → post the specific error from stderr as an ADO comment. STOP.
+   - Exit 0 (parsed) → continue to step 2a (fill in inferred fields if any are missing).
+   - Exit 2 (no block) → fall through to step 2b (LLM extraction from story prose).
+   - Exit 3 (malformed: missing `page-url`, duplicate field, or unclosed fence) → post the specific error from stderr as an ADO comment. STOP.
+
+2a. **Fill in missing fields** (block was present but partial):
+    Read `simple-block.yaml`. For each missing optional field, infer it
+    from the surrounding story text and overwrite `simple-block.yaml`:
+    - `component-locator` missing → infer from the story's element references.
+      Examples: "Language Selector button" → `dialog-title="Language Selector"`;
+      "Get started heading" → `heading-text="Get started"`. If the story
+      gives a JCR path, use `jcr-path=...`.
+    - `change-value` missing → use the story's natural-language description
+      of the change in plain English (this is the input the model uses to
+      decide whether the change is content, code, or both).
+    The classifier (Phase 2) uses these as hints; nothing here gates execution.
+
+2b. **LLM extraction** (no block found): read `raw-story.md` and extract
+    the same fields directly from the story description, acceptance
+    criteria, and comments:
+    - `page-url` (REQUIRED): find the QA author URL in the story. If
+      multiple, prefer the one nearest the change description; if still
+      ambiguous, post the template at
+      `$CLAUDE_PLUGIN_ROOT/skills/dx-simple/templates/simple-block.md.tmpl`
+      as an ADO comment and STOP.
+    - `component-locator`: derive from the story's element references
+      (visible text, dialog title, JCR path).
+    - `change-value`: take the most specific change description in the story.
+      Keep it as natural language — the model decides downstream whether each
+      part is a content edit or a code edit.
+    Write the inferred values to `$SPEC_DIR/simple-block.yaml` with a
+    `# inferred: true` comment at the top so downstream phases can flag
+    lower confidence in the report.
 
 3. Semantic validation (Safeguard #1):
-   - Read `simple-block.yaml`; extract `page-url`, `component-locator`, `change-type`, `change-value`.
+   - Read `simple-block.yaml`; extract `page-url`, `component-locator`, `change-value`.
    - Navigate Chrome to `page-url`:
      ```
      mcp__plugin_dx-aem_chrome-devtools-mcp__navigate_page with url=<page-url>
@@ -181,9 +213,10 @@ digraph dx_simple {
      mcp__plugin_dx-aem_chrome-devtools-mcp__take_snapshot
      ```
    - Match the locator. The locator is one of:
-     - `heading-text="..."` → look for element with that exact visible text in headings
+     - `heading-text="..."` / `button-text="..."` / `link-text="..."` → look for elements with that exact visible text
      - `jcr-path=...` → use AEM MCP `getNodeContent` to confirm node exists; locator match count = 1 if node exists, 0 if not
      - `dialog-title="..."` → ambiguous on its own; require AEM MCP `scanPageComponents` to resolve to a unique component instance
+     - free-form description (from LLM extraction) → use the Chrome snapshot + scanPageComponents to find the single best match; if more than one element matches, ABORT G1 with the ambiguous-locator message
 
 4. **Take BEFORE screenshot** (Safeguard #6): capture and save as `$SPEC_DIR/before.png`:
    ```
@@ -192,18 +225,14 @@ digraph dx_simple {
    Also record the locator's bounding box (from snapshot) to `$SPEC_DIR/locator-bbox.json` for the visual-diff step.
 
 5. **G1 — Locator match (HARD GATE):**
-   - If 0 matches: post ADO comment "Component not found on page. Verified by: <snapshot-id>. Check page-url + component-locator." Exit non-zero. NO file reads beyond this point.
-   - If >1 matches: post "Ambiguous locator: <N> matches. Specify jcr-path=... instead." Exit non-zero.
+   - If 0 matches: post ADO comment "Component not found on page. Verified by: <snapshot-id>. Check page-url + the element you wanted to change." Exit non-zero. NO file reads beyond this point.
+   - If >1 matches: post "Ambiguous locator: <N> matches. Add a `jcr-path=...` to the `simple` block, or describe the element more specifically." Exit non-zero.
    - If exactly 1: continue. Record `G1 = 1 match` in `confidence.json`.
 
-6. **G2 — Resource type allowlist:**
-   Read `.ai/config.yaml > dx-simple.allowed-resource-types`. If `*`, allow any. Otherwise check the resolved component's `sling:resourceType` is in the list.
-   - Not in list → post ADO comment "Resource type `<type>` not allowlisted for /dx-simple. Add to .ai/config.yaml > dx-simple.allowed-resource-types." Exit non-zero.
-
-7. Update progress:
+6. Update progress:
    ```bash
    bash $CLAUDE_PLUGIN_ROOT/skills/dx-simple/scripts/update-progress.sh \
-        "$SPEC_DIR" "Phase 1: DoR" "done" "G1+G2 passed"
+        "$SPEC_DIR" "Phase 1: Extract + locate" "done" "G1 passed"
    ```
 
 ### Phase 2: Classify (parallel subagents)
@@ -232,7 +261,7 @@ Dispatch THREE subagents in a single message (parallel):
    Agent(subagent_type: aem-file-resolver, prompt: "Resolve source files for resource type <resource-type>. Return JSON: {\"files\": [{\"path\": \"...\"}, ...]}.")
    ```
 
-Synthesize the three returns into `$SPEC_DIR/dialog-map.json` and `$SPEC_DIR/file-list.json`. Then run the deterministic classifier:
+Synthesize the three returns into `$SPEC_DIR/dialog-map.json` and `$SPEC_DIR/file-list.json`. Then build a **baseline** work-plan with the deterministic heuristic:
 
 ```bash
 bash $CLAUDE_PLUGIN_ROOT/skills/dx-simple/scripts/classify-work.sh \
@@ -242,22 +271,46 @@ bash $CLAUDE_PLUGIN_ROOT/skills/dx-simple/scripts/classify-work.sh \
      "$SPEC_DIR/work-plan.json"
 ```
 
-Read `work-plan.json` and extract `confidence.G3-classification`.
+`classify-work.sh` only suggests obvious matches based on keywords in
+`change-value` against dialog field names. **You — the orchestrator — are
+responsible for the final classification.** Read `work-plan.json`, read
+`change-value` and `raw-story.md`, and decide what to do:
 
-**G3 — Classification:**
-- `high` (1 unambiguous match) → take authoring path
-- `medium` (>1 candidate, picked best by name heuristic) → take authoring path, log alternatives in report Notes
-- `low` (no dialog field match) → fall back to code-path. If code-path also can't identify the file with high confidence (Phase 3b), exit.
+- The change is a content edit that matches a dialog field → keep / add
+  an item in `.authoring[]`.
+- The change involves hardcoded strings, JS behavior (focus traps,
+  keyboard handlers, click handlers), HTL templates, or CSS classes →
+  keep / add items in `.code[]`.
+- The change requires **both** (e.g. "rename the heading **and** trap
+  focus in the modal") → populate **both** arrays. Phase 3a and Phase 3b
+  will both run.
+- The locator pointed at a component whose dialog has no matching field,
+  but the change-value clearly describes a content change → that string
+  is hardcoded; route to `.code[]` and let the file-resolver candidates
+  in there carry it.
+
+If the deterministic baseline missed items, append them to `work-plan.json`
+via `Write`. If the baseline included items the model rejects on inspection,
+remove them. Once `work-plan.json` reflects the model's final plan, set
+`confidence."G3-classification"` to one of:
+
+- `high` — at least one path (authoring or code) has an unambiguous target
+- `medium` — at least one path has a target, but with ambiguity worth noting
+  in the report
+- `low` — neither path has a workable target → abort with G3 fail
 
 Update progress:
 ```bash
 bash $CLAUDE_PLUGIN_ROOT/skills/dx-simple/scripts/update-progress.sh \
-     "$SPEC_DIR" "Phase 2: Classify" "done" "G3=<level>"
+     "$SPEC_DIR" "Phase 2: Classify" "done" "G3=<level>, authoring=<n>, code=<n>"
 ```
 
 ### Phase 3a: Apply authoring writes
 
-**Only if work-plan.json has authoring items.**
+**Runs whenever `work-plan.authoring[]` is non-empty.** If `work-plan.code[]`
+is also non-empty, Phase 3b runs immediately after Phase 3a (sequential, not
+parallel — Phase 3a must record the JCR before-state in main context for
+rollback before Phase 3b touches anything).
 
 For each item in `work-plan.authoring[]`:
 
@@ -292,9 +345,13 @@ Update progress.
 
 ### Phase 3b: Apply code edits
 
-**Only if work-plan.json has code items (G3 was low OR change-type is css-class).**
+**Runs whenever `work-plan.code[]` is non-empty** — independently of whether
+Phase 3a ran. The code path now covers any change that touches source
+files: hardcoded strings, HTL templates, CSS classes, focus traps and
+other JS behavior, click/keyboard handlers, etc. The model chose this
+path in Phase 2 based on the change-value text and dialog map.
 
-`classify-work.sh` populates `.code[]` with placeholder items (confidence=0, empty contexts). The agent MUST fill them in and rewrite `work-plan.json` to disk BEFORE the G4 gate runs.
+`classify-work.sh` populates `.code[]` with placeholder items (confidence=0, empty contexts) for each candidate file. The agent MUST fill them in (or remove them) and rewrite `work-plan.json` to disk BEFORE the G4 gate runs. For changes that add new code (focus traps, new event listeners) rather than replace an existing line, set `match-context` to the anchor line you're inserting **after**, and `replacement` to the anchor line followed by the new code.
 
 For each item in `work-plan.code[]`:
 
@@ -376,7 +433,7 @@ The classifier produces EITHER authoring OR code items, never both — `classify
   - To request visual verify for a code-path run anyway, add `force-visual-verify: true` to the simple block. The pipeline will navigate and screenshot, but G5/G6 are downgraded to WARN (recorded in report.md, do not abort). Useful only when an external job pre-deploys the branch to QA before SimpleAgent runs.
   - Local dev (non-pipeline) is free to run visual verify when the developer has deployed locally — the same `force-visual-verify: true` flag opts in.
 
-**When skipped:** code-only non-visual change-type (aria-label, copy in HTL) — recorded as "verify-deferred-to-qa" in the report.
+**When skipped:** code-only non-visual changes (aria-label edits, copy in HTL, etc.) — recorded as "verify-deferred-to-qa" in the report.
 
 If running:
 
@@ -411,7 +468,7 @@ Either gate fail:
 If Phase 3b ran (code edits applied), invoke `dx-pr-reviewer` for a single-pass review on the working tree:
 
 ```
-Agent(subagent_type: dx-pr-reviewer, prompt: "Review the staged diff (git diff HEAD) for the following changes. Context: this is a small ≤50-line tweak via /dx-simple targeting <change-type> on component <resource-type>. Focus on:
+Agent(subagent_type: dx-pr-reviewer, prompt: "Review the staged diff (git diff HEAD) for the following changes. Context: this is a small ≤50-line tweak via /dx-simple on component <resource-type> — change described as <change-value>. Focus on:
 - Does the change actually accomplish what the requirement says?
 - Any obvious bug (wrong variable, missing semicolon, off-by-one)?
 - Any accessibility regression (e.g., removing existing aria text)?
@@ -510,9 +567,7 @@ When any G1–G9 gate fails:
 
 - **"Component not found on page"** — Locator did not match anything in Chrome snapshot. Check `page-url` (loads on QA author?), `component-locator` (matches visible element?), QA content sync (component exists on QA?).
 
-- **"Ambiguous locator"** — Multiple DOM matches. Use `jcr-path=...` form for unambiguous targeting.
-
-- **"Resource type not allowlisted"** — Component isn't in `.ai/config.yaml > dx-simple.allowed-resource-types`. Add it (intentional opt-in).
+- **"Ambiguous locator"** — Multiple DOM matches. Use `jcr-path=...` form for unambiguous targeting, or describe the element more specifically (e.g. add the surrounding section name).
 
 - **"Edit confidence too low (G4)"** — Agent couldn't identify which file/line to edit unambiguously. Either the source isn't deterministic from the locator, or the change is too ambiguous for /dx-simple. Re-tag as `KAI-DEV-AUTOMATION` to use full DevAgent.
 

--- a/plugins/dx-core/skills/dx-simple/scripts/classify-work.sh
+++ b/plugins/dx-core/skills/dx-simple/scripts/classify-work.sh
@@ -1,22 +1,35 @@
 #!/usr/bin/env bash
 # Deterministic part of Phase 2: takes simple-block.yaml + dialog-map.json
-# (produced by the dialog-inspector subagent) and a file-list.json (from
-# file-resolver subagent), produces work-plan.json with authoring/code split
-# and confidence per item.
+# (produced by the dialog-inspector subagent) and a file-list.json (from the
+# file-resolver subagent), produces work-plan.json with an authoring/code
+# split and confidence per item.
 #
-# Field-match heuristic:
-#   change-type            preferred dialog field names (regex on name+label)
-#   aria-label             aria.*label, accessibility.*label, screenreader
-#   color-token            (color|bg|background).*(picker|field)?, fill
-#   spacing                (spacing|margin|padding).*select
-#   copy                   (text|heading|title|body|copy)
-#   icon                   icon, (logo|image).*ref
-#   css-class              n/a (always code)
+# How the classifier decides authoring-vs-code:
+#   1. Read the natural-language `change-value` from the simple block.
+#   2. Scan it for keyword clusters that map to dialog-field name patterns.
+#   3. If exactly one dialog field matches the strongest cluster, propose
+#      an authoring write (high confidence).
+#   4. If multiple match, propose the best by name heuristic (medium).
+#   5. If none match — or the change-value reads as a behavioral change
+#      (focus trap, keyboard handler, click listener, CSS class toggle,
+#      etc.) — fall through to the code path.
+#
+# Keyword clusters (case-insensitive substring on change-value):
+#   aria-label : aria, accessibility, screen reader
+#   color      : color, background, fill, bg, hue, palette, theme
+#   spacing    : spacing, margin, padding, gap
+#   copy       : rename, label, heading, title, copy, text, wording, message
+#   icon       : icon, logo, image src, image path
+#   behavior   : focus, trap, keyboard, tab key, escape, click handler,
+#                listener, modal open, dialog open
+#   css-class  : class, hidden class, visible class, modifier class
+#
+# behavior + css-class are always routed to code path (no dialog field).
 #
 # Usage: classify-work.sh <simple-block.yaml> <dialog-map.json> <file-list.json> <output: work-plan.json>
 # Exit codes:
 #   0 — classified, work-plan.json written
-#   8 — change-type couldn't be classified with high or medium confidence
+#   8 — inputs missing / unreadable
 
 set -euo pipefail
 
@@ -30,11 +43,24 @@ OUT="${4:?output work-plan.json path required}"
 [[ -f "$FILES" ]]  || { echo "ERROR: $FILES missing" >&2; exit 8; }
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 8; }
 
-CHANGE_TYPE=$(grep -E '^change-type:' "$BLOCK" | head -1 | sed -E 's/^change-type:[[:space:]]*//; s/[[:space:]]+$//')
-CHANGE_VALUE=$(grep -E '^change-value:' "$BLOCK" | head -1 | sed -E 's/^change-value:[[:space:]]*//; s/[[:space:]]+$//' | sed -E 's/^"//;s/"$//')
+CHANGE_VALUE=$(grep -E '^change-value:' "$BLOCK" | head -1 | sed -E 's/^change-value:[[:space:]]*//; s/[[:space:]]+$//' | sed -E 's/^"//;s/"$//' || true)
 JCR_PATH=$(jq -r '.["jcr-path"] // empty' "$DIALOG")
 RESOURCE_TYPE=$(jq -r '.["resource-type"] // empty' "$DIALOG")
 
+# Lowercase change-value for keyword matching.
+CV_LC=$(echo "$CHANGE_VALUE" | tr '[:upper:]' '[:lower:]')
+
+# Detect behavioral / css-class signals first — they short-circuit to code.
+BEHAVIOR_HIT=0
+if echo "$CV_LC" | grep -qE 'focus|trap|keyboard|tab[[:space:]]*key|escape[[:space:]]*key|click[[:space:]]+handler|event[[:space:]]+listener|onclick|onkey|modal[[:space:]]+open|dialog[[:space:]]+open'; then
+  BEHAVIOR_HIT=1
+fi
+CSS_CLASS_HIT=0
+if echo "$CV_LC" | grep -qE 'css[[:space:]]+class|class[[:space:]]+name|add[[:space:]]+class|remove[[:space:]]+class|toggle[[:space:]]+class|hidden[[:space:]]+class|modifier[[:space:]]+class'; then
+  CSS_CLASS_HIT=1
+fi
+
+# Field-name regex per cluster (matched against dialog field NAMES, not change-value).
 declare -A PATTERNS=(
   ["aria-label"]='aria.*label|accessibility.*label|screen.?reader'
   ["color-token"]='color|bg|background|fill'
@@ -43,14 +69,31 @@ declare -A PATTERNS=(
   ["icon"]='icon|(logo|image).?(ref|path)'
 )
 
-PATTERN="${PATTERNS[$CHANGE_TYPE]:-}"
+# Decide which cluster best fits the change-value text.
+# (Order matters when the description uses overlapping words — aria > copy.)
+CLUSTER=""
+if echo "$CV_LC" | grep -qE 'aria|accessibility|screen[[:space:]]*reader'; then
+  CLUSTER="aria-label"
+elif echo "$CV_LC" | grep -qE 'color|background|bg[[:space:]]|hue|palette|theme|fill'; then
+  CLUSTER="color-token"
+elif echo "$CV_LC" | grep -qE 'spacing|margin|padding|gap'; then
+  CLUSTER="spacing"
+elif echo "$CV_LC" | grep -qE 'icon|logo|image[[:space:]]+(src|path|ref)'; then
+  CLUSTER="icon"
+elif echo "$CV_LC" | grep -qE 'rename|label|heading|title|copy|text|wording|message|caption'; then
+  CLUSTER="copy"
+fi
+
+PATTERN=""
+[[ -n "$CLUSTER" ]] && PATTERN="${PATTERNS[$CLUSTER]:-}"
+
 AUTH_FIELD=""
 AUTH_TYPE=""
 AUTH_CONF=0
 ALTERNATIVES=()
 ALT_TYPES=()
 
-if [[ -n "$PATTERN" && "$CHANGE_TYPE" != "css-class" ]]; then
+if [[ -n "$PATTERN" && "$BEHAVIOR_HIT" -eq 0 && "$CSS_CLASS_HIT" -eq 0 ]]; then
   while IFS=$'\t' read -r FIELD TYPE; do
     if echo "$FIELD" | grep -qiE "$PATTERN"; then
       ALTERNATIVES+=("$FIELD")
@@ -86,9 +129,10 @@ if [[ "$AUTH_CONF" -ge 75 ]]; then
     }]')
 fi
 
-# Build code item(s) — only when authoring confidence < 75 OR change-type is css-class
+# Build code item(s) when authoring confidence < 75 OR the change-value
+# describes a behavioral / css-class change.
 CODE="[]"
-if [[ "$AUTH_CONF" -lt 75 || "$CHANGE_TYPE" == "css-class" ]]; then
+if [[ "$AUTH_CONF" -lt 75 || "$BEHAVIOR_HIT" -eq 1 || "$CSS_CLASS_HIT" -eq 1 ]]; then
   CODE=$(jq '[.files[] | {
     "file": .path,
     "match-line": 0,
@@ -113,17 +157,22 @@ jq -n \
   --argjson auth "$AUTHORING" \
   --argjson code "$CODE" \
   --arg level "$LEVEL" \
+  --arg cluster "${CLUSTER:-none}" \
   --arg alts "${ALTERNATIVES[*]:-none}" \
   '{
     ticket: $ticket,
     component: { "jcr-path": $path, "resource-type": $rtype, "page-url": $page },
     authoring: $auth,
     code: $code,
-    confidence: { "G3-classification": $level, rationale: ("alternatives: " + $alts) }
+    confidence: {
+      "G3-classification": $level,
+      "cluster": $cluster,
+      "rationale": ("cluster=" + $cluster + " alternatives=" + $alts)
+    }
   }' > "$OUT"
 
 if [[ "$LEVEL" == "low" ]]; then
-  echo "LOW-CONFIDENCE: no dialog field matched — falling back to code-only path" >&2
+  echo "LOW-CONFIDENCE: no dialog field matched cluster '$CLUSTER' — falling back to code-only path" >&2
 fi
 
-echo "OK: work-plan written to $OUT (G3=$LEVEL, authoring=$(echo "$AUTHORING" | jq 'length'), code=$(echo "$CODE" | jq 'length'))" >&2
+echo "OK: work-plan written to $OUT (G3=$LEVEL, cluster=${CLUSTER:-none}, authoring=$(echo "$AUTHORING" | jq 'length'), code=$(echo "$CODE" | jq 'length'))" >&2

--- a/plugins/dx-core/skills/dx-simple/scripts/parse-simple-block.sh
+++ b/plugins/dx-core/skills/dx-simple/scripts/parse-simple-block.sh
@@ -3,12 +3,20 @@
 # simple-block.yaml. Exits non-zero with a printable error if the block is
 # missing or malformed.
 #
+# Required field: page-url only.
+# Optional fields: component-locator, change-value, brand, activate.
+# Anything else is preserved verbatim — the skill's LLM phases use these
+# as hints. The kind of change (authoring vs code, what field to edit, etc.)
+# is inferred entirely from the natural-language change-value + story prose
+# by classify-work.sh and the Phase 2 subagents.
+#
 # Usage: parse-simple-block.sh <raw-story.md> <output-yaml-path>
 # Exit codes:
 #   0  — block parsed successfully
-#   2  — block missing (file not found or no fenced block)
-#   3  — block malformed (missing required field, bad enum, duplicate
-#         field, or unterminated fence)
+#   2  — block missing (file not found or no fenced block) — skill falls
+#         back to LLM extraction from the story prose
+#   3  — block malformed (missing page-url, duplicate field, or
+#         unterminated fence)
 #
 # Comment handling: only WHOLE-LINE comments are stripped (lines whose
 # first non-whitespace character is `#`). Inline `#` characters inside
@@ -69,32 +77,23 @@ CLEAN=$(echo "$BLOCK" \
   | sed -E 's/[[:space:]]+$//' \
   | sed -E '/^[[:space:]]*$/d')
 
-# Required fields
-for FIELD in page-url component-locator change-type change-value; do
-  if ! echo "$CLEAN" | grep -qE "^${FIELD}:"; then
-    echo "ERROR: required field '${FIELD}' missing from simple block" >&2
-    exit 3
-  fi
-done
+# Only page-url is strictly required — everything else can be inferred from
+# story prose by the LLM phases (component-locator from a Chrome snapshot of
+# the page, the kind of change from the change-value text, etc.).
+if ! echo "$CLEAN" | grep -qE '^page-url:'; then
+  echo "ERROR: required field 'page-url' missing from simple block" >&2
+  exit 3
+fi
 
-# Duplicate-field check: every required field must appear exactly once.
-for FIELD in page-url component-locator change-type change-value; do
+# Duplicate-field check: every known field must appear at most once.
+# Legacy `change-type` is silently tolerated (it's ignored downstream).
+for FIELD in page-url component-locator change-value brand activate change-type; do
   COUNT=$(echo "$CLEAN" | grep -cE "^${FIELD}:" || true)
   if [[ "$COUNT" -gt 1 ]]; then
     echo "ERROR: duplicate field '${FIELD}' in simple block" >&2
     exit 3
   fi
 done
-
-# Validate change-type enum (trailing whitespace already stripped above).
-CHANGE_TYPE=$(echo "$CLEAN" | grep -E '^change-type:' | head -1 | sed -E 's/^change-type:[[:space:]]*//')
-case "$CHANGE_TYPE" in
-  aria-label|color-token|spacing|copy|css-class|icon) ;;
-  *)
-    echo "ERROR: change-type '${CHANGE_TYPE}' not in allowed enum (aria-label|color-token|spacing|copy|css-class|icon)" >&2
-    exit 3
-    ;;
-esac
 
 # Write YAML output (line-by-line, preserve order)
 echo "$CLEAN" > "$OUT"

--- a/plugins/dx-core/skills/dx-simple/scripts/preflight.sh
+++ b/plugins/dx-core/skills/dx-simple/scripts/preflight.sh
@@ -3,11 +3,10 @@
 # Checks:
 #   1. CLAUDE_PLUGIN_ROOT is set and resolves to an existing dir containing
 #      this very script (catches Agent SDK plugin-load misconfig fast).
-#   2. .ai/config.yaml exists and has dx-simple section
-#   3. Required keys present: dx-simple.allowed-resource-types, AND one of
-#      build.compile / build.compile-fast / build.command
+#   2. .ai/config.yaml exists
+#   3. One of build.compile / build.compile-fast / build.command is declared
 #   4. (Pipeline mode) AEM_QA_URL/USER/PASSWORD env vars set
-#   5. .ai/lib/dx-common.sh exists and find-spec-dir works
+#   5. .ai/lib/dx-common.sh exists
 #
 # Does NOT do the live HEAD-test on the page-url — that runs from the skill body
 # via Chrome MCP. This script is the env/config check only.
@@ -41,12 +40,7 @@ fi
 # 2. config.yaml
 [[ -f .ai/config.yaml ]] || ERRORS+=("missing .ai/config.yaml — run /dx-init")
 
-# 3. dx-simple section
-if [[ -f .ai/config.yaml ]] && ! grep -qE '^dx-simple:' .ai/config.yaml; then
-  ERRORS+=("missing dx-simple: block in .ai/config.yaml — see plugins/dx-core/skills/dx-simple/README for schema")
-fi
-
-# 4. Build command available — accept any one of compile, compile-fast, or
+# 3. Build command available — accept any one of compile, compile-fast, or
 # command (legacy: many consumer repos only declare build.command).
 if [[ -f .ai/config.yaml ]]; then
   if ! grep -qE '^\s*(compile(-fast)?|command):' .ai/config.yaml; then

--- a/plugins/dx-core/skills/dx-simple/templates/report.md.tmpl
+++ b/plugins/dx-core/skills/dx-simple/templates/report.md.tmpl
@@ -19,7 +19,6 @@ verified: {VERIFIED}
 | Gate | Score | Threshold | Status |
 |---|---|---|---|
 | G1 Locator | {G1_SCORE} | exactly 1 | {G1_STATUS} |
-| G2 Allowlist | {G2_TYPE} | listed | {G2_STATUS} |
 | G3 Classification | {G3_LEVEL} | high or medium | {G3_STATUS} |
 | G4 Edit | {G4_SCORE} | ≥85% | {G4_STATUS} |
 | G5 Visual non-target | {G5_SCORE} | ≥99% identical | {G5_STATUS} |

--- a/plugins/dx-core/skills/dx-simple/templates/simple-block.md.tmpl
+++ b/plugins/dx-core/skills/dx-simple/templates/simple-block.md.tmpl
@@ -1,16 +1,40 @@
-**Cannot run /dx-simple — required `simple` block is missing or malformed.**
+**`/dx-simple` could not figure out where to make a change from this story.**
 
-Add this block to the story description:
+Add the change request as a small block in the story description. Only the
+**page URL** is required — leave the rest blank and the agent will read the
+story prose to figure them out.
 
 ```simple
-page-url: https://qa-author.example.com/editor.html/content/site/en/home.html
-component-locator: heading-text="Get started today"
-  # alternates: jcr-path=/content/site/en/home/jcr:content/root/hero
-  #             dialog-title="Hero CTA"
-change-type: aria-label    # one of: aria-label | color-token | spacing | copy | css-class | icon
-change-value: "Get started with our product today"
-brand: site                # optional; defaults to brands[0] in .ai/config.yaml
-activate: true             # optional; defaults to true; set false to skip auto-activation
+page-url:   https://qa-author.example.com/editor.html/content/example/en/home.html
+element:    "Get started today" heading
+            # any of: visible text, button label, image alt, dialog title,
+            # or paste a JCR path like /content/example/en/home/jcr:content/root/hero
+what:       Rename the call-to-action to "Begin now" and trap focus inside
+            the modal until the user presses Escape.
+            # plain English — what should the agent change? More than one
+            # thing is fine: the agent decides what's content, what's code,
+            # and runs them in parallel where it can.
+why:        Match the new marketing copy (optional, helps the reviewer)
+activate:   true   # optional; defaults to true; set false to skip auto-activation
 ```
+
+That's it. The agent reads `what` to decide whether each piece is a content
+edit (handled directly in AEM) or a code change (a small pull request) — or
+both, in the same ticket. It enforces a hard limit of 5 files / 50 lines /
+10 content writes — anything larger is rejected with a clear message in the
+story comments.
+
+### How to write the `what` field
+
+Write it the way you would describe the change to a developer:
+
+- "Change the button label from 'Submit' to 'Send'"
+- "Make the heading say 'Welcome back' instead of 'Hello'"
+- "Trap keyboard focus inside the modal until the user presses Escape"
+- "Hide the icon on mobile, keep it on desktop"
+- "Rename the heading **and** trap focus inside the modal" (two things at once
+  is fine)
+
+Avoid technical jargon — the agent figures out the right kind of change.
 
 After updating the story, re-tag with `KAI-SIMPLE-AUTOMATION` to retry.

--- a/plugins/dx-core/skills/dx-simple/tests/fixtures/raw-story-valid.md
+++ b/plugins/dx-core/skills/dx-simple/tests/fixtures/raw-story-valid.md
@@ -9,13 +9,12 @@ As a screen-reader user
 I want the hero CTA button to announce its purpose
 So that I can understand what clicking will do
 
-## Acceptance Criteria
+## Change request
 
 ```simple
 page-url: https://qa-author.example.com/editor.html/content/site/en/home.html
 component-locator: heading-text="Get started today"
-change-type: aria-label
-change-value: "Get started with our product today"
+change-value: Update the aria label to "Get started with our product today" so screen readers announce the purpose.
 brand: site
 activate: true
 ```

--- a/plugins/dx-core/skills/dx-simple/tests/run-tests.sh
+++ b/plugins/dx-core/skills/dx-simple/tests/run-tests.sh
@@ -57,24 +57,38 @@ expect_exit "parse: missing block exits 2" 2 \
 expect_exit "parse: missing file exits 2" 2 \
   "$SCRIPTS/parse-simple-block.sh" "/nonexistent/file.md" "$TMP/missing.yaml"
 
-# Build a fixture with no change-value field for the missing-field test.
-cat > "$TMP/raw-no-change-value.md" <<'EOF'
+# page-url is the only strictly required field. Other fields can be inferred
+# from story prose by the LLM phases.
+cat > "$TMP/raw-no-page-url.md" <<'EOF'
 ---
 ticket: 9999996
 ---
 
 ```simple
-page-url: https://qa-author.example.com/editor.html/content/site/en/home.html
 component-locator: heading-text="Get started today"
-change-type: aria-label
+change-value: "anything"
 brand: site
 ```
 EOF
-expect_exit "parse: missing change-value field exits 3" 3 \
-  "$SCRIPTS/parse-simple-block.sh" "$TMP/raw-no-change-value.md" "$TMP/no-change-value.yaml"
+expect_exit "parse: missing page-url exits 3" 3 \
+  "$SCRIPTS/parse-simple-block.sh" "$TMP/raw-no-page-url.md" "$TMP/no-page-url.yaml"
 
-# Build a fixture with an invalid change-type enum value.
-cat > "$TMP/raw-bad-enum.md" <<'EOF'
+# A block with ONLY page-url should parse cleanly — everything else is optional.
+cat > "$TMP/raw-page-only.md" <<'EOF'
+---
+ticket: 9999997
+---
+
+```simple
+page-url: https://qa-author.example.com/editor.html/content/site/en/home.html
+```
+EOF
+run "parse: only page-url is enough (everything else inferred)" \
+  "$SCRIPTS/parse-simple-block.sh" "$TMP/raw-page-only.md" "$TMP/page-only.yaml"
+
+# change-type is no longer a field the parser cares about — legacy stories
+# that still set it must parse cleanly, and the value is ignored downstream.
+cat > "$TMP/raw-legacy-type.md" <<'EOF'
 ---
 ticket: 9999995
 ---
@@ -82,14 +96,13 @@ ticket: 9999995
 ```simple
 page-url: https://qa-author.example.com/editor.html/content/site/en/home.html
 component-locator: heading-text="Get started today"
-change-type: not-a-real-type
-change-value: "anything"
+change-type: aria-label
+change-value: "trap focus inside modal until Escape"
 brand: site
 EOF
-# Close fence on its own line to avoid heredoc indentation issues.
-echo '```' >> "$TMP/raw-bad-enum.md"
-expect_exit "parse: invalid change-type exits 3" 3 \
-  "$SCRIPTS/parse-simple-block.sh" "$TMP/raw-bad-enum.md" "$TMP/bad-enum.yaml"
+echo '```' >> "$TMP/raw-legacy-type.md"
+run "parse: legacy change-type field tolerated and ignored" \
+  "$SCRIPTS/parse-simple-block.sh" "$TMP/raw-legacy-type.md" "$TMP/legacy-type.yaml"
 
 # Hex-color fixture: parse must succeed AND output must retain literal `#FF0000`
 # (proves inline `#` inside a quoted value is preserved — C1 fix).
@@ -196,14 +209,12 @@ run "visual-diff: Sub-filtered PNG reports correct px-total" \
   bash -c "$SCRIPTS/visual-diff.sh $FIXTURES/sub-filtered.png $FIXTURES/sub-filtered.png | grep -q '\"px-total\": 64'"
 
 # ===== preflight tests =====
-# Create temp project with minimal config
+# Create temp project with minimal config (a build command is the only
+# required key — the dx-simple block itself is now optional).
 TMPPROJ="$TMP/proj1"
 mkdir -p "$TMPPROJ/.ai/lib"
 touch "$TMPPROJ/.ai/lib/dx-common.sh"
 cat > "$TMPPROJ/.ai/config.yaml" <<EOF
-dx-simple:
-  allowed-resource-types:
-    - mysite/components/hero
 build:
   compile: "mvn compile"
 EOF
@@ -212,17 +223,8 @@ EOF
 # containing dx-simple. tests/ → dx-simple → skills → dx-core (the plugin).
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-run "preflight: valid config passes" \
+run "preflight: minimal config passes (no dx-simple block needed)" \
   bash -c "cd $TMPPROJ && CLAUDE_PLUGIN_ROOT='$PLUGIN_ROOT' $SCRIPTS/preflight.sh"
-
-# Missing dx-simple section
-TMPPROJ2="$TMP/proj2"
-mkdir -p "$TMPPROJ2/.ai/lib"
-touch "$TMPPROJ2/.ai/lib/dx-common.sh"
-echo "build: {compile: mvn compile}" > "$TMPPROJ2/.ai/config.yaml"
-
-expect_exit "preflight: missing dx-simple block exits 6" 6 \
-  bash -c "cd $TMPPROJ2 && CLAUDE_PLUGIN_ROOT='$PLUGIN_ROOT' $SCRIPTS/preflight.sh"
 
 # Pipeline mode without AEM vars
 expect_exit "preflight: pipeline mode without AEM_QA_* exits 7" 7 \
@@ -417,9 +419,6 @@ run "g4: tunable threshold (0.80 min lets 0.84 through)" \
 cat > "$TMP/cfg-cmd-only.yaml" <<'EOF'
 build:
   command: mvn clean install
-dx-simple:
-  allowed-resource-types:
-    - mysite/components/hero
 EOF
 run "preflight: build.command satisfies build-command check" \
   bash -c "grep -qE '^\s*(compile(-fast)?|command):' $TMP/cfg-cmd-only.yaml"
@@ -428,9 +427,6 @@ run "preflight: build.command satisfies build-command check" \
 cat > "$TMP/cfg-neither.yaml" <<'EOF'
 build:
   artifact: target/app.jar
-dx-simple:
-  allowed-resource-types:
-    - mysite/components/hero
 EOF
 expect_exit "preflight: missing all three build keys is detected" 1 \
   bash -c "grep -qE '^\s*(compile(-fast)?|command):' $TMP/cfg-neither.yaml"


### PR DESCRIPTION
## Summary

Relaxes the `/dx-simple` contract to the minimum that automation actually needs, so business users (not just engineers) can author tickets that the skill runs on.

### What changes

- **Only `page-url` is required.** `component-locator`, `change-value`, `change-type` are all optional. Phase 1 falls back to LLM extraction from story prose when fields are missing.
- **`change-type` field removed entirely.** The model reads the natural-language `change-value` (e.g. "rename the heading and trap focus inside the modal") and decides what kind of change it is. Legacy stories with `change-type` parse cleanly — the value is just ignored.
- **G2 (resource-type allowlist) gate removed.** The skill runs on any component. Scope budgets (≤ 5 files / ≤ 50 lines / ≤ 10 JCR writes) remain the hard limit.
- **Authoring AND code paths can both run** for a single ticket. Phase 3a and Phase 3b are no longer either/or — work-plan items in both arrays both execute. Useful when a story asks for, say, a copy edit *and* a focus-trap behavior change at the same time.
- **Classifier is a baseline hint, not the decider.** `classify-work.sh` populates a starting work-plan; the orchestrator amends it via LLM reasoning over `change-value` + `raw-story.md` before G3 is checked.
- **Pipeline now fails when the agent fails.** `pipeline-agent.js` scans the agent's final text for `verdict: pass|warn|fail` and exits non-zero on `fail`. Previously masked because the SDK reported `subtype: success` regardless of what the agent said.
- **Business-friendly block template.** Renamed fields to `element` / `what` / `why`; no more "color-token" / "css-class" jargon.

### Files

- `plugins/dx-core/skills/dx-simple/SKILL.md` — gate table, flow digraph, Phase 1/2/3 rewritten
- `plugins/dx-core/skills/dx-simple/scripts/preflight.sh` — drop `dx-simple:` block requirement
- `plugins/dx-core/skills/dx-simple/scripts/parse-simple-block.sh` — only `page-url` required, `change-type` ignored
- `plugins/dx-core/skills/dx-simple/scripts/classify-work.sh` — keyword-scan over `change-value`, both arrays can populate
- `plugins/dx-core/skills/dx-simple/templates/simple-block.md.tmpl` — business-friendly
- `plugins/dx-core/skills/dx-simple/templates/report.md.tmpl` — drop G2 row
- `plugins/dx-core/skills/dx-simple/tests/{run-tests.sh,fixtures/raw-story-valid.md}` — updated for new contract
- `plugins/dx-automation/skills/auto-init/SKILL.md` — drop allowlist config instructions
- `plugins/dx-automation/data/scripts/pipeline-agent.js` — verdict-driven exit code

### Test plan

- [x] `bash plugins/dx-core/skills/dx-simple/tests/run-tests.sh` — **64/64 pass**
- [x] No `allowed-resource-types` / `G2 Allowlist` references remain in active plugin code (historical `docs/superpowers/` plans unchanged)
- [x] `parse-simple-block.sh` with only `page-url` exits 0
- [x] `parse-simple-block.sh` without `page-url` exits 3
- [x] Legacy `change-type` value parses cleanly and is ignored downstream
- [ ] End-to-end pipeline run on a real story (manual smoke test after merge)

### Follow-ups (not in this PR — flagged in chat)

- G4 to support `insert` operations (not just `replace`) so focus-trap-style additive code edits can pass the gate
- Trigger-comment contract (`@kai-simple <command>`) parsed at the Lambda
- Pre-check on story state (skip when `Ready For QA` / `Done`)
- Per-tag rate limit on the public webhook