### PR TITLE
fix(playwright): resolve QA Basic Auth credentials before browser_navigate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## This Repo's SCM
+
+**This repo is on GitHub** (`github.com/easingthemes/dx-aem-flow`), not Azure DevOps. For any git operation on this repo (branches, PRs, commits, checks), use `git` and `gh` CLI — **never** ADO MCP tools (`mcp__ado__repo_*`, `mcp__ado__pipelines_*`). The plugin *contents* describe ADO workflows for consumer projects; the repo itself is GitHub.
+
 ## What This Is
 
 Four Claude Code plugins for AI-assisted Azure DevOps development workflows. There is no build system — plugins are pure Markdown (skills, agents, rules, templates) with shell helper scripts.

--- a/plugins/dx-aem/skills/aem-qa/SKILL.md
+++ b/plugins/dx-aem/skills/aem-qa/SKILL.md
@@ -271,12 +271,18 @@ Check the verification plan from "Determine verification environment". If Publis
 
 ### Verify on publisher (Playwright)
 
+**QA Basic Auth (first navigation only):** follow the `qa-basic-auth` rule. Resolve credentials in priority order:
+1. Env vars: `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS`
+2. `.ai/config.yaml` keys `aem.qa-basic-auth.username` / `aem.qa-basic-auth.password`
+
+If credentials found and publish-url is non-localhost, embed in the URL for the first navigation — session cookie persists for subsequent navigations. If not found on a non-localhost URL, warn and skip publisher verification.
+
 For each page to verify on publisher:
 
 **Navigate to Page (Publisher)** — no `wcmmode` param needed, publisher IS the production rendering:
 ```
 mcp__plugin_dx-aem_playwright__browser_navigate
-  url: "<publish-url>/content/<path>.html"
+  url: "<publish-url-with-creds-for-first-nav>/content/<path>.html"
 ```
 
 Wait for page load:

--- a/plugins/dx-core/skills/dx-axe/SKILL.md
+++ b/plugins/dx-core/skills/dx-axe/SKILL.md
@@ -55,21 +55,17 @@ http://admin:admin@host.docker.internal:4502/content/...?wcmmode=disabled
 
 ### Remote AEM (QA / Stage)
 
-Read `.ai/config.yaml` for `aem.qa-basic-auth`. If the URL matches a QA/Stage host (`aem.author-url-qa`, `aem.publish-url-qa`) and has no credentials, embed them:
+Follow the `qa-basic-auth` rule. Resolve credentials in priority order:
+1. Env vars: `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS`
+2. `.ai/config.yaml` keys `aem.qa-basic-auth.username` / `aem.qa-basic-auth.password`
 
-```yaml
-# .ai/config.yaml
-aem:
-  qa-basic-auth:
-    username: "<user>"
-    password: "<pass>"
-```
+If credentials are found, embed them in the URL for the **first** navigation only — the session cookie persists for subsequent navigations:
 
 ```
 https://<user>:<pass>@qa.example.com/content/...
 ```
 
-If `qa-basic-auth` is not configured and the URL looks like a QA/Stage host, warn the user that auth may be needed.
+If no credentials are found and the URL is a non-localhost QA/Stage host, warn the user that `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS` env vars are not set and auth will likely fail.
 
 ### Public URLs
 

--- a/plugins/dx-core/skills/dx-simple/SKILL.md
+++ b/plugins/dx-core/skills/dx-simple/SKILL.md
@@ -470,7 +470,12 @@ re-applies the work-plan as part of its normal flow.
 
 3. Semantic validation (Safeguard #1):
    - Read `simple-block.yaml`; extract `page-url`, `element`, `what`.
-   - Navigate Chrome to `page-url`:
+   - **QA Basic Auth (first navigation only):** follow the `qa-basic-auth` rule. Resolve credentials in priority order:
+     1. Env vars: `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS`
+     2. `.ai/config.yaml` keys `aem.qa-basic-auth.username` / `aem.qa-basic-auth.password`
+     If credentials are found AND `page-url` is not a localhost URL, embed them in the URL for this navigation: `https://<user>:<pass>@<host>/path`. Subsequent navigations (Phase 5) use the clean URL — the session cookie persists. Never log or echo the URL with embedded credentials.
+     If no credentials are found and the URL is non-localhost: post ADO comment explaining that `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS` env vars are not set (see `qa-basic-auth` rule) and exit non-zero.
+   - Navigate Chrome to the page URL (credential-embedded for first QA visit):
      ```
      mcp__plugin_dx-aem_playwright__browser_navigate with url=<page-url>
      ```
@@ -950,7 +955,7 @@ fixes).
 
 | class | examples | recovery |
 |-------|----------|----------|
