### PR TITLE
fix(dx-pr-review): URL-encode project/repo in queue discovery REST call

### DIFF
--- a/plugins/dx-core/skills/dx-pr-review/scripts/discover-review-queue.sh
+++ b/plugins/dx-core/skills/dx-pr-review/scripts/discover-review-queue.sh
@@ -24,6 +24,11 @@ PROJECT="${2:?project required}"
 REPO="${3:?repo required}"
 ORG_URL="${ORG_URL%/}"
 
+# URL-encode the project + repo path segments (project names often contain
+# spaces, e.g. "My Team Project") so the REST URL is well-formed.
+PROJECT_ENC=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+REPO_ENC=$(printf '%s' "$REPO" | jq -sRr @uri)
+
 : "${ADO_PAT:?ADO_PAT env required}"
 : "${REVIEWER_IDENTITIES:?REVIEWER_IDENTITIES env required}"
 REVIEW_OWN="0"
@@ -36,7 +41,7 @@ echo "Reviewer identities: $IDS_JSON (review_own=$REVIEW_OWN)" >&2
 
 # List Active PRs in the repo. $top=200 is well beyond any real reviewer queue;
 # if a repo ever exceeds it, paginate with $skip (documented limitation).
-API="${ORG_URL}/${PROJECT}/_apis/git/repositories/${REPO}/pullrequests?searchCriteria.status=active&\$top=200&api-version=7.1"
+API="${ORG_URL}/${PROJECT_ENC}/_apis/git/repositories/${REPO_ENC}/pullrequests?searchCriteria.status=active&\$top=200&api-version=7.1"
 RESP=$(curl -fsS -u ":${ADO_PAT}" -H "Accept: application/json" "$API") || {
   echo "ERROR: failed to list PRs for ${PROJECT}/${REPO}" >&2
   exit 1
@@ -57,8 +62,7 @@ jq -r --argjson ids "$IDS_JSON" --arg own "$REVIEW_OWN" '
   | .pullRequestId
 ' <<<"$RESP" | while read -r PRID; do
   [ -n "$PRID" ] || continue
-  # URL-encode the project path segment (it may contain spaces); /dx-pr-review
-  # URL-decodes it back when it parses the PR URL.
-  PROJECT_ENC=$(printf '%s' "$PROJECT" | jq -sRr @uri)
+  # Emit the web PR URL with the encoded project segment (it may contain
+  # spaces); /dx-pr-review URL-decodes it back when it parses the PR URL.
   echo "${ORG_URL}/${PROJECT_ENC}/_git/${REPO}/pullrequest/${PRID}"
 done


### PR DESCRIPTION
## Problem
The autonomous reviewer-queue sweep (`ado-cli-pr-review.yml` → `discover-review-queue.sh`) built the ADO PR-list REST URL with the **raw project name**. For projects whose name contains spaces this produced a malformed URL and curl failed:

```
curl: (3) URL rejected: Malformed input to a URL function
ERROR: failed to list PRs for <project>/<repo>
```

…failing the **Build review queue** step.

## Fix
- URL-encode the **project** and **repo** path segments with `jq @uri` before building the API URL.
- Reuse the encoded project for the emitted PR web URLs (removes the now-redundant inline re-encode in the loop).

## Test
`bash -n` passes; `jq -sRr @uri` confirmed to encode spaces and leave hyphen/dot repo names untouched.