### PR TITLE
Fix

### DIFF
--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -20,12 +20,16 @@ project:
   brand: brand-a                  # optional — this repo's brand (split-platform frontends)
 
 scm:
-  provider: ado                   # ado | github
-  org: "https://myorg.visualstudio.com/"  # Organization URL
-  project: "My ADO Project"      # ADO project name (or GitHub org)
+  provider: ado                   # ado | github | bitbucket-cloud | bitbucket-dc
+  org: "https://myorg.visualstudio.com/"  # ADO/GitHub org URL; Bitbucket workspace or project key
+  project: "My ADO Project"      # ADO project name (not used for Bitbucket)
+  # Bitbucket Cloud / DC only:
+  # bitbucket-host: "https://bitbucket.example.com"  # DC instance URL, no trailing slash
+  # bitbucket-token: ""           # prefer BITBUCKET_TOKEN env var
+  # bitbucket-username: ""        # Cloud only — your workspace username (for own-PR detection)
 
 tracker:
-  provider: ado                   # ado | jira (preferred over scm.provider for work items)
+  provider: ado                   # ado | jira — work item tracking, independent of scm.provider
   repo-id: "uuid-here"           # Repository ID (auto-discovered or manual)
   base-branch: develop            # Default PR target branch
   wiki-id: "uuid-here"           # ADO wiki UUID (for dx-doc-gen wiki posting)
@@ -92,6 +96,9 @@ overrides:
     persona: "senior developer, brief responses"
 
 # ─── Jira / Confluence (when tracker.provider: jira) ──────
+# Note: tracker.provider is independent of scm.provider.
+# A project can use Bitbucket for code (scm.provider: bitbucket-cloud)
+# and Jira for work items (tracker.provider: jira) simultaneously.
 
 # jira:
 #   url: "https://myorg.atlassian.net"    # Jira Cloud instance URL
@@ -164,11 +171,14 @@ roles:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `provider` | string | yes | `ado` or `github` |
-| `org` | string | yes | Organization URL |
-| `project` | string | yes | Project name within the org |
-| `repo-id` | string | no | Repository UUID (auto-discovered if not set) |
+| `provider` | string | yes | `ado` \| `github` \| `bitbucket-cloud` \| `bitbucket-dc` — the code-hosting platform. Independent of `tracker.provider`. |
+| `org` | string | yes | ADO/GitHub: organization URL. Bitbucket Cloud: workspace slug. Bitbucket DC: project key (e.g., `MYPROJ`). |
+| `project` | string | conditional | ADO project name within the org. Not used for Bitbucket. |
+| `repo-id` | string | no | ADO/GitHub: repository UUID (auto-discovered if not set). Not used for Bitbucket. |
 | `base-branch` | string | yes | Default PR target (e.g., `develop`, `main`) |
+| `bitbucket-host` | string | conditional | **Bitbucket DC only.** Base URL of the DC instance, no trailing slash (e.g., `https://bitbucket.example.com`). Required when `provider: bitbucket-dc`. |
+| `bitbucket-token` | string | no | Bitbucket bearer token. Prefer the `BITBUCKET_TOKEN` environment variable — this field is a fallback for local development. |
+| `bitbucket-username` | string | no | **Bitbucket Cloud only.** Your workspace username / nickname. Used by `dx-pr-answer` to detect own PRs when `BITBUCKET_USERNAME` env var is not set. |
 | `wiki-id` | string | no | ADO wiki identifier UUID (for `/dx-doc-gen`, `/dx-pr-review-report` wiki posting) |
 | `wiki-project` | string | no | ADO project that owns the wiki (if different from `scm.project`) |
 | `wiki-doc-root` | string | no | Root wiki path for technical documentation (sprint subfolders created beneath) |
@@ -180,7 +190,7 @@ roles:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `provider` | string | no | `ado` or `jira`. Preferred over `scm.provider` for work item tracking. Falls back to `scm.provider` if not set. |
+| `provider` | string | no | `ado` \| `jira`. Work-item tracking platform. **Independent of `scm.provider`** — a project can use Bitbucket for code and Jira for tickets simultaneously. Falls back to `scm.provider` if not set, defaulting to `ado`. |
 
 ### `jira`
 
@@ -267,7 +277,9 @@ SimpleAgent (`/dx-simple`) settings. All optional.
 | `platform` | string | no | Opaque, project-defined platform identifier (e.g., `alpha`, `beta`) |
 | `brand` | string | no | Repo's brand identity — used by `/dx-simple` routing to select the correct per-brand frontend repo on split platforms |
 | `path` | string | no | Local filesystem path for cross-repo checks (relative or absolute) |
-| `ado-project` | string | no | ADO project name if different from `scm.project` |
+| `ado-project` | string | no | ADO project name if different from `scm.project` (ADO only) |
+| `bitbucket-workspace` | string | no | Bitbucket Cloud workspace slug if different from `scm.org` |
+| `bitbucket-project` | string | no | Bitbucket DC project key if different from `scm.org` |
 | `base-branch` | string | no | Default branch (falls back to `scm.base-branch`) |
 
 ### `overrides`

--- a/plugins/dx-core/shared/bitbucket-config.md
+++ b/plugins/dx-core/shared/bitbucket-config.md
@@ -1,0 +1,274 @@
+# Bitbucket Config Lookup
+
+Skills that interact with Bitbucket pull requests read provider details from `.ai/config.yaml`.
+
+## When This Applies
+
+When `scm.provider` is `bitbucket-cloud` or `bitbucket-dc`.
+
+## Config Fields
+
+### Bitbucket Cloud
+
+```yaml
+scm:
+  provider: bitbucket-cloud
+  org: "myworkspace"              # Bitbucket workspace slug
+  bitbucket-token: ""             # App password or OAuth token (or use BITBUCKET_TOKEN env var)
+```
+
+### Bitbucket Data Center (Server)
+
+```yaml
+scm:
+  provider: bitbucket-dc
+  org: "MYPROJECT"                # Bitbucket project key (e.g., "PROJ")
+  bitbucket-host: "https://bitbucket.example.com"  # DC host URL (no trailing slash)
+  bitbucket-token: ""             # Personal access token (or use BITBUCKET_TOKEN env var)
+```
+
+## Token Resolution
+
+Read token in this order:
+1. `BITBUCKET_TOKEN` environment variable
+2. `scm.bitbucket-token` from `.ai/config.yaml`
+
+```bash
+TOKEN="${BITBUCKET_TOKEN:-$(grep 'bitbucket-token:' .ai/config.yaml 2>/dev/null | awk '{print $2}' | tr -d '"')}"
+[ -z "$TOKEN" ] && echo "ERROR: Bitbucket token not found. Set BITBUCKET_TOKEN env var or scm.bitbucket-token in config." && exit 2
+```
+
+## URL Patterns
+
+### Bitbucket Cloud
+
+Pull requests:
+```
+https://bitbucket.org/{workspace}/{repo-slug}/pull-requests/{id}
+```
+
+### Bitbucket DC
+
+Pull requests:
+```
+https://{host}/projects/{project}/repos/{repo}/pull-requests/{id}
+```
+
+## REST API Reference
+
+All requests require the auth header. Set a shell variable before making calls:
+
+```bash
+BB_AUTH="-H \"Authorization: Bearer $TOKEN\""
+BB_JSON="-H \"Content-Type: application/json\""
+```
+
+### Bitbucket Cloud (api.bitbucket.org/2.0)
+
+| Operation | Method | Endpoint |
+|---|---|---|
+| Get PR | GET | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}` |
+| List PR comments | GET | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}/comments?pagelen=100` |
+| Post PR comment (general) | POST | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}/comments` |
+| Post inline comment | POST | Same — add `inline` block (see below) |
+| Reply to comment | POST | Same — add `parent.id` field |
+| Approve PR | POST | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}/approve` |
+| Request changes | POST | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}/request-changes` |
+| Remove approval | DELETE | `/2.0/repositories/{workspace}/{repo}/pullrequests/{id}/approve` |
+| Get current user | GET | `/2.0/user` |
+
+#### Comment body — general (Cloud)
+
+```json
+{"content": {"raw": "<comment text>"}}
+```
+
+#### Comment body — inline (Cloud)
+
+```json
+{
+  "content": {"raw": "<comment text>"},
+  "inline": {
+    "path": "path/to/file.js",
+    "to": 42
+  }
+}
+```
+
+Use `"to"` for the end line. Use `"from"` optionally for the range start (multi-line comment).
+
+#### Reply to existing comment (Cloud)
+
+```json
+{
+  "content": {"raw": "<reply text>"},
+  "parent": {"id": 123}
+}
+```
+
+#### Key PR fields (Cloud response)
+
+| Field | Path in JSON |
+|---|---|
+| PR ID | `.id` |
+| Title | `.title` |
+| Description | `.description` |
+| Source branch | `.source.branch.name` |
+| Target branch | `.destination.branch.name` |
+| State | `.state` (OPEN \| MERGED \| DECLINED) |
+| Author display name | `.author.display_name` |
+| Author username / slug | `.author.nickname` |
+| Author account ID | `.author.account_id` |
+| SSH clone URL | `.source.repository.links.clone[] \| select(.name=="ssh") \| .href` |
+| HTTPS clone URL | `.source.repository.links.clone[] \| select(.name=="https") \| .href` |
+
+#### Key comment fields (Cloud response `.values[]`)
+
+| Field | Path |
+|---|---|
+| Comment ID | `.id` |
+| Author nickname | `.author.nickname` |
+| Comment text | `.content.raw` |
+| Inline file | `.inline.path` |
+| Inline line | `.inline.to` |
+| Parent ID | `.parent.id` (if a reply) |
+| Created | `.created_on` |
+
+### Bitbucket DC / Server (REST API 1.0)
+
+Base URL: `{scm.bitbucket-host}/rest/api/1.0`
+
+Store as shell variable: `BASE="{scm.bitbucket-host}/rest/api/1.0"`
+
+| Operation | Method | Endpoint |
+|---|---|---|
+| Get PR | GET | `/projects/{project}/repos/{repo}/pull-requests/{id}` |
+| List PR activities | GET | `/projects/{project}/repos/{repo}/pull-requests/{id}/activities?limit=100` |
+| List PR comments | GET | `/projects/{project}/repos/{repo}/pull-requests/{id}/comments?limit=100` |
+| Post PR comment (general) | POST | `/projects/{project}/repos/{repo}/pull-requests/{id}/comments` |
+| Post inline comment | POST | Same — add `anchor` block (see below) |
+| Reply to comment | POST | `/projects/{project}/repos/{repo}/pull-requests/{id}/comments` with `parent.id` |
+| Approve PR | POST | `/projects/{project}/repos/{repo}/pull-requests/{id}/approve` |
+| Request changes (Needs Work) | PUT | `/projects/{project}/repos/{repo}/pull-requests/{id}/participants/{userSlug}` |
+| Get current user info | GET | `/users/{userSlug}` or parse from git config |
+
+#### Comment body — general (DC)
+
+```json
+{"text": "<comment text>"}
+```
+
+#### Comment body — inline (DC)
+
+```json
+{
+  "text": "<comment text>",
+  "anchor": {
+    "line": 42,
+    "lineType": "ADDED",
+    "fileType": "TO",
+    "path": "path/to/file.js"
+  }
+}
+```
+
+`lineType`: `ADDED` (green/new line), `REMOVED` (red/old line), `CONTEXT` (unchanged). Use `ADDED` for inline review comments on new code.
+`fileType`: `TO` (new version of the file). Always use `TO` for review comments.
+
+#### Reply to existing comment (DC)
+
+```json
+{
+  "text": "<reply text>",
+  "parent": {"id": 123}
+}
+```
+
+#### Approval and vote (DC)
+
+Approve:
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "$BASE/projects/{project}/repos/{repo}/pull-requests/{id}/approve"
+```
+
+Request changes ("Needs Work") — requires the reviewer's user slug (readable from `git config user.name` or a dedicated lookup):
+```bash
+# Resolve slug from email
+USER_SLUG=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/users?filter={email}" | jq -r '.values[0].slug')
+
+# Set status to NEEDS_WORK
+curl -s -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"user\": {\"name\": \"$USER_SLUG\"}, \"approved\": false, \"status\": \"NEEDS_WORK\"}" \
+  "$BASE/projects/{project}/repos/{repo}/pull-requests/{id}/participants/$USER_SLUG"
+```
+
+Remove approval:
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "$BASE/projects/{project}/repos/{repo}/pull-requests/{id}/approve"
+```
+
+#### Key PR fields (DC response)
+
+| Field | Path in JSON |
+|---|---|
+| PR ID | `.id` |
+| Title | `.title` |
+| Description | `.description` |
+| Source branch | `.fromRef.displayId` |
+| Target branch | `.toRef.displayId` |
+| State | `.state` (OPEN \| MERGED \| DECLINED \| SUPERSEDED) |
+| Author display name | `.author.user.displayName` |
+| Author username / slug | `.author.user.name` |
+| Author email | `.author.user.emailAddress` |
+| SSH clone URL | `.fromRef.repository.links.clone[] \| select(.name=="ssh") \| .href` |
+
+#### Key comment fields (DC response `.values[]`)
+
+| Field | Path |
+|---|---|
+| Comment ID | `.id` |
+| Author slug | `.author.name` |
+| Author email | `.author.emailAddress` |
+| Comment text | `.text` |
+| Inline file | `.anchor.path` |
+| Inline line | `.anchor.line` |
+| Parent ID | `.parent.id` (if a reply) |
+| Created | `.createdDate` (epoch ms) |
+
+## Vote Mapping
+
+| ADO concept | Bitbucket Cloud | Bitbucket DC |
+|---|---|---|
+| Approved (+10) | POST `/approve` | POST `/approve` |
+| ApprovedWithSuggestions (+5) | POST `/approve` | POST `/approve` |
+| WaitingForAuthor / changes-requested | POST `/request-changes` | PUT `/participants/{slug}` with `status: NEEDS_WORK` |
+| NoVote (0) | DELETE `/approve` (if previously set) | PUT `/participants/{slug}` with `status: UNAPPROVED` |
+| Skip voting | (no-op) | (no-op) |
+
+## Idempotency — Duplicate Detection
+
+Before posting, check existing PR comments for the `**[AI Review]` marker:
+- **Cloud:** check `.values[].content.raw` for `**[AI Review]`
+- **DC:** check `.values[].text` for `**[AI Review]`
+
+For inline dedup, build a set of `(filePath, line)` from existing inline comments:
+- **Cloud:** `(.inline.path, .inline.to)` from existing `.values[]`
+- **DC:** `(.anchor.path, .anchor.line)` from existing `.values[]`
+
+## Cross-Repo Awareness
+
+When `.ai/config.yaml` has a `repos:` section, individual repos can override workspace/project:
+
+```yaml
+repos:
+  - name: my-backend
+    path: ../my-backend
+    role: backend
+    bitbucket-workspace: "other-workspace"   # Cloud override
+    bitbucket-project: "OTHERPROJ"           # DC project key override
+```

--- a/plugins/dx-core/shared/provider-config.md
+++ b/plugins/dx-core/shared/provider-config.md
@@ -11,7 +11,23 @@ All skills that call work-item or wiki MCP tools must detect the provider and us
 
 If neither field is set, default to `ado`.
 
-**Why `tracker.provider`?** Work-item tracking (ADO/Jira) is separate from source-code management (ADO repos/GitHub/Bitbucket). A project can use Jira for tickets but ADO for code repos. `scm.provider` is kept for backward compatibility but `tracker.provider` is the canonical field.
+For **source-code management (PRs, repos)**, check `scm.provider`:
+   - `ado` → Azure DevOps repos (default)
+   - `github` → GitHub repos (MCP tools available)
+   - `bitbucket-cloud` → Bitbucket Cloud repos (REST API via curl)
+   - `bitbucket-dc` → Bitbucket Data Center repos (REST API via curl)
+
+**Why `tracker.provider`?** Work-item tracking (ADO/Jira) is separate from source-code management (ADO repos/GitHub/Bitbucket). A project can use Jira for tickets but ADO or Bitbucket for code repos. `scm.provider` is kept for backward compatibility but `tracker.provider` is the canonical field for work items.
+
+## Bitbucket Configuration
+
+When `scm.provider = bitbucket-cloud` or `scm.provider = bitbucket-dc`:
+
+- **Workspace / Project key:** `scm.org`
+- **DC Host:** `scm.bitbucket-host` (Bitbucket DC only)
+- **Token:** `BITBUCKET_TOKEN` env var (preferred) or `scm.bitbucket-token`
+
+No MCP server — all Bitbucket API calls are made via `curl`. See `shared/bitbucket-config.md` for full REST API reference, URL patterns, comment bodies, and vote mappings.
 
 ## ADO Configuration
 

--- a/plugins/dx-core/skills/dx-init/SKILL.md
+++ b/plugins/dx-core/skills/dx-init/SKILL.md
@@ -85,14 +85,22 @@ Output is JSON:
   "base_branch": "develop",
   "ado_org": "myorg",
   "ado_project": "myproject",
+  "bb_workspace": "",
+  "bb_project": "",
+  "bb_host": "",
+  "bb_repo": "",
   "sibling_repos": ["sibling-a", "sibling-b"]
 }
 ```
 