-| `needs-user-input` | G1 ambiguous/no match, missing `page-url`, G3 low classification, authoring value drifted, `ambiguous-branch` (M1) | human replies `@<keyword> <answer>` → resume at blocked phase |
+| `needs-user-input` | G1 ambiguous/no match, missing `page-url`, missing QA Basic Auth credentials, G3 low classification, authoring value drifted, `ambiguous-branch` (M1) | human replies `@<keyword> <answer>` → resume at blocked phase |
 | `transient` | MAX_TURNS / step timeout / MCP unreachable / network blip — **infra only** | re-trigger (any `@<keyword>` reply, or re-run) → resume forward from `last-completed-phase` (replaying code edits if past 3b) |
 | `hard` | scope-check exceeded (>5 files / >50 lines / >10 writes), G7 real review blocker, **any compile failure surviving Phase 4's in-run 3× retry (M3)**, `answer-attempts` cap reached | not recoverable here → recommend re-tag `KAI-DEV-AUTOMATION` (DevAgent) |
 | `wrong-target` | Phase 0.5 repo identity guard aborted — ticket's platform/brand/scope does not match this repo's identity | terminal — not recoverable here → human must re-trigger in the correct repo |
@@ -1004,7 +1009,7 @@ as `@<keyword>` (placeholder) so the example line cannot self-trigger the hook.
 
 ## Troubleshooting
 
-- **"Component not found on page"** — Locator did not match anything in Chrome snapshot. Check `page-url` (loads on QA author?), `element` (matches visible element?), QA content sync (component exists on QA?).
+- **"Component not found on page"** — Locator did not match anything in Chrome snapshot. Check `page-url` (loads on QA?), `element` (matches visible element?), QA content sync (component exists on QA?). If the QA site requires HTTP Basic Auth, ensure `QA_BASIC_AUTH_USER` / `QA_BASIC_AUTH_PASS` env vars are set (see `qa-basic-auth` rule) — the skill embeds them in the first navigation URL automatically.
 
 - **"Ambiguous locator"** — Multiple DOM matches. Use `jcr-path=...` form for unambiguous targeting, or describe the element more specifically (e.g. add the surrounding section name).
 


### PR DESCRIPTION
## Summary

- **dx-simple**: add QA Basic Auth credential resolution (env vars first, config fallback) before the G1 locator navigate; remove the incorrect AEM MCP fallback that was added — AEM MCP is a CLI with no browser and accesses AEM Author, not the QA publisher
- **dx-axe**: fix credential resolution priority order — was checking config only, now checks `QA_BASIC_AUTH_USER`/`QA_BASIC_AUTH_PASS` env vars first
- **aem-qa**: add missing Basic Auth block before publisher `browser_navigate` — had no auth handling at all

## Root cause

Skills navigating to QA publisher URLs were failing with `ERR_INVALID_AUTH_CREDENTIALS` because Playwright received no credentials. The existing `qa-basic-auth` rule already defines the correct pattern (URL-embedded credentials for first navigation, clean URL after — session cookie persists), but it wasn't being applied consistently.

## Test plan

- [ ] Re-trigger a dx-simple pipeline run against a ticket with a QA publisher URL — G1 should pass without asking for credentials, provided `QA_BASIC_AUTH_USER`/`QA_BASIC_AUTH_PASS` are set in pipeline env vars
- [ ] Run `/dx-axe` against a QA URL — should embed credentials automatically
- [ ] Run `/aem-qa` with publisher verification enabled — first navigate should embed credentials