### PR TITLE
docs: replace stale /dx-req-all references with valid skill names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ paths: ["**/*.ts"]     # optional — limit auto-activation to file patterns
 
 - Skills go in `plugins/{dx-core,dx-hub,dx-aem,dx-automation}/skills/<name>/SKILL.md`
 - Helper scripts go in `skills/<name>/scripts/*.sh`
-- Naming: kebab-case, plugin prefix required. Format: `{plugin}-{name}` (e.g., `dx-req-all`, `aem-init`). Group prefixes within dx: `dx-req-*`, `dx-plan-*`, `dx-step-*`, `dx-pr-*`, `dx-bug-*`, `dx-agent-*`. Coordinators use `-all` suffix.
+- Naming: kebab-case, plugin prefix required. Format: `{plugin}-{name}` (e.g., `dx-agent-all`, `aem-init`). Group prefixes within dx: `dx-req-*`, `dx-plan-*`, `dx-step-*`, `dx-pr-*`, `dx-bug-*`, `dx-agent-*`. Coordinators use `-all` suffix.
 
 ### Flow Control (branching skills only)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Enterprise AI development platform for teams shipping on Azure DevOps and Atlass
 
 Enterprise teams run complex sprints across multiple repos, multiple IDEs, and multiple team members. They need a system that handles the full lifecycle — requirements analysis, implementation planning, code generation, testing, verification, documentation, and PR creation — with governance at every step. Without re-explaining the project every session.
 
-KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines across every major AI platform. A single command like `/dx-req-all` pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
+KAI is a structured development workflow built as a plugin system for enterprise teams. It encodes your entire sprint lifecycle — requirements, planning, execution, review, PR — into **skills** that orchestrate multi-agent pipelines across every major AI platform. A single command like `/dx-req` pulls the ticket from Azure DevOps or Jira, validates readiness against your DoR, distills developer requirements, researches the codebase with parallel subagents, and generates a team summary. Each skill chains specialized agents (Opus for deep review, Sonnet for execution, Haiku for lookups), gathers context from multiple sources (tickets, config, codebase, Figma designs, live AEM content), and writes structured output that the next skill picks up automatically.
 
 **What makes it different:**
 - **Every AI platform** — same 75+ skills work identically in Claude Code, GitHub Copilot CLI, and VS Code Chat. Same plugins, same config, same results — regardless of which IDE your team uses.
@@ -88,7 +88,7 @@ Three ways to initialize — all produce the same project structure:
 /dx-init
 
 # 3. Work on a story
-/dx-req-all 2416553        # Fetch story, distill requirements, research codebase
+/dx-req 2416553             # Fetch story, distill requirements, research codebase
 /dx-plan                    # Generate implementation plan
 /dx-step-all                # Execute all steps autonomously
 /dx-step-build              # Build & deploy

--- a/docs/todo/todo-hermes-agent-research.md
+++ b/docs/todo/todo-hermes-agent-research.md
@@ -212,7 +212,7 @@ Project memory already exists across `.ai/config.yaml`, `.ai/rules/*.md`, `.ai/p
 
 **What Hermes does**: Turn-based nudge counter + post-task skill creation prompt.
 
-**What to add**: Prompt additions to coordinator skills (`dx-step-all`, `dx-bug-all`, `dx-req-all`):
+**What to add**: Prompt additions to coordinator skills (`dx-step-all`, `dx-bug-all`, `dx-agent-all`):
 
 ```markdown
 ## Post-Completion Reflection

--- a/docs/todo/todo-provider-support.md
+++ b/docs/todo/todo-provider-support.md
@@ -48,7 +48,7 @@
 **Problem:** dx-req currently requires an ADO or Jira ticket ID as input. But ADO/Jira are just the *fetch* step — once requirements are in `explain.md`, the entire downstream flow (dx-plan → dx-step → dx-pr) is already source-agnostic. A markdown file with requirements should be a first-class alternative input, enabling the full dev workflow for any project regardless of tracker.
 **Scope:**
 - `plugins/dx-core/skills/dx-req/SKILL.md` — currently reads from ADO/Jira MCP tools
-- `plugins/dx-core/skills/dx-req-all/SKILL.md` — coordinator that chains dx-req → dx-plan
+- `plugins/dx-core/skills/dx-agent-all/SKILL.md` — coordinator that chains dx-req → dx-plan
 - `plugins/dx-core/data/lib/dx-common.sh` — `find_spec_dir` uses ticket ID for directory naming
 - `plugins/dx-core/data/templates/spec/` — templates reference `<id>` from ticket
 **Done-when:** Running `/dx-req path/to/requirements.md` reads the markdown file, creates a spec directory (`.ai/specs/<slug>/`), and produces `explain.md`. Then `/dx-plan`, `/dx-step 1`, `/dx-pr` all work without modification. Full flow, no tracker needed.


### PR DESCRIPTION
## Bug

`/dx-req-all` is a leftover reference throughout the docs, but **no `dx-req-all` skill exists** — it was consolidated into `dx-req`. Reported expectation: only `/dx-req` should occur in documentation.

## Fix

Repointed the **5 live references** to valid skill names; left the 2 `CHANGELOG.md` entries untouched (they're historical records of the original rename commits).

| File | Was | Now |
|------|-----|-----|
| `README.md` (intro) | "A single command like `/dx-req-all`" | `/dx-req` |
| `README.md` (quick-start) | `/dx-req-all 2416553` | `/dx-req 2416553` |
| `CLAUDE.md:220` | naming example `dx-req-all` | `dx-agent-all` |
| `docs/todo/todo-hermes-agent-research.md` | coordinator list `dx-req-all` | `dx-agent-all` |
| `docs/todo/todo-provider-support.md` | path `skills/dx-req-all/SKILL.md` | `skills/dx-agent-all/SKILL.md` |

Where a real `-all` coordinator example was needed (CLAUDE.md naming convention + 2 TODO coordinator refs), I used `dx-agent-all` — the actual end-to-end coordinator — rather than `dx-req`, which isn't a `-all` coordinator. This keeps each reference both valid and contextually correct.

## Verification

```
$ grep -rn "dx-req-all" --include="*.md" ... .
CHANGELOG.md:732: ... deprecated /dx-req-all ...   # historical — intentional
CHANGELOG.md:739: ... /dx-req-all → /dx-req ...    # historical — intentional
```

No remaining live references. Docs-only change (`docs:` prefix → no version bump).