-- `scm_provider`: `"ado"` → Azure DevOps, `"github"` → GitHub, `"unknown"` → ask the user
-- If the remote URL points to a Bitbucket or Atlassian instance, or if the user selects `jira` when asked: set provider to `jira`
+- `scm_provider`: `"ado"` → Azure DevOps, `"github"` → GitHub, `"bitbucket-cloud"` → Bitbucket Cloud, `"bitbucket-dc"` → Bitbucket Data Center, `"unknown"` → ask the user which platform they use
+- **`scm.provider` is the code hosting platform — it is independent of `tracker.provider`.** A team can use Bitbucket for code and Jira for work items simultaneously. Do NOT set `scm.provider` to `jira` — that is not a valid SCM provider. If the remote is Bitbucket, set `scm.provider: bitbucket-cloud` or `bitbucket-dc`. Ask separately (step 3 confirmation) whether the team uses Jira for work items.
 - `base_branch`: `"unknown"` → ask the user
 - `ado_org` / `ado_project`: empty if not ADO or extraction failed → ask the user
+- `bb_workspace`: Bitbucket Cloud workspace slug (populated when `scm_provider == "bitbucket-cloud"`)
+- `bb_project`: Bitbucket DC project key (populated when `scm_provider == "bitbucket-dc"`)
+- `bb_host`: Bitbucket DC base URL, e.g. `https://bitbucket.example.com` (populated when `scm_provider == "bitbucket-dc"`)
+- `bb_repo`: repo slug for either Bitbucket platform
 - `sibling_repos`: if non-empty, ask: "Found these sibling repos: <list>. Are any of these related to this project? (comma-separated numbers, or 'none')"
   - For each selected sibling, store `name`, `path` (default: `../<sibling-name>`), and `role`:
     ```yaml
@@ -121,14 +129,22 @@ Present detected values and ask to confirm or correct:
 | Build | `<command>` |
 | Test | `<command>` |
 | Lint | `<command or "none detected">` |
-| SCM | <ADO / GitHub / Bitbucket> |
-| Tracker | <ADO / Jira> |
-| Organization | <org> |
-| Project | <project> |
+| SCM (code hosting) | <ADO / GitHub / Bitbucket Cloud / Bitbucket DC> |
+| Workspace / Org | <workspace, org, or project key> |
 | Base Branch | <branch> |
+| Work-item tracker | <ADO / Jira / unknown — ask separately> |
 
 **Correct?** Type "yes" or tell me what to change.
 ```
+
+After the user confirms, ask one additional question if the SCM is Bitbucket or the tracker could not be determined:
+
+> **Where do you track work items?**
+> 1. Azure DevOps (Boards)
+> 2. Jira
+> 3. Neither / skip
+
+Set `tracker.provider` from the answer (`ado` | `jira` | omit the section). This question is skipped when `scm_provider == "ado"` (ADO handles both by default) or when the tracker is already known from a previous run.
 
 ## 4. Preferences
 
@@ -224,6 +240,41 @@ confluence:
 ```
 
 Print: "Add `JIRA_PERSONAL_TOKEN` and `CONFLUENCE_PERSONAL_TOKEN` to your `.claude/settings.local.json` env block or shell profile."
+
+#### If scm.provider = bitbucket-cloud
+
+Set `scm.org` to `bb_workspace` (detected). Set `scm.provider` to `bitbucket-cloud`. No additional questions needed — the workspace was extracted from the remote URL.
+
+Uncomment and populate the Bitbucket fields in `.ai/config.yaml` (they are commented out in the template by default):
+
+```yaml
+scm:
+  provider: bitbucket-cloud
+  org: "<bb_workspace>"        # workspace slug
+  base-branch: "<base_branch>"
+  bitbucket-token: ""          # set via BITBUCKET_TOKEN env var (preferred)
+```
+
+#### If scm.provider = bitbucket-dc
+
+Set `scm.org` to `bb_project` (detected project key). Set `scm.provider` to `bitbucket-dc`.
+
+If `bb_host` was successfully extracted from the remote URL, use it. Otherwise ask:
+
+> **Bitbucket DC host URL?** (e.g., `https://bitbucket.example.com`)
+
+Uncomment and populate the Bitbucket fields in `.ai/config.yaml`:
+
+```yaml
+scm:
+  provider: bitbucket-dc
+  org: "<bb_project>"          # project key, e.g. MYPROJ
+  base-branch: "<base_branch>"
+  bitbucket-host: "<bb_host>"  # DC instance URL, no trailing slash
+  bitbucket-token: ""          # set via BITBUCKET_TOKEN env var (preferred)
+```
+
+Print: "Add `BITBUCKET_TOKEN` to your `.claude/settings.local.json` env block or shell profile."
 
 ### 5c. (Removed — .ai/README.md and agent-index.md no longer generated)
 
@@ -321,7 +372,7 @@ The ADO MCP server entry (use the confirmed `scm.org` value — just the org nam
 
 Where `<ado_org>` is the organization name extracted from `scm.org` (e.g., if `scm.org` is `https://myorg.visualstudio.com/`, use `myorg`; if `scm.org` is already just `myorg`, use it as-is).
 
-**If SCM is not ADO** (GitHub or other): Skip this step entirely.
+**If SCM is not ADO** (GitHub, Bitbucket Cloud, Bitbucket DC, or other): Skip this step entirely. There is no MCP server to configure for Bitbucket — it uses REST API calls with a bearer token.
 
 ### 5g-bis. Configure Atlassian MCP Server
 
@@ -464,6 +515,16 @@ If `tracker.provider` is `jira`, also include Jira/Confluence tokens in the plac
   "env": {
     "JIRA_PERSONAL_TOKEN": "",
     "CONFLUENCE_PERSONAL_TOKEN": ""
+  }
+}
+```
+
+If `scm.provider` is `bitbucket-cloud` or `bitbucket-dc`, also include:
+
+```json
+{
+  "env": {
+    "BITBUCKET_TOKEN": ""
   }
 }
 ```
@@ -777,6 +838,9 @@ After writing, display:
 **Attribution:** `.claude/settings.json` — commit/PR attribution disabled
 **Secrets:** `.claude/settings.local.json` — local env vars for QA auth, API keys (gitignored)
 <If ADO:> **MCP:** `.mcp.json` — ADO MCP server configured (org: `<ado_org>`)
+<If Bitbucket Cloud:> **SCM:** Bitbucket Cloud (workspace: `<bb_workspace>`) — REST API, no MCP
+<If Bitbucket DC:> **SCM:** Bitbucket Data Center (project: `<bb_project>`, host: `<bb_host>`) — REST API, no MCP
+<If Bitbucket:> **Auth:** Set `BITBUCKET_TOKEN` in shell profile or `.claude/settings.local.json` before running `dx-pr-review`
 <If Jira:> **Tracker:** Jira (project: `<project-key>`, deployment: `<server|cloud>`)
 <If Jira:> **Wiki:** Confluence (space: `<space-key>`)
 <If Jira:> **MCP:** `.mcp.json` — Atlassian MCP server configured
@@ -840,6 +904,7 @@ agent.index.md         ← AI setup entry point (all paths, all agents)
 <If Jira:> - Start working: `/dx-req <Jira issue key, e.g. PROJ-123>`
 - Full pipeline: `/dx-agent-all <ID>`
 - Re-detect project profile: `/dx-adapt` (re-run anytime if structure changes)
+<If Bitbucket:> - Review a PR: `/dx-pr-review <PR URL or ID>` (set `BITBUCKET_TOKEN` first)
 <If AEM:>
 - AEM component lookup: `/aem-component <name>`
 - AEM baseline snapshot: `/aem-snapshot <name>`

--- a/plugins/dx-core/skills/dx-init/scripts/detect-env.sh
+++ b/plugins/dx-core/skills/dx-init/scripts/detect-env.sh
@@ -6,10 +6,14 @@
 #
 # Fields:
 #   remote_url      — git remote origin URL (or "")
-#   scm_provider    — "ado" | "github" | "unknown"
+#   scm_provider    — "ado" | "github" | "bitbucket-cloud" | "bitbucket-dc" | "unknown"
 #   base_branch     — detected default branch (or "unknown")
 #   ado_org         — ADO organization name (or "")
 #   ado_project     — ADO project name (or "")
+#   bb_workspace    — Bitbucket Cloud workspace slug (or "")
+#   bb_project      — Bitbucket DC project key (or "")
+#   bb_host         — Bitbucket DC base URL, no trailing slash (or "")
+#   bb_repo         — Bitbucket repo slug (or "")
 #   sibling_repos   — array of sibling repo names with git dirs
 
 set -euo pipefail
@@ -23,6 +27,11 @@ if [[ "$remote_url" == *"visualstudio.com"* || "$remote_url" == *"dev.azure.com"
   scm_provider="ado"
 elif [[ "$remote_url" == *"github.com"* ]]; then
   scm_provider="github"
+elif [[ "$remote_url" == *"bitbucket.org"* ]]; then
+  scm_provider="bitbucket-cloud"
+elif [[ "$remote_url" == */scm/* || "$remote_url" == */projects/*/repos/* ]]; then
+  # Bitbucket DC uses /scm/{PROJECT}/{repo}.git (HTTPS) or /projects/{PROJECT}/repos/{repo} paths
+  scm_provider="bitbucket-dc"
 fi
 
 # --- Base branch ---
@@ -48,6 +57,44 @@ if [[ "$scm_provider" == "ado" ]]; then
   if [[ "$remote_url" == *"dev.azure.com"* ]]; then
     ado_org=$(echo "$remote_url" | sed -n 's|https://dev\.azure\.com/\([^/]*\)/.*|\1|p')
     ado_project=$(echo "$remote_url" | sed -n 's|https://dev\.azure\.com/[^/]*/\([^/]*\)/_git/.*|\1|p')
+  fi
+fi
+
+# --- Bitbucket field extraction ---
+bb_workspace=""
+bb_project=""
+bb_host=""
+bb_repo=""
+if [[ "$scm_provider" == "bitbucket-cloud" ]]; then
+  # HTTPS: https://bitbucket.org/{workspace}/{repo}.git
+  # SSH:   git@bitbucket.org:{workspace}/{repo}.git
+  if [[ "$remote_url" == https://bitbucket.org/* ]]; then
+    bb_workspace=$(echo "$remote_url" | sed -n 's|https://bitbucket\.org/\([^/]*\)/.*|\1|p')
+    bb_repo=$(echo "$remote_url" | sed -n 's|https://bitbucket\.org/[^/]*/\([^/.]*\).*|\1|p')
+  elif [[ "$remote_url" == git@bitbucket.org:* ]]; then
+    bb_workspace=$(echo "$remote_url" | sed -n 's|git@bitbucket\.org:\([^/]*\)/.*|\1|p')
+    bb_repo=$(echo "$remote_url" | sed -n 's|git@bitbucket\.org:[^/]*/\([^/.]*\).*|\1|p')
+  fi
+elif [[ "$scm_provider" == "bitbucket-dc" ]]; then
+  # HTTPS /scm/ format:      https://{host}/scm/{PROJECT}/{repo}.git
+  # HTTPS /projects/ format: https://{host}/projects/{PROJECT}/repos/{repo}
+  # SSH format:              ssh://git@{host}/{PROJECT}/{repo}.git
+  if [[ "$remote_url" == https://* ]]; then
+    bb_host=$(echo "$remote_url" | sed -n 's|https://\([^/]*\)/.*|\1|p')
+    bb_host="https://$bb_host"
+    if [[ "$remote_url" == */scm/* ]]; then
+      bb_project=$(echo "$remote_url" | sed -n 's|.*/scm/\([^/]*\)/.*|\1|p' | tr '[:lower:]' '[:upper:]')
+      bb_repo=$(echo "$remote_url" | sed -n 's|.*/scm/[^/]*/\([^/.]*\).*|\1|p')
+    elif [[ "$remote_url" == */projects/*/repos/* ]]; then
+      bb_project=$(echo "$remote_url" | sed -n 's|.*/projects/\([^/]*\)/repos/.*|\1|p')
+      bb_repo=$(echo "$remote_url" | sed -n 's|.*/repos/\([^/]*\).*|\1|p')
+    fi
+  elif [[ "$remote_url" == ssh://* ]]; then
+    # ssh://git@{host}/{PROJECT}/{repo}.git
+    bb_host=$(echo "$remote_url" | sed -n 's|ssh://git@\([^/]*\)/.*|\1|p')
+    bb_host="https://$bb_host"
+    bb_project=$(echo "$remote_url" | sed -n 's|ssh://git@[^/]*/\([^/]*\)/.*|\1|p' | tr '[:lower:]' '[:upper:]')
+    bb_repo=$(echo "$remote_url" | sed -n 's|ssh://git@[^/]*/[^/]*/\([^/.]*\).*|\1|p')
   fi
 fi
 
@@ -84,6 +131,10 @@ cat <<EOF
   "base_branch": "$base_branch",
   "ado_org": "$ado_org",
   "ado_project": "$ado_project",
+  "bb_workspace": "$bb_workspace",
+  "bb_project": "$bb_project",
+  "bb_host": "$bb_host",
+  "bb_repo": "$bb_repo",
   "sibling_repos": $sibling_json
 }
 EOF

--- a/plugins/dx-core/skills/dx-pr-answer/SKILL.md
+++ b/plugins/dx-core/skills/dx-pr-answer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dx-pr-answer
-description: Answer open comments on your ADO pull requests. Researches codebase context, drafts thoughtful replies, and posts them. Also detects and applies proposed code patches from reviewer comments. Use when someone wants to answer PR comments, respond to review feedback, handle open PR threads, or accept proposed patches.
+description: Answer open comments on your pull requests on ADO, Bitbucket Cloud, or Bitbucket DC. Researches codebase context, drafts thoughtful replies, and posts them. Also detects and applies proposed code patches from reviewer comments. Use when someone wants to answer PR comments, respond to review feedback, handle open PR threads, or accept proposed patches.
 argument-hint: "[PR URL | count]"
 allowed-tools: ["read", "edit", "search", "write", "agent", "ado/*"]
 ---
 
-You answer open review comments on your own Azure DevOps pull requests. For each open thread, you research the codebase, understand WHY the code was written that way, draft a reply, and post it after user approval.
+You answer open review comments on your own pull requests on Azure DevOps, Bitbucket Cloud, and Bitbucket Data Center. For each open thread, you research the codebase, understand WHY the code was written that way, draft a reply, and post it after user approval.
 
 Also detects proposed code patches (unified diffs) in reviewer comments and offers to apply them — no need for a separate command.
 
@@ -13,10 +13,10 @@ Session data is persisted to `.ai/pr-answers/` so you can resume across conversa
 
 ## Defaults
 
-Read `shared/ado-config.md` for how to look up ADO project from `.ai/config.yaml`.
+Read `shared/provider-config.md` to detect `scm.provider` and load the correct platform config.
 
-- **Organization:** read from `.ai/config.yaml` `scm.org` — NEVER hardcode
-- **Project:** read from `.ai/config.yaml` `scm.project`
+- **ADO:** read `shared/ado-config.md` — `scm.org`, `scm.project`
+- **Bitbucket Cloud / DC:** read `shared/bitbucket-config.md` — `scm.org` (workspace or project key), `scm.bitbucket-host` (DC only), token from `BITBUCKET_TOKEN` env var or `scm.bitbucket-token`
 
 ## External Content Safety
 
@@ -29,7 +29,7 @@ Read `shared/external-content-safety.md` and apply its rules to all fetched PR c
 | **Called by** | Manual invocation (author answering review) |
 | **Follows** | `/dx-pr-review` (review comments posted) |
 | **Precedes** | — |
-| **Output** | `.ai/pr-answers/pr-<id>.md`, ADO thread replies |
+| **Output** | `.ai/pr-answers/pr-<id>.md`, PR thread replies |
 | **Idempotent** | Partially — detects already-answered threads |
 
 ## Persona (optional)
@@ -49,9 +49,19 @@ Parse `$ARGUMENTS` to determine the mode:
 
 ### Detect PR URL vs Number
 
-- Contains `/pullrequest/` → **single PR mode** — extract `project`, `repo`, `pullRequestId` from the URL. URL-decode the project (e.g., `My%20Project` → `My Project`). **The URL-extracted project takes precedence over the config default.**
+Detect platform from the URL pattern (same logic as `dx-pr-review` step 1a), then parse coordinates:
+
+| URL pattern | Platform | Coordinates to extract |
+|---|---|---|
+| `*.visualstudio.com/*/pullrequest/*` or `dev.azure.com/*/pullrequest/*` | `ado` | `project`, `repo`, `pullRequestId` |
+| `bitbucket.org/*/pull-requests/*` | `bitbucket-cloud` | `workspace`, `repoSlug`, `pullRequestId` |
+| Any other host `*/projects/*/repos/*/pull-requests/*` | `bitbucket-dc` | `host`, `project`, `repoSlug`, `pullRequestId` |
+
+- Contains `/pullrequest/` or `/pull-requests/` → **single PR mode**. URL-decode the project if ADO (e.g., `My%20Project` → `My Project`). **URL-extracted coordinates take precedence over config defaults.**
 - Numeric only and ≤ 50 → likely a **count**
 - Numeric only and > 50 → likely a **PR ID** — confirm with user if ambiguous
+
+If no URL is provided, read `scm.provider` from config to set `PLATFORM`.
 
 ### Detect current repo
 
@@ -61,9 +71,10 @@ When no URL is provided, detect the repo from the git remote:
 git remote get-url origin
 ```
 
-Extract the repo name from the URL. Common ADO formats:
-- `vs-ssh.visualstudio.com:v3/<org>/<project>/<repo>` → repo name is the last segment
-- `<org>.visualstudio.com/<project>/_git/<repo>` → repo name after `_git/`
+Extract repo name and coordinates by platform:
+- **ADO:** `vs-ssh.visualstudio.com:v3/<org>/<project>/<repo>` or `<org>.visualstudio.com/<project>/_git/<repo>` → repo name is last segment
+- **Bitbucket Cloud:** `bitbucket.org/<workspace>/<repo>.git` or `git@bitbucket.org:<workspace>/<repo>.git` → workspace + repo slug
+- **Bitbucket DC:** `https://<host>/scm/<PROJECT>/<repo>.git` or SSH equivalents → host + project key + repo slug
 
 ## Automation Mode (pipeline / orchestrated)
 
@@ -101,9 +112,11 @@ echo "automation=$AUTOMATION disagree_min=$DISAGREE_MIN max_disagree=$MAX_DISAGR
 
 **When `AUTOMATION=0`** — the interactive flow below is unchanged.
 
-## 2. Load MCP Tools & Resolve Repo
+## 2. Load Tools & Resolve Repo
 
-Before any ADO calls, load the tools:
+### ADO
+
+Load MCP tools before any ADO calls:
 
 ```
 ToolSearch("+ado repo")
@@ -118,13 +131,29 @@ mcp__ado__repo_get_repo_by_name_or_id
   repositoryNameOrId: "<repo name>"
 ```
 
-**Important:** If the user provided a PR URL, use the project extracted from that URL — NOT the config default. The same repo can exist in multiple ADO projects.
+**Important:** If the user provided a PR URL, use the project extracted from that URL — NOT the config default. Save the `id` field — needed for all subsequent calls.
 
-Save the `id` field — needed for all subsequent calls.
+### Bitbucket Cloud / DC
+
+Resolve auth token (see `shared/bitbucket-config.md`):
+
+```bash
+TOKEN="${BITBUCKET_TOKEN:-$(grep 'bitbucket-token:' .ai/config.yaml 2>/dev/null | awk '{print $2}' | tr -d '"')}"
+[ -z "$TOKEN" ] && echo "ERROR: Bitbucket token not found. Set BITBUCKET_TOKEN env var or scm.bitbucket-token in config." && exit 2
+```
+
+For DC also set:
+
+```bash
+BB_HOST=$(grep 'bitbucket-host:' .ai/config.yaml | awk '{print $2}' | tr -d '"')
+BB_BASE="$BB_HOST/rest/api/1.0"
+```
+
+No repo ID resolution needed — Bitbucket REST uses workspace/project + repo slug directly.
 
 ## 3. Fetch My PRs
 
-Detect the current user:
+Detect the current user identity:
 
 ```bash
 git config user.email
@@ -132,34 +161,68 @@ git config user.email
 
 ### Single PR mode
 
-If input is a PR URL or ID, fetch just that one:
+If input is a PR URL or ID, fetch just that one.
 
+**ADO:**
 ```
 mcp__ado__repo_get_pull_request_by_id
   repositoryId: "<repo ID>"
   pullRequestId: <PR ID>
 ```
 
-Verify the PR is **mine**:
-- **Interactive** (`AUTOMATION=0`): compare `createdBy.uniqueName` with the current user email (`git config user.email`).
-- **Automation** (`AUTOMATION=1`): compare `createdBy.uniqueName` / `createdBy.displayName` against the comma-separated `MY_IDENTITIES` env (case-insensitive). The pipeline runs as a service account, so `git config user.email` is NOT the author — you MUST use `MY_IDENTITIES` here, or every PR is wrongly rejected.
+**Bitbucket Cloud:**
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{pullRequestId}"
+```
+
+**Bitbucket DC:**
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{pullRequestId}"
+```
+
+Verify the PR is **mine** — compare by platform:
+
+| Platform | Author field | Compare against |
+|---|---|---|
+| ADO interactive | `createdBy.uniqueName` | `git config user.email` |
+| ADO automation | `createdBy.uniqueName` / `createdBy.displayName` | `MY_IDENTITIES` env (comma-separated) |
+| Bitbucket Cloud | `.author.nickname` | `BITBUCKET_USERNAME` env or `scm.bitbucket-username` config |
+| Bitbucket DC | `.author.user.emailAddress` | `git config user.email` (interactive) or `MY_IDENTITIES` (automation) |
 
 If not mine:
-
 ```
 This PR was created by <author> — not yours. Only your PRs can be answered. Use /dx-pr-review to review others' PRs instead.
 ```
 
 ### Multiple PR mode
 
-Fetch my active PRs:
+Fetch my active PRs in the current repo.
 
+**ADO:**
 ```
 mcp__ado__repo_list_pull_requests_by_repo_or_project
   repositoryId: "<repo ID>"
   created_by_me: true
   status: "Active"
   top: <count>
+```
+
+**Bitbucket Cloud** (resolve own account ID first, then filter):
+```bash
+MY_ACCOUNT=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/user" | jq -r '.account_id')
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests?state=OPEN&q=author.account_id=%22$MY_ACCOUNT%22&pagelen={count}"
+```
+
+**Bitbucket DC:**
+```bash
+MY_SLUG=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/users?filter=$(git config user.email)" | jq -r '.values[0].slug')
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests?state=OPEN&author.name=$MY_SLUG&limit={count}"
 ```
 
 ### Present PR List
@@ -223,6 +286,7 @@ For each selected PR:
 
 ### 5a. Fetch Active Threads
 
+**ADO:**
 ```
 mcp__ado__repo_list_pull_request_threads
   repositoryId: "<repo ID>"
@@ -231,10 +295,23 @@ mcp__ado__repo_list_pull_request_threads
   fullResponse: true
 ```
 
+**Bitbucket Cloud:**
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments?pagelen=100"
+```
+Filter to active comments: exclude deleted (`.deleted: true`). Group by `parent.id` to reconstruct threads — root comments have no `parent.id`.
+
+**Bitbucket DC:**
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments?limit=100"
+```
+Filter to active comments: exclude deleted (`.state: "DELETED"`). Same grouping by `parent.id`.
+
 ### 5b. Read Thread Comments
 
-For each active thread, read the full conversation:
-
+**ADO:** full conversation already fetched in 5a via `fullResponse: true`. For a specific thread:
 ```
 mcp__ado__repo_list_pull_request_thread_comments
   repositoryId: "<repo ID>"
@@ -242,6 +319,8 @@ mcp__ado__repo_list_pull_request_thread_comments
   threadId: <thread ID>
   fullResponse: true
 ```
+
+**Bitbucket Cloud / DC:** the full comment list is already fetched in 5a. Extract a thread by filtering on the root comment ID and all replies where `parent.id` matches that root.
 
 ### 5b-2. Detect Patches in Thread Comments
 
@@ -281,8 +360,8 @@ Tag threads containing patches as `[PATCH]` alongside `[BOT]`/`[HUMAN]`.
 ### 5c. Skip Non-Reviewable Threads
 
 Skip threads that are:
-- **System threads** — no meaningful author, or generated by ADO (status updates, vote changes, policy checks)
-- **Your own threads** — threads YOU created (you don't answer your own questions)
+- **System threads** — no meaningful author, or auto-generated by the platform (status updates, vote changes, policy checks, CI notifications)
+- **Your own threads** — threads YOU created (you don't answer your own questions). Identify by matching the root comment author against your identity (same platform-aware comparison as step 3 "Verify the PR is mine")
 - **Already answered** — if the last comment in the thread is from you (you already replied)
 
 ### 5d. Detect Bot vs Human
@@ -291,7 +370,9 @@ Check **two layers** — identity AND content.
 
 **Layer 1: Identity patterns** (case-insensitive)
 - Display name contains: `bot`, `service`, `pipeline`, `automation`, `webhook`, `build`, `azure devops`, `microsoft`, `agent`, `system`
-- Unique name contains: `@bot`, `vstfs:`, `\\Build\\`, `\\Project Collection`
+- ADO unique name contains: `@bot`, `vstfs:`, `\\Build\\`, `\\Project Collection`
+- Bitbucket Cloud nickname contains: `+bot`, `automation`, `pipeline`, `service`
+- Bitbucket DC username contains: `bot`, `automation`, `pipeline`, `service`, `bamboo`, `jenkins`
 - Author identity type is `system` or has no real email
 
 **Layer 2: Content patterns** (check the first comment's text)
@@ -417,10 +498,11 @@ Write `.ai/pr-answers/pr-<id>.md` with this format:
 # PR #<id> — <title>
 
 **Branch:** <sourceBranch> → <targetBranch>
-**Repo:** <repoName> (ID: <repoId>)
-**Project:** <ADO project name>
-**Author:** <createdBy.displayName>
-**Author ID:** <createdBy.id>  <!-- used to @-mention the author in needs-human-input replies -->
+**Repo:** <repoName> (ID: <repoId> — ADO only; omit for Bitbucket)
+**Platform:** <ado | bitbucket-cloud | bitbucket-dc>
+**Project / Workspace:** <ADO project name, BB workspace, or BB project key>
+**Author:** <author display name>
+**Author ID:** <createdBy.id (ADO) | author.account_id (BB Cloud) | author.user.name (BB DC)>  <!-- used to @-mention the author in needs-human-input replies -->
 **Last updated:** <ISO date>
 **Status:** drafting | partial | complete
 
@@ -507,7 +589,10 @@ This ensures the session file always reflects the latest state, even if the conv
 I raised this once and we don't seem aligned, so I'm handing it to you rather than going back and forth: <one line — what's unresolved or why the answer is uncertain>.
 ```
 
-- **Author mention:** ADO renders `@<{GUID}>` as a notification mention — use `createdBy.id`. If the id is unavailable, fall back to `@<createdBy.uniqueName>` (or plain `@<displayName>`), which still surfaces the author's name in the reply.
+- **Author mention by platform:**
+  - **ADO:** `@<{createdBy.id}>` (GUID renders as a notification mention). Fallback: `@<createdBy.uniqueName>` or plain `@<displayName>`.
+  - **Bitbucket Cloud:** `@<author.nickname>` (e.g., `@johndoe`). Bitbucket renders `@nickname` as a mention.
+  - **Bitbucket DC:** `@<author.user.name>` (the user's slug). Bitbucket DC renders `@slug` as a mention.
 - Leave the thread **open**, mark it `needs-human-input` in the session, and count it toward `verdict: warn`.
 
 This keeps autonomy honest: one grounded rebuttal goes out automatically; if the human isn't convinced — or you can't ground it — it escalates to the author by name instead of the bot arguing in circles. Never faked, never dropped, never a second round.
@@ -567,14 +652,33 @@ If no patches were detected, skip this step entirely.
 
 ## 7. Post Approved Answers
 
-For each approved answer, post the reply:
+For each approved answer, post the reply.
 
+**ADO:**
 ```
 mcp__ado__repo_reply_to_comment
   repositoryId: "<repo ID>"
   pullRequestId: <PR ID>
   threadId: <thread ID>
   content: "<approved reply text>"
+```
+
+**Bitbucket Cloud:**
+```bash
+BODY=$(jq -n --arg text "<reply text>" --argjson pid <rootCommentId> \
+  '{content: {raw: $text}, parent: {id: $pid}}')
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
+```
+
+**Bitbucket DC:**
+```bash
+BODY=$(jq -n --arg text "<reply text>" --argjson pid <rootCommentId> \
+  '{text: $text, parent: {id: $pid}}')
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
 ```
 
 **Never resolve threads** — the user handles resolution manually.
@@ -719,15 +823,7 @@ Skill(/dx-pr-commit, args: "apply reviewer-proposed patches")
 
 #### 7a-5. Reply to Patch Threads
 
-After `/dx-pr-commit` completes, reply to each successfully applied patch thread:
-
-```
-mcp__ado__repo_reply_to_comment
-  repositoryId: "<repo ID>"
-  pullRequestId: <PR ID>
-  threadId: <thread ID>
-  content: "Applied, thanks!"
-```
+After `/dx-pr-commit` completes, reply to each successfully applied patch thread using the same platform-specific reply API as step 7.
 
 Short and appreciative: "Applied, thanks!", "Patched, cheers.", "Nice catch — applied."
 
@@ -824,11 +920,23 @@ Run headless with `DX_PIPELINE_MODE=true` and `MY_IDENTITIES` set. Detects `AUTO
 ```
 Lists your active PRs with open threads. For each, researches codebase context, drafts replies categorized as agree-will-fix / question / disagree / skip. Presents for approval before posting.
 
-### Answer specific PR
+### Answer specific PR (ADO)
 ```
 /dx-pr-answer https://dev.azure.com/myorg/My%20Project/_git/My-Repo/pullrequest/12345
 ```
 Processes only PR #12345. Detects bot vs human reviewers, applies patches if detected.
+
+### Answer specific PR (Bitbucket Cloud)
+```
+/dx-pr-answer https://bitbucket.org/myworkspace/my-repo/pull-requests/42
+```
+Detects `bitbucket-cloud` from URL. Fetches PR and all comments via REST API. Researches codebase, drafts replies, posts them as comment replies using the `parent.id` threading model.
+
+### Answer specific PR (Bitbucket DC)
+```
+/dx-pr-answer https://bitbucket.example.com/projects/MYPROJ/repos/my-repo/pull-requests/42
+```
+Detects `bitbucket-dc` from URL. Uses `BB_BASE` from `scm.bitbucket-host` in config.
 
 ### Resume previous session
 ```
@@ -922,8 +1030,8 @@ Before presenting drafted responses:
 - **Persist session** — always save to `.ai/pr-answers/pr-<id>.md` after drafting AND after posting. Update thread statuses on every state change
 - **Resume sessions** — on re-run, check `.ai/pr-answers/` first. Reuse drafts for unchanged threads, re-research only threads with new comments
 - **Subagent for research** — always use a `general-purpose` subagent for file reading, diff analysis, and answer drafting. This keeps the main context clean for MCP calls and user interaction
-- **MCP stays in main context** — all ADO API calls happen here, not in the research agent
-- **MCP tools are deferred** — always load via ToolSearch before first use
+- **API calls stay in main context** — all ADO MCP calls and Bitbucket `curl` calls happen here, not in the research agent
+- **MCP tools are deferred (ADO only)** — always load via ToolSearch before first ADO call; Bitbucket uses curl with a bearer token
 - **Dry-run patches first** — always `git apply --check` before actual apply. Never apply a patch blind
 - **Graceful patch failures** — if one patch fails, skip it, apply the rest, report what failed
 - **Delegate git to /dx-pr-commit** — never handle staging, committing, rebasing, or pushing directly

--- a/plugins/dx-core/skills/dx-pr-answer/references/apply-fixes.md
+++ b/plugins/dx-core/skills/dx-pr-answer/references/apply-fixes.md
@@ -228,6 +228,30 @@ Reply tone:
 
 **Never resolve threads** — the user and reviewer handle resolution.
 
+### Bitbucket Cloud
+
+If `Platform: bitbucket-cloud` in session: skip MCP above. Resolve `TOKEN=${BITBUCKET_TOKEN:-$(read scm.bitbucket-token from config)}`. Read `WORKSPACE` and `REPO_SLUG` from session file.
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://api.bitbucket.org/2.0/repositories/$WORKSPACE/$REPO_SLUG/pullrequests/<PR_ID>/comments" \
+  -d "$(jq -n --argjson parent <threadId> '{"content":{"raw":"Fixed."},"parent":{"id":$parent}}')"
+```
+
+### Bitbucket DC
+
+If `Platform: bitbucket-dc` in session: skip MCP above. Resolve `TOKEN=${BITBUCKET_TOKEN:-$(read scm.bitbucket-token from config)}`. Read `BB_HOST`, `BB_PROJECT`, and `REPO_SLUG` from session file.
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "$BB_HOST/rest/api/1.0/projects/$BB_PROJECT/repos/$REPO_SLUG/pull-requests/<PR_ID>/comments" \
+  -d "$(jq -n --argjson parent <threadId> '{"text":"Fixed.","parent":{"id":$parent}}')"
+```
+
 ## 8. Update Session File
 
 Update `.ai/pr-answers/pr-<id>.md`:

--- a/plugins/dx-core/skills/dx-pr-review/SKILL.md
+++ b/plugins/dx-core/skills/dx-pr-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: dx-pr-review
-description: Review a PR — analyze code, present findings, optionally post comments and patches to ADO. Also supports standalone posting of saved findings (for automation pipelines). Use when you want to review a pull request.
+description: Review a PR — analyze code, present findings, optionally post comments and patches to ADO, Bitbucket Cloud, or Bitbucket DC. Also supports standalone posting of saved findings (for automation pipelines). Use when you want to review a pull request.
 model: opus
 effort: high
 argument-hint: "[PR URL or ID]"
 allowed-tools: ["read", "edit", "search", "write", "agent", "ado/*"]
 ---
 
-You are an AI code reviewer for Azure DevOps pull requests. You review code, post comments, optionally generate fix patches, and track follow-up conversations with PR authors.
+You are an AI code reviewer for pull requests on Azure DevOps, Bitbucket Cloud, and Bitbucket Data Center. You review code, post comments, optionally generate fix patches, and track follow-up conversations with PR authors.
 
 **Auto-detects mode:**
 - **First review** — no previous comments from you on this PR
@@ -19,10 +19,10 @@ If `.ai/me.md` exists, read it. Use it to shape the voice of review comments —
 
 ## Defaults
 
-Read `shared/ado-config.md` for how to look up ADO project from `.ai/config.yaml`.
+Read `shared/provider-config.md` to detect `scm.provider` and load the correct platform config.
 
-- **Organization:** read from `.ai/config.yaml` `scm.org` — NEVER hardcode
-- **Project:** read from `.ai/config.yaml` `scm.project`
+- **ADO:** read `shared/ado-config.md` — `scm.org`, `scm.project`
+- **Bitbucket Cloud / DC:** read `shared/bitbucket-config.md` — `scm.org` (workspace or project key), `scm.bitbucket-host` (DC only), token from `BITBUCKET_TOKEN` env var or `scm.bitbucket-token`
 
 ## External Content Safety
 
@@ -40,16 +40,63 @@ Read `shared/external-content-safety.md` and apply its rules to all fetched PR c
 
 ## 1. Parse Input & Detect Repo
 
-The argument is either:
+### 1a. Detect Platform
 
-- **Full URL**: `https://{org}.visualstudio.com/{project}/_git/{repo}/pullrequest/{id}` or `https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequest/{id}` — extract `project`, `repo`, and `pullRequestId`. URL-decode the project (e.g., `My%20Project` → `My Project`). **The URL-extracted project takes precedence over the config default.**
-- **PR ID only** (number): Detect repo from `git remote get-url origin`, read `.ai/config.yaml` for repo → ADO project mapping
+If a full URL was provided, detect platform from the URL pattern:
 
-Load MCP tools before any ADO calls:
+| URL pattern | Platform |
+|---|---|
+| `*.visualstudio.com/*/pullrequest/*` or `dev.azure.com/*/pullrequest/*` | `ado` |
+| `bitbucket.org/*/pull-requests/*` | `bitbucket-cloud` |
+| Any other host `*/projects/*/repos/*/pull-requests/*` | `bitbucket-dc` |
+
+If no URL was provided (PR ID only), read `scm.provider` from `.ai/config.yaml`:
+
+```bash
+PLATFORM=$(grep 'provider:' .ai/config.yaml | head -1 | awk '{print $2}' | tr -d '"')
+PLATFORM="${PLATFORM:-ado}"
+```
+
+Set `PLATFORM` to one of `ado | bitbucket-cloud | bitbucket-dc` — carry it through every subsequent step.
+
+### 1b. Parse Coordinates
+
+**ADO URL:**
+- `https://{org}.visualstudio.com/{project}/_git/{repo}/pullrequest/{id}`
+- `https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequest/{id}`
+- Extract: `project`, `repoName`, `pullRequestId`. URL-decode the project (e.g., `My%20Project` → `My Project`). **URL-extracted project takes precedence over config default.**
+
+**Bitbucket Cloud URL:**
+- `https://bitbucket.org/{workspace}/{repo-slug}/pull-requests/{id}`
+- Extract: `workspace` (maps to `scm.org`), `repoSlug`, `pullRequestId`
+
+**Bitbucket DC URL:**
+- `https://{host}/projects/{project}/repos/{repo}/pull-requests/{id}`
+- Extract: `host` (maps to `scm.bitbucket-host`), `project` (maps to `scm.org`), `repoSlug`, `pullRequestId`
+
+**PR ID only:** Detect repo from `git remote get-url origin`, read `.ai/config.yaml` for project/workspace mapping.
+
+### 1c. Load Tools
+
+**ADO:**
 
 ```
 ToolSearch("+ado repo")
 ToolSearch("+ado pull request thread")
+```
+
+**Bitbucket Cloud / DC:** resolve auth token using `shared/bitbucket-config.md` token resolution:
+
+```bash
+TOKEN="${BITBUCKET_TOKEN:-$(grep 'bitbucket-token:' .ai/config.yaml 2>/dev/null | awk '{print $2}' | tr -d '"')}"
+[ -z "$TOKEN" ] && echo "ERROR: Bitbucket token not found. Set BITBUCKET_TOKEN env var or scm.bitbucket-token in config." && exit 2
+```
+
+For Bitbucket DC, also read the host:
+
+```bash
+BB_HOST=$(grep 'bitbucket-host:' .ai/config.yaml | awk '{print $2}' | tr -d '"')
+BB_BASE="$BB_HOST/rest/api/1.0"
 ```
 
 If the PR is from a **different repo** than the current working directory, note this — you'll handle it in step 4.
@@ -95,6 +142,8 @@ If hub mode is not active: continue with normal flow below.
 
 ## 2. Fetch PR Details
 
+### ADO
+
 Resolve the repo ID first:
 
 ```
@@ -113,21 +162,41 @@ mcp__ado__repo_get_pull_request_by_id
   pullRequestId: <PR ID>
 ```
 
-Extract:
-- **Title and description** — understand the intent
-- **Source branch** (`sourceRefName`) and **target branch** (`targetRefName`)
-- **Status** — only review active PRs
-- **Reviewers** — existing votes
-- **Created by** — for context
-- **SSH URL** — from `repository.sshUrl` (needed for cross-repo)
+Extract: title, description, `sourceRefName`/`targetRefName` (strip `refs/heads/`), status (only review `active`), `createdBy.uniqueName` + `createdBy.displayName`, `repository.sshUrl`.
+
+### Bitbucket Cloud
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{pullRequestId}"
+```
+
+Extract: `.title`, `.description`, `.source.branch.name` / `.destination.branch.name`, `.state` (only review `OPEN`), `.author.display_name` + `.author.nickname` (slug) + `.author.account_id`, SSH clone URL from `.source.repository.links.clone[] | select(.name=="ssh") | .href`.
+
+### Bitbucket DC
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{pullRequestId}"
+```
+
+Extract: `.title`, `.description`, `.fromRef.displayId` / `.toRef.displayId`, `.state` (only review `OPEN`), `.author.user.displayName` + `.author.user.name` (slug) + `.author.user.emailAddress`, SSH clone URL from `.fromRef.repository.links.clone[] | select(.name=="ssh") | .href`.
 
 ### Skip own PRs
 
-**Unless `REVIEW_OWN_PRS=1`** (the `DX_REVIEW_OWN_PRS=true` override — default on in CI, off locally), compare the PR's `createdBy.uniqueName` / `createdBy.displayName` against the current user (`git config user.email`). If they match:
+**Unless `REVIEW_OWN_PRS=1`** (the `DX_REVIEW_OWN_PRS=true` override — default on in CI, off locally), compare the PR author against the current user. If they match:
 
 ```
 Skipping PR #<id> — you are the author. You can't review your own PR.
 ```
+
+**Identity comparison by platform:**
+
+| Platform | Author field | Compare against |
+|---|---|---|
+| ADO | `createdBy.uniqueName` | `git config user.email` |
+| Bitbucket Cloud | `.author.nickname` | `scm.bitbucket-username` from config, or `BITBUCKET_USERNAME` env var |
+| Bitbucket DC | `.author.user.emailAddress` | `git config user.email` |
 
 And stop. If invoked from `/dx-pr-review-all`, return this so the orchestrator can skip to the next PR.
 
@@ -135,7 +204,9 @@ If `REVIEW_OWN_PRS=1`, do **not** skip — continue reviewing even when the auth
 
 ## 3. Fetch Existing Review Threads
 
-Check for existing threads — these provide valuable context for the review:
+Check for existing comments/threads — these provide valuable context for the review.
+
+### ADO
 
 ```
 mcp__ado__repo_list_pull_request_threads
@@ -152,6 +223,24 @@ mcp__ado__repo_list_pull_request_thread_comments
   threadId: <thread ID>
   fullResponse: true
 ```
+
+### Bitbucket Cloud
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{pullRequestId}/comments?pagelen=100"
+```
+
+The response is a flat list (`.values[]`). Group into logical threads using `parent.id` — top-level comments (no `parent.id`) are thread roots; comments with `parent.id` are replies. Skip deleted comments (`.deleted: true`).
+
+### Bitbucket DC
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{pullRequestId}/comments?limit=100"
+```
+
+Same flat-list structure as Cloud. Group by `parent.id` into thread roots and replies. Skip deleted comments (`.state: "DELETED"`).
 
 Build a structured summary of existing review comments:
 
@@ -181,7 +270,10 @@ After fetching threads, determine whether this is a first review or follow-up:
    git config user.email
    ```
 
-2. Scan all fetched threads — check each thread's comments for ones authored by the current user (match `uniqueName` against your email).
+2. Scan all fetched threads — check each thread's comments for ones authored by the current user. Match by platform:
+   - **ADO:** match comment `uniqueName` against `git config user.email`
+   - **Bitbucket Cloud:** match comment `.author.nickname` against `BITBUCKET_USERNAME` or `scm.bitbucket-username`
+   - **Bitbucket DC:** match comment `.author.emailAddress` against `git config user.email`
 
 3. Check for a session file:
    ```bash
@@ -593,11 +685,13 @@ AskUserQuestion(
 
 **Wait for explicit approval.**
 
-### 8. Post Comments to ADO
+### 8. Post Comments
 
-#### Without patches (default)
+Post inline comments and a summary thread. Follow `references/post-findings.md` for the full posting procedure including idempotency guards, comment formats, and vote casting — it covers all three platforms (ADO, Bitbucket Cloud, Bitbucket DC).
 
-Post each comment as a thread:
+**Quick reference — inline comment API per platform:**
+
+#### ADO (without patches)
 
 ```
 mcp__ado__repo_create_pull_request_thread
@@ -612,7 +706,7 @@ mcp__ado__repo_create_pull_request_thread
   status: "active"
 ```
 
-Then post the summary (no filePath = general PR comment):
+Summary (no filePath = general PR comment):
 
 ```
 mcp__ado__repo_create_pull_request_thread
@@ -622,11 +716,37 @@ mcp__ado__repo_create_pull_request_thread
   status: "active"
 ```
 
-#### With patches
+#### Bitbucket Cloud (without patches)
 
-For each fix, post a comment with the issue AND the specific patch:
+```bash
+# Inline comment
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"content\": {\"raw\": \"<comment>\"}, \"inline\": {\"path\": \"<file>\", \"to\": <line>}}" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
 
-**Comment format for fixable issues:**
+# Summary comment (no inline block)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"content\": {\"raw\": \"**Verdict**: <verdict>\\n\\nReviewed N files — N comments.\"}}" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
+```
+
+#### Bitbucket DC (without patches)
+
+```bash
+# Inline comment
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"text\": \"<comment>\", \"anchor\": {\"line\": <line>, \"lineType\": \"ADDED\", \"fileType\": \"TO\", \"path\": \"<file>\"}}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
+
+# Summary comment (no anchor block)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"text\": \"**Verdict**: <verdict>\\n\\nReviewed N files — N comments.\"}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
+```
+
+#### With patches (all platforms)
+
+For each fixable issue, embed the patch in a collapsible block:
 
 ```markdown
 <issue description — written like a colleague, not a linting tool>
@@ -643,13 +763,13 @@ To apply: \`git apply fix.patch\`
 ```
 
 > **CRITICAL — diff rendering in `<details>` blocks:**
-> 1. **Blank line after `</summary>` is mandatory** — without it, ADO won't process the code fence as markdown
-> 2. **NEVER HTML-encode diff content** — write raw `<p>`, `<span>`, `<div>`, NOT `&lt;p&gt;`, `&lt;span&gt;`, `&lt;div&gt;`. The code fence handles escaping for display. HTML-encoding creates double-encoding that shows literal `&lt;` text to the reader.
-> 3. **Always include the triple-backtick code fence** with `diff` language tag — without it, HTML tags in the diff get parsed as actual HTML
+> 1. **Blank line after `</summary>` is mandatory** — without it, the platform won't process the code fence as markdown
+> 2. **NEVER HTML-encode diff content** — write raw `<p>`, `<span>`, `<div>`, NOT `&lt;p&gt;`, `&lt;span&gt;`, `&lt;div&gt;`
+> 3. **Always include the triple-backtick code fence** with `diff` language tag
 
 **For non-fixable issues (QUESTION):** regular comment without a patch.
 
-**Summary thread** (no filePath):
+**Summary thread:**
 
 ```markdown
 **Review with proposed fixes**
@@ -687,16 +807,16 @@ AskUserQuestion(
 )
 ```
 
-Map the user's choice to the `vote` enum and cast it via MCP:
+Map the user's choice and cast the vote via the platform API:
 
-| Option | `vote` enum | ADO integer |
-|---|---|---|
-| Approve — no critical issues | `Approved` | 10 |
-| Approve with suggestions — minor improvements | `ApprovedWithSuggestions` | 5 |
-| Request changes — critical issues | `WaitingForAuthor` | -5 |
-| (reject variant, if needed) | `Rejected` | -10 |
-| (clear vote) | `NoVote` | 0 |
-| Skip voting — comments only | *(no-op — do not call the tool)* | — |
+| Option | ADO | Bitbucket Cloud | Bitbucket DC |
+|---|---|---|---|
+| Approve | `vote: Approved` (+10) | POST `/approve` | POST `/approve` |
+| Approve with suggestions | `vote: ApprovedWithSuggestions` (+5) | POST `/approve` | POST `/approve` |
+| Request changes | `vote: WaitingForAuthor` (-5) | POST `/request-changes` | PUT `/participants/{slug}` `status: NEEDS_WORK` |
+| Skip voting | *(no-op)* | *(no-op)* | *(no-op)* |
+
+**ADO:**
 
 ```
 mcp__ado__repo_vote_pull_request
@@ -705,9 +825,35 @@ mcp__ado__repo_vote_pull_request
   vote: "<Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote>"
 ```
 
-The tool auto-adds the caller as a reviewer if not already one. If the user picks **Skip voting — comments only**, do not call the tool.
+The tool auto-adds the caller as a reviewer if not already one.
 
-Never auto-approve or auto-decline without explicit user confirmation.
+**Bitbucket Cloud:**
+
+```bash
+# Approve
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/approve"
+# Request changes
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/request-changes"
+```
+
+**Bitbucket DC:**
+
+```bash
+# Approve
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/approve"
+# Request changes (Needs Work) — resolve user slug first
+USER_SLUG=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/users?filter=$(git config user.email)" | jq -r '.values[0].slug')
+curl -s -X PUT \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"user\": {\"name\": \"$USER_SLUG\"}, \"approved\": false, \"status\": \"NEEDS_WORK\"}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/participants/$USER_SLUG"
+```
+
+If the user picks **Skip voting — comments only**, do not call any vote API. Never auto-approve or auto-decline without explicit user confirmation.
 
 ---
 
@@ -734,7 +880,9 @@ If no new commits since review commit: "No new commits since your last review. N
 
 #### 4F-3. Fetch Current Threads
 
-Refetch all threads from ADO (already done in step 3). For each of **my** threads, read the full conversation:
+Refetch all threads (already done in step 3). For each of **my** threads, read the full conversation.
+
+**ADO:**
 
 ```
 mcp__ado__repo_list_pull_request_thread_comments
@@ -743,6 +891,8 @@ mcp__ado__repo_list_pull_request_thread_comments
   threadId: <thread ID>
   fullResponse: true
 ```
+
+**Bitbucket Cloud / DC:** The full comment list was already fetched in step 3. Extract the thread by filtering on the root comment ID and all comments with `parent.id` matching that root.
 
 #### 4F-4. Classify Each Thread
 
@@ -884,9 +1034,30 @@ Task(
 
 Same as first-review steps 6-8 — generate patches if requested, post comments.
 
-For ARGUED thread reactions: reply via `mcp__ado__repo_reply_to_comment` (existing threads, not new ones).
+For ARGUED thread reactions and IGNORED thread pings: reply to the existing thread root comment.
 
-For IGNORED thread pings: reply to existing thread with a polite nudge.
+**ADO:**
+```
+mcp__ado__repo_reply_to_comment
+  repositoryId: "<repo ID>"
+  pullRequestId: <PR ID>
+  threadId: <thread ID>
+  content: "<reply text>"
+```
+
+**Bitbucket Cloud:**
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"content\": {\"raw\": \"<reply text>\"}, \"parent\": {\"id\": <rootCommentId>}}" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
+```
+
+**Bitbucket DC:**
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"text\": \"<reply text>\", \"parent\": {\"id\": <rootCommentId>}}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
+```
 
 ---
 
@@ -907,12 +1078,13 @@ Write `.ai/pr-reviews/pr-<id>.md`:
 
 **Author:** <name>
 **Branch:** <sourceBranch> → <targetBranch>
-**Repo:** <repoName> (ID: <repoId>)
-**Project:** <ADO project name>
+**Repo:** <repoName> (ID: <repoId> — ADO only; omit for Bitbucket)
+**Platform:** <ado | bitbucket-cloud | bitbucket-dc>
+**Project / Workspace:** <ADO project name, BB workspace, or BB project key>
 **Last reviewed:** <ISO date>
 **Review commit:** <SHA>
 **Status:** reviewed | follow-up-needed | complete
-**Vote:** <Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote | skipped> — set via `mcp__ado__repo_vote_pull_request`
+**Vote:** <Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote | skipped>
 
 ## My Threads
 
@@ -1005,6 +1177,24 @@ Detects previous review threads from you on this PR. Shows what changed since yo
 ```
 Runs full review but saves findings to `.ai/pr-reviews/pr-12345-findings.md` without presenting interactively or posting to ADO. Used by `/dx-pr-review-all` and CI pipelines.
 
+### Bitbucket Cloud — review by PR URL
+```
+/dx-pr-review https://bitbucket.org/myworkspace/my-repo/pull-requests/42
+```
+Detects `bitbucket-cloud` platform from URL. Reads token from `BITBUCKET_TOKEN`. Fetches PR via REST API, spawns review agent on the local git diff, presents findings table, posts inline comments and summary via Bitbucket Cloud REST.
+
+### Bitbucket DC — review by PR URL
+```
+/dx-pr-review https://bitbucket.example.com/projects/MYPROJ/repos/my-repo/pull-requests/42
+```
+Detects `bitbucket-dc` platform from URL. Reads `BB_BASE` from `scm.bitbucket-host` in config + token from `BITBUCKET_TOKEN`. Full review and posting via Bitbucket Server/DC REST API 1.0.
+
+### Bitbucket — review by ID (current repo)
+```
+/dx-pr-review 42
+```
+With `scm.provider: bitbucket-cloud` (or `bitbucket-dc`) in config, detects platform from config, resolves workspace/project from `scm.org`, repo slug from `git remote`. Same full review flow.
+
 ## Troubleshooting
 
 ### "You are the author — can't review your own PR"
@@ -1015,9 +1205,19 @@ Runs full review but saves findings to `.ai/pr-reviews/pr-12345-findings.md` wit
 **Cause:** PR is from a different repo than your working directory.
 **Fix:** Check `.ai/config.yaml` `repos:` for a `path` entry. If missing, the skill will shallow-clone to `/tmp/` automatically.
 
-### Comments fail to post with 403
+### Comments fail to post with 403 (ADO)
 **Cause:** ADO PAT lacks "Code (Read & Write)" scope, or you don't have PR comment permissions.
 **Fix:** Regenerate PAT with correct scopes. The skill continues posting remaining comments if one fails.
+
+### Bitbucket token not found
+**Cause:** `BITBUCKET_TOKEN` env var is not set and `scm.bitbucket-token` is missing from config.
+**Fix:** Export `BITBUCKET_TOKEN=<your-token>` in your shell (preferred), or add `bitbucket-token: "<token>"` under `scm:` in `.ai/config.yaml`. For Bitbucket Cloud use an App Password with "Pull requests: Read & Write" scope. For DC use a Personal Access Token with "Repositories: Write" and "Pull requests: Write" permissions.
+
+### Bitbucket inline comment returns 400
+**Cause (Cloud):** `inline.path` is incorrect or `inline.to` is out of range for the diff.
+**Fix:** Verify the file path matches exactly what appears in the PR diff (no leading slash for Cloud). Check that the line number is within the changed hunk.
+**Cause (DC):** `anchor.lineType` is `CONTEXT` for a line that is `ADDED` in the diff.
+**Fix:** Use `lineType: ADDED` for new lines. Use `CONTEXT` only for unchanged context lines within the diff.
 
 ### No issues found on a clearly problematic PR
 **Cause:** Confidence threshold filters out low-confidence findings (only ≥80 reported).
@@ -1092,7 +1292,7 @@ Common excuses for weak reviews — and why they're wrong:
 ## Rules
 
 - **Agent handles analysis** — diff, context loading, and code review run inside the `dx-pr-reviewer` agent, keeping the main context lean
-- **MCP stays in main context** — all ADO API calls happen here, not in the agent
+- **API calls stay in main context** — all ADO MCP calls and Bitbucket `curl` calls happen here, not in the agent
 - **Auto-detect mode** — check for previous review threads to determine first review vs follow-up. No flags needed
 - **Session persistence** — always save to `.ai/pr-reviews/pr-<id>.md` after posting. Update on follow-up
 - **Never push to their branch** — generate patches, never commit or push to the author's branch
@@ -1116,5 +1316,5 @@ Common excuses for weak reviews — and why they're wrong:
 - **Scope your review** — review what's in the PR, don't suggest unrelated refactors
 - **Follow-up verification** — for silently fixed threads, verify the fix before marking as addressed
 - **Continue on failure** — if one comment fails to post, log and continue
-- **MCP tools are deferred** — always load via ToolSearch before first use
+- **MCP tools are deferred** — always load via ToolSearch before first use (ADO only; Bitbucket uses curl)
 - **URL project precedence** — if a PR URL was provided, use the project from the URL, not from config

--- a/plugins/dx-core/skills/dx-pr-review/references/post-findings.md
+++ b/plugins/dx-core/skills/dx-pr-review/references/post-findings.md
@@ -1,6 +1,6 @@
 # Post Findings — Standalone Procedure
 
-This reference describes the standalone posting procedure for PR review findings saved to disk by `/dx-pr-review`. Used by automation pipelines and when posting is deferred from the review step.
+This reference describes the standalone posting procedure for PR review findings saved to disk by `/dx-pr-review`. Used by automation pipelines and when posting is deferred from the review step. Covers Azure DevOps, Bitbucket Cloud, and Bitbucket DC.
 
 ## 1. Load Findings File
 
@@ -26,7 +26,11 @@ cat .ai/pr-reviews/pr-<id>.patch 2>/dev/null
 
 If found, read and split by `diff --git` markers into per-file patches. Map each file patch to its corresponding issue by matching the file path.
 
-## 3. Load MCP Tools
+## 3. Detect Platform and Load Tools
+
+Read the `Platform:` field from the findings metadata (added by `/dx-pr-review` step 10). If absent, default to `ado`.
+
+### ADO
 
 ```
 ToolSearch("+ado pull request thread")
@@ -41,11 +45,31 @@ mcp__ado__repo_get_repo_by_name_or_id
   repositoryNameOrId: "<repo name>"
 ```
 
+### Bitbucket Cloud / DC
+
+Resolve the auth token (see `shared/bitbucket-config.md` — token resolution):
+
+```bash
+TOKEN="${BITBUCKET_TOKEN:-$(grep 'bitbucket-token:' .ai/config.yaml 2>/dev/null | awk '{print $2}' | tr -d '"')}"
+[ -z "$TOKEN" ] && echo "ERROR: Bitbucket token not found." && exit 2
+```
+
+For DC, also set:
+
+```bash
+BB_HOST=$(grep 'bitbucket-host:' .ai/config.yaml | awk '{print $2}' | tr -d '"')
+BB_BASE="$BB_HOST/rest/api/1.0"
+```
+
+The workspace/project key and repo slug come from findings metadata (`Project / Workspace:`, `Repo:`).
+
 ## 4. Post Issue Threads
 
 ### Idempotency — skip threads you already posted
 
-**Before posting anything**, fetch the PR's existing threads so a re-run never double-posts. A re-run happens whenever the queue's `vote == 0` filter re-selects this PR: a prior run that posted threads but **crashed before casting the vote**, a manually cleared vote, or a verdict that mapped to `NoVote`.
+**Before posting anything**, fetch the PR's existing comments so a re-run never double-posts.
+
+**ADO:**
 
 ```
 mcp__ado__repo_list_pull_request_threads
@@ -55,13 +79,34 @@ mcp__ado__repo_list_pull_request_threads
 
 Build a set of `(filePath, startLine)` from existing threads anchored to a file (`threadContext.filePath` + `threadContext.rightFileStart.line`). Also note whether any existing thread's first comment already contains the `**[AI Review]` marker (the summary thread).
 
-- **Skip** any finding whose `(filePath, startLine)` already has a thread — it was posted on a prior run. Log `already posted: <file> L<line>` and continue.
+**Bitbucket Cloud:**
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments?pagelen=100"
+```
+
+Build a set of `(inline.path, inline.to)` from existing inline comments. Check for `**[AI Review]` in any top-level `content.raw` for the summary guard.
+
+**Bitbucket DC:**
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments?limit=100"
+```
+
+Build a set of `(anchor.path, anchor.line)` from existing inline comments. Check for `**[AI Review]` in any `text` for the summary guard.
+
+**Skip rules (all platforms):**
+- **Skip** any finding whose `(filePath, line)` already has a matching comment — it was posted on a prior run. Log `already posted: <file> L<line>` and continue.
 - **Skip** the summary thread (step 5) if an `**[AI Review]` summary already exists.
-- If **every** finding and the summary are already posted, post nothing and go straight to the vote (step 6). This is the crash-before-vote recovery path — it makes the whole procedure safe to re-run.
+- If **every** finding and the summary are already posted, post nothing and go straight to the vote (step 6). This is the crash-before-vote recovery path.
 
 For each issue in the findings (that survived the idempotency skip above):
 
 ### Without patch (no patch file, or issue not fixable)
+
+**ADO:**
 
 ```
 mcp__ado__repo_create_pull_request_thread
@@ -76,17 +121,46 @@ mcp__ado__repo_create_pull_request_thread
   status: "active"
 ```
 
-**Inline positioning rules:**
-- `filePath` must start with `/` and be relative to repo root (e.g., `/ui.frontend/src/brand/components/hero/brand-hero.js`)
-- Parse line numbers from the findings table `Line(s)` column: `L42-L45` -> `rightFileStartLine: 42`, `rightFileEndLine: 45`
-- Single-line findings (e.g., `L42`): set both start and end to the same line
-- If line numbers are missing or the issue is file-level, omit `filePath` and all `rightFile*` params — this creates a PR-level comment instead of an inline one
-- Always set `rightFileStartOffset: 1` and `rightFileEndOffset: 1` (column precision not available)
+ADO inline positioning rules:
+- `filePath` must start with `/` and be relative to repo root
+- `L42-L45` → `rightFileStartLine: 42`, `rightFileEndLine: 45`. Single line: set both to the same value.
+- If line numbers are missing, omit `filePath` and all `rightFile*` params — creates a PR-level comment
+- Always set `rightFileStartOffset: 1` and `rightFileEndOffset: 1`
 - Right-side line numbers refer to the NEW version of the file (post-change)
+
+**Bitbucket Cloud:**
+
+```bash
+# With inline context
+BODY=$(jq -n --arg text "<comment>" --arg path "<file>" --argjson line <line> \
+  '{content: {raw: $text}, inline: {path: $path, to: $line}}')
+# File-level only (no line)
+BODY=$(jq -n --arg text "<comment>" '{content: {raw: $text}}')
+
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
+```
+
+Cloud path note: no leading slash — e.g., `src/components/hero.js` not `/src/components/hero.js`.
+
+**Bitbucket DC:**
+
+```bash
+# With inline context
+BODY=$(jq -n --arg text "<comment>" --arg path "<file>" --argjson line <line> \
+  '{text: $text, anchor: {line: $line, lineType: "ADDED", fileType: "TO", path: $path}}')
+# File-level only (no line)
+BODY=$(jq -n --arg text "<comment>" '{text: $text}')
+
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
+```
 
 ### With patch (patch file exists and issue is fixable)
 
-Format the comment with an embedded patch:
+Format the comment with an embedded patch (same format for all platforms):
 
 ```markdown
 <issue comment text>
@@ -103,19 +177,19 @@ To apply: `git apply` the patch from the summary comment, or copy this diff.
 ```
 
 > **CRITICAL — diff rendering in `<details>` blocks:**
-> 1. **Blank line after `</summary>` is mandatory** — without it, ADO won't process the code fence as markdown
-> 2. **NEVER HTML-encode diff content** — write raw `<p>`, `<span>`, `<div>`, NOT `&lt;p&gt;`, `&lt;span&gt;`, `&lt;div&gt;`. The code fence handles escaping for display. HTML-encoding creates double-encoding that shows literal `&lt;` text to the reader.
-> 3. **Always include the triple-backtick code fence** with `diff` language tag — without it, HTML tags in the diff get parsed as actual HTML
+> 1. **Blank line after `</summary>` is mandatory** — without it, the platform won't process the code fence as markdown
+> 2. **NEVER HTML-encode diff content** — write raw `<p>`, `<span>`, `<div>`, NOT `&lt;p&gt;`, `&lt;span&gt;`, `&lt;div&gt;`. The code fence handles escaping for display.
+> 3. **Always include the triple-backtick code fence** with `diff` language tag
 
-Post with the same `mcp__ado__repo_create_pull_request_thread` call.
+Post with the same platform-specific API call as above (substitute the formatted markdown for the plain text).
 
-If a thread fails to post: log the error and continue with remaining issues.
+If a comment fails to post: log the error and continue with remaining issues.
 
 ## 5. Post Summary Thread
 
-Post a general PR comment (no `filePath`) with the review summary:
+Post a general PR comment (no inline context) with the review summary. The comment format is the same for all platforms — only the API call differs.
 
-### Without patches
+### Comment text — without patches
 
 ```markdown
 **[AI Review] Verdict: <verdict>**
@@ -130,7 +204,7 @@ Reviewed <N> files — <M> issues found.
 | 2 | QUESTION | `file.js` | L10 | <short description> |
 ```
 
-### With patches
+### Comment text — with patches
 
 ```markdown
 **[AI Review] Verdict: <verdict> — with proposed fixes**
@@ -158,28 +232,51 @@ git apply pr-fixes.patch
 </details>
 ```
 
-## 6. Set Vote
+### Post via platform API
 
-Determine vote from the verdict in the findings:
-
-| Verdict | Interactive `vote` | ADO int | Automation `vote` (clamped — never positive on a blocking issue, never hard-blocking) |
-|---------|-------------|---------|---------|
-| `approved` | `Approved` | 10 | `Approved` (+10) |
-| `approved-with-suggestions` | `ApprovedWithSuggestions` | 5 | `ApprovedWithSuggestions` (+5) |
-| `changes-requested` | `WaitingForAuthor` | -5 | **`NoVote` (0)** |
-| `rejected` *(explicit block)* | `Rejected` | -10 | **`NoVote` (0)** |
-| *(clear existing vote)* | `NoVote` | 0 | `NoVote` (0) |
-
-Cast the vote via MCP (the tool auto-adds the caller as a reviewer if not already one):
+**ADO** (no `filePath` = PR-level comment):
 
 ```
-mcp__ado__repo_vote_pull_request
+mcp__ado__repo_create_pull_request_thread
   repositoryId: "<repo ID>"
   pullRequestId: <PR ID>
-  vote: "<Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote>"
+  content: "<summary markdown>"
+  status: "active"
 ```
 
-Detect automation the same way the main skill does (do NOT rely on prompt keywords):
+**Bitbucket Cloud** (no `inline` block = PR-level comment):
+
+```bash
+BODY=$(jq -n --arg text "<summary markdown>" '{content: {raw: $text}}')
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/comments"
+```
+
+**Bitbucket DC** (no `anchor` block = PR-level comment):
+
+```bash
+BODY=$(jq -n --arg text "<summary markdown>" '{text: $text}')
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "$BODY" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/comments"
+```
+
+## 6. Set Vote
+
+Determine vote from the verdict in the findings. The clamping rules apply to all platforms.
+
+### Vote mapping
+
+| Verdict | Interactive | Automation (clamped — never positive on MUST-FIX, never hard-blocking) |
+|---------|-------------|---------|
+| `approved` | Approve | Approve |
+| `approved-with-suggestions` | Approve with suggestions | Approve with suggestions |
+| `changes-requested` | Request changes | **No vote (0)** — do not hard-block |
+| `rejected` | Reject | **No vote (0)** — do not hard-block |
+| *(clear vote)* | No vote | No vote |
+
+Detect automation before voting:
 
 ```bash
 AUTOMATION=0
@@ -191,16 +288,58 @@ if [ -f "$FLAG" ]; then
 fi
 ```
 
-**When `AUTOMATION=1`** (pipeline / orchestrated): cast the vote automatically from the verdict, **clamped at both ends**. An autonomous agent must neither hard-block a human's PR nor *approve* one it found a blocking bug in:
+**When `AUTOMATION=1`**: cast vote automatically, clamped at both ends. Positive votes only when no MUST-FIX exists; `changes-requested`/`rejected` → `NoVote` on all platforms. The summary thread must state plainly the bot is NOT approving when clamped. Never call `AskUserQuestion`.
 
-- `approved` → `Approved` (+10), `approved-with-suggestions` → `ApprovedWithSuggestions` (+5) — positive votes are fine **only when there is no MUST-FIX**.
-- `changes-requested` / `rejected` → **`NoVote` (0)**. Never `WaitingForAuthor`/`Rejected` (don't hard-block), but also never a positive `ApprovedWithSuggestions`/`Approved` — a positive vote counts toward branch-policy minimum-approvals and auto-complete, so approving a PR with a known MUST-FIX would actively help merge the bug. `NoVote` leaves the decision entirely to a human: the bot has stated its concern and explicitly declined to approve.
+**When `AUTOMATION=0`**: use `AskUserQuestion` to confirm the vote, then call the platform API.
 
-The findings carry the signal; a human casts any approving **or** blocking vote.
+### ADO
 
-When you clamp a `changes-requested`/`rejected` verdict to `NoVote`, the **summary thread (step 5) MUST state plainly that the bot is NOT approving because of a blocking-level (MUST-FIX) concern, and a human must review before merge** — keep the `MUST-FIX` severity labels on the individual issue comments intact. Do NOT write "neither blocks merge" or any phrasing that softens the MUST-FIX; sharpen it ("not approving — blocking concern flagged for a human"). You MUST NOT call `AskUserQuestion`.
+```
+mcp__ado__repo_vote_pull_request
+  repositoryId: "<repo ID>"
+  pullRequestId: <PR ID>
+  vote: "<Approved | ApprovedWithSuggestions | WaitingForAuthor | Rejected | NoVote>"
+```
 
-**When `AUTOMATION=0`** (user invoked directly): use `AskUserQuestion` to confirm the vote, map the choice to the enum, then call `repo_vote_pull_request`.
+The tool auto-adds the caller as a reviewer if not already one.
+
+### Bitbucket Cloud
+
+```bash
+# Approve (covers both Approved and ApprovedWithSuggestions)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/approve"
+
+# Request changes
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/request-changes"
+
+# Remove/clear approval (NoVote)
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://api.bitbucket.org/2.0/repositories/{workspace}/{repoSlug}/pullrequests/{id}/approve"
+```
+
+### Bitbucket DC
+
+```bash
+# Approve
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/approve"
+
+# Request changes (Needs Work) — resolve user slug first
+USER_SLUG=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BB_BASE/users?filter=$(git config user.email)" | jq -r '.values[0].slug')
+curl -s -X PUT \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"user\": {\"name\": \"$USER_SLUG\"}, \"approved\": false, \"status\": \"NEEDS_WORK\"}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/participants/$USER_SLUG"
+
+# NoVote / clear
+curl -s -X PUT \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d "{\"user\": {\"name\": \"$USER_SLUG\"}, \"approved\": false, \"status\": \"UNAPPROVED\"}" \
+  "$BB_BASE/projects/{project}/repos/{repoSlug}/pull-requests/{id}/participants/$USER_SLUG"
+```
 
 ## 7. Update Session
 
@@ -219,11 +358,13 @@ Threads: <list of thread IDs>
 
 ## Rules
 
-- **Read-only** — never modifies code, never pushes, only reads saved files and posts to ADO
+- **Read-only** — never modifies code, never pushes, only reads saved files and posts to the SCM platform
 - **Findings required** — always requires `.ai/pr-reviews/pr-<id>-findings.md` from a prior `/dx-pr-review` run
 - **Patches optional** — posts with patches if `.ai/pr-reviews/pr-<id>.patch` exists, plain comments otherwise
-- **Continue on failure** — if one thread fails to post, log and continue
+- **Continue on failure** — if one comment fails to post, log and continue
 - **Collapsible patches** — use `<details>` with mandatory blank line after `</summary>`, never HTML-encode diff content
-- **MCP tools are deferred** — always load via ToolSearch before first use
-- **URL project precedence** — if a PR URL was provided, use the project from the URL, not from config
+- **Platform detection required** — read `Platform:` from findings metadata before any API calls; default to `ado`
+- **MCP tools are deferred (ADO only)** — always load via ToolSearch before first ADO call; Bitbucket uses curl
+- **URL project precedence** — if a PR URL was provided, use the project/workspace from the URL, not from config
 - **Automation-safe** — no `AskUserQuestion` calls when running in pipeline context
+- **Vote clamping applies on all platforms** — `changes-requested`/`rejected` → no vote in automation mode, on ADO, Cloud, and DC alike

--- a/plugins/dx-core/templates/config.yaml.template
+++ b/plugins/dx-core/templates/config.yaml.template
@@ -11,11 +11,17 @@ project:
   role: "{{PROJECT_ROLE}}"              # frontend | backend | fullstack | config
 
 scm:
-  provider: ado                           # ado | github
-  org: "{{SCM_ORG}}"                      # e.g., https://myorg.visualstudio.com/
-  project: "{{SCM_PROJECT}}"              # ADO project name
-  repo-id: "{{SCM_REPO_ID}}"             # Auto-discovered, or set manually
+  provider: ado                           # ado | github | bitbucket-cloud | bitbucket-dc
+  org: "{{SCM_ORG}}"                      # ADO/GitHub org URL or Bitbucket workspace/project key
+  project: "{{SCM_PROJECT}}"              # ADO project name (not used for Bitbucket)
+  repo-id: "{{SCM_REPO_ID}}"             # Auto-discovered, or set manually (ADO/GitHub only)
   base-branch: "{{BASE_BRANCH}}"         # e.g., develop, development, main
+
+# Bitbucket Cloud / DC (when scm.provider is bitbucket-cloud or bitbucket-dc)
+# bitbucket-dc only: host URL of your Bitbucket Data Center instance
+# bitbucket-host: "https://bitbucket.example.com"
+# Token: prefer the BITBUCKET_TOKEN env var over storing here
+# bitbucket-token: ""
 
 # Work item tracker (defaults to scm.provider if not set)
 # tracker:
@@ -80,6 +86,8 @@ preferences:
 #     role: backend                    # backend | frontend | fullstack | config
 #     platform: alpha                  # opaque, project-defined platform identifier, e.g. alpha | beta (AEM only, added by /aem-init)
 #     ado-project: "My Project"        # ADO project (if different from scm.project)
+#     bitbucket-workspace: "myteam"    # Bitbucket Cloud: workspace slug (if different from scm.org)
+#     bitbucket-project: "MYPROJ"      # Bitbucket DC: project key (if different from scm.org)
 #     base-branch: develop             # Default branch (defaults to scm.base-branch)
 
 # Optional — override plugin default prompts


### PR DESCRIPTION
# PR Description

## What does this PR do?

Extends `dx-pr-review`, `dx-pr-answer`, and `dx-init` to support Bitbucket Cloud and Bitbucket Data Center alongside the existing Azure DevOps path. Adds platform detection, per-platform API branching, a shared Bitbucket REST reference, and auto-detection of Bitbucket remotes in `detect-env.sh`.

## Why?

`dx-pr-review` and `dx-pr-answer` were hardwired to Azure DevOps — every API call used `mcp__ado__*` tools. Teams on Bitbucket Cloud or Bitbucket DC got an immediate failure with no fallback. Since AEM projects frequently live on Bitbucket, this blocked a large share of users from the core PR workflow entirely.

## What changed

**Platform detection added to steps 1, 2, 3, 8, 9 of `dx-pr-review` and steps 1–3, 5, 7 of `dx-pr-answer`.**  
Each step that previously made an unconditional ADO MCP call now detects `PLATFORM` from the URL or `scm.provider` config and branches: ADO keeps its existing MCP path unchanged; Bitbucket uses `curl` with a bearer token (`BITBUCKET_TOKEN` env → `scm.bitbucket-token` config).

**Key API differences handled:**
- Bitbucket has no thread objects — comments are flat, grouped by `parent.id`
- Inline comments: Cloud uses `inline.path`/`to`; DC uses `anchor.line`/`lineType`/`fileType`/`path`
- Votes: Cloud = `POST /approve` or `POST /request-changes`; DC = `POST /approve` or `PUT /participants/{slug}` with `status: NEEDS_WORK`
- Identity for skip-own-PR: ADO/DC expose email; Cloud exposes `author.nickname` only

## Type of Change

- [ ] Bug fix (patch)
- [x] New skill/agent (minor)
- [x] Enhancement to existing skill/agent (minor)
- [ ] Breaking change (major)
- [ ] Documentation only

## Checklist

- [x] No hardcoded org URLs, project names, paths, or branch names
- [x] New config fields documented in `docs/reference/config-reference.md`
- [ ] Skill/agent catalogs updated if applicable
- [x] Shell scripts are `chmod +x`
- [ ] Version bumped in all 4 version files (if non-trivial change)
- [ ] Tested manually by running the skill in a test project

## Files Changed

| File | Change |
|------|--------|
| `shared/bitbucket-config.md` | New — full Bitbucket REST API reference (endpoints, request bodies, vote mapping, idempotency) |
| `skills/dx-pr-review/SKILL.md` | Platform detection + branching in steps 1–3, 8–9, follow-up mode |
| `skills/dx-pr-review/references/post-findings.md` | Multi-platform posting and vote procedure |
| `skills/dx-pr-answer/SKILL.md` | Platform detection + branching in steps 1–3, 5, 7 |
| `skills/dx-pr-answer/references/apply-fixes.md` | Bitbucket reply-after-fix sections added |
| `shared/provider-config.md` | Bitbucket added to valid provider list |
| `templates/config.yaml.template` | Bitbucket provider options and `repos[]` workspace/project fields |
| `skills/dx-init/scripts/detect-env.sh` | Auto-detects Bitbucket Cloud/DC from git remote; extracts workspace, project, host, repo slug |
| `skills/dx-init/SKILL.md` | Config generation for Bitbucket projects; fixed `scm.provider` vs `tracker.provider` conflation bug |
| `docs/reference/config-reference.md` | Bitbucket fields documented |
| `docs/bitbucket-pr-review-support.md` | Implementation notes and known gaps |

## Known Gaps

| Gap | Notes |
|-----|-------|
| `discover-review-queue.sh` is ADO-only | Autonomous PR-review queue won't discover Bitbucket PRs — needs a separate script |
| `dx-doctor` doesn't validate Bitbucket config | Missing `bitbucket-host` or `BITBUCKET_TOKEN` won't be caught |
| Bitbucket Cloud own-PR detection | Requires `BITBUCKET_USERNAME` / `scm.bitbucket-username` — Cloud doesn't expose author email |
| `dx-pr` / `dx-pr-commit` PR creation | ADO-only, out of scope |

## Environment Tested

| Field | Value |
|-------|-------|
| Platform | Claude Code |
| Model | |
| OS | |