### PR TITLE
docs(todo): add #162 no-op skill audit

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -200,7 +200,9 @@
 | 160 | Add circuit breaker + observability layer to local harness | Medium | Open | 2026-06-15 | [todo-harness-design.md#11-circuit-breaker-pattern](todo-harness-design.md#11-circuit-breaker-pattern) — (1) Loop-detection `PostToolUse` hook: same tool + args + file within 5 turns → exit 2 + ABORT comment. (2) `Stop` async hook appending JSON line to `.ai/telemetry.jsonl` (ts, skill, ticket, turns, outcome). `dx-doctor --config-validate` reads and reports failure rates. Phase 1 is low effort. |
 | 161 | `dx-doctor` config schema validation gate | Medium | Open | 2026-06-15 | [todo-harness-design.md#13-config-schema-validation](todo-harness-design.md#13-config-schema-validation) — Silent misconfiguration (e.g. `aem.author_url` vs `aem.author-url`) causes skills to fall back to localhost silently. `dx-doctor --config-validate` checks required fields, deprecated names, AEM section completeness. Optional `SessionStart` hook for always-on pre-flight. |
 
-**Counts:** 161 total — 34 done (+6 from main: #34 #97 #98 #104 #105 #133), 102 open, 5 blocked, 10 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing, 1 re-test, 1 mitigated
+| 162 | No-op skill audit — remove filler instructions that don't change agent behavior | Low | Open | 2026-06-26 | [todo-skill-conventions.md#13-no-op-audit](todo-skill-conventions.md#13-no-op-audit--remove-filler-instructions-that-dont-change-agent-behavior) |
+
+**Counts:** 162 total — 34 done (+6 from main: #34 #97 #98 #104 #105 #133), 103 open, 5 blocked, 10 watch, 0 deferred, 1 decision needed, 1 pending, 1 ongoing, 1 re-test, 1 mitigated
 
 Last platform state research: [2026-05-29-platform-state-update.md](../research/2026-05-29-platform-state-update.md) (delta to [2026-05-01-platform-state-update.md](../research/2026-05-01-platform-state-update.md))
 

--- a/docs/todo/todo-skill-conventions.md
+++ b/docs/todo/todo-skill-conventions.md
@@ -263,6 +263,27 @@ linking to canonical upstream docs.
 **Approach:** Bundle with whichever larger refactor next touches each
 skill. Don't do as its own pass.
 
+## 13. No-op audit — remove filler instructions that don't change agent behavior
+
+**Added:** 2026-06-26
+**Problem:** Skills can accumulate "no-op" lines — instructions that sound meaningful but don't actually change what the agent does, because the agent would do it anyway. Examples: "be thorough", "think carefully", "write clear commit messages", "make the output easy to read". These burn tokens on every skill invocation, make skills harder to audit, and dilute the signal of the instructions that actually matter. This codebase has very few (1–2 confirmed vs. the ~77 SKILL.md files), but they should be removed, and a convention should prevent new ones from creeping in via AI-assisted skill authoring.
+**Scope:**
+- `plugins/dx-core/skills/dx-figma-extract/SKILL.md:275` — "be thorough" (the rationale "only Figma interaction" is fine; the "be thorough" phrase is not)
+- `plugins/dx-core/skills/dx-figma-prototype/SKILL.md:152` — explanatory sentence ("This ensures the prototype is grounded in the actual component library...") adds rationale but no behavioral constraint
+- `CLAUDE.md` Conventions checklist — add a no-op rule
+**Done-when:**
+```bash
+# Confirmed no-ops removed:
+grep -n "be thorough" plugins/dx-core/skills/dx-figma-extract/SKILL.md  # returns empty
+grep -n "grounded in the actual component library" plugins/dx-core/skills/dx-figma-prototype/SKILL.md  # returns empty
+# No-op rule present in checklist:
+grep -n "no-op" CLAUDE.md  # returns a line in the Checklist section
+```
+**Approach:** Three steps, in order:
+1. **Remove the 2 confirmed no-ops** — targeted Edit on each file. Test: re-read the surrounding context and confirm the removal doesn't drop a behavioral constraint (the "be thorough" removal keeps the "only Figma interaction" rationale; the prototype sentence removal is safe because the preceding steps already instruct the agent to use the component library).
+2. **Add to CLAUDE.md checklist** — one bullet: *"No no-ops — every instruction must change agent behavior. No 'be thorough', 'think carefully', 'write clear X'. Test: remove the line; if output doesn't change, the line was a no-op."*
+3. **Broader section-level audit** (deferred, pair with #9 concise-body audit) — scan the 10 longest SKILL.md files for entire paragraphs that describe *what* the skill does rather than constraining *how*. These are subtler no-ops: rationale prose that makes the skill feel complete but doesn't alter execution.
+
 ---
 
 ## Dropped after reality check against Claude Code docs

--- a/docs/todo/todo-skill-conventions.md
+++ b/docs/todo/todo-skill-conventions.md
@@ -266,6 +266,7 @@ skill. Don't do as its own pass.
 ## 13. No-op audit — remove filler instructions that don't change agent behavior
 
 **Added:** 2026-06-26
+**Source:** https://x.com/mattpocockuk/status/2069784839474032896?s=46
 **Problem:** Skills can accumulate "no-op" lines — instructions that sound meaningful but don't actually change what the agent does, because the agent would do it anyway. Examples: "be thorough", "think carefully", "write clear commit messages", "make the output easy to read". These burn tokens on every skill invocation, make skills harder to audit, and dilute the signal of the instructions that actually matter. This codebase has very few (1–2 confirmed vs. the ~77 SKILL.md files), but they should be removed, and a convention should prevent new ones from creeping in via AI-assisted skill authoring.
 **Scope:**
 - `plugins/dx-core/skills/dx-figma-extract/SKILL.md:275` — "be thorough" (the rationale "only Figma interaction" is fine; the "be thorough" phrase is not)


### PR DESCRIPTION
## Summary

- Evaluated the claim that agent-authored skills are "littered with no-ops" against this codebase
- Finding: **very low severity** — only 1–2 confirmed no-ops across 77 SKILL.md files; the codebase is already disciplined (DOT digraphs, `ultrathink`, exact bash commands, anti-rationalization tables)
- Added TODO #162 to track the cleanup and prevent future no-ops via a CLAUDE.md checklist rule

## What's tracked (TODO #162)

**Confirmed no-ops to remove (quick wins):**
- `dx-figma-extract/SKILL.md:275` — "be thorough" phrase
- `dx-figma-prototype/SKILL.md:152` — explanatory sentence that adds rationale but no behavioral constraint

**Convention to add:**
- One bullet in the CLAUDE.md skill authoring checklist: test whether removing a line changes output; if not, it's a no-op

**Deferred:**
- Section-level filler audit on the 10 longest skills (pair with #9 concise-body audit)

## Test plan

- [ ] `grep -n "be thorough" plugins/dx-core/skills/dx-figma-extract/SKILL.md` returns empty (after fix)
- [ ] `grep -n "no-op" CLAUDE.md` returns a checklist line (after fix)
- [ ] No behavioral changes to any skill — this PR is docs-only

https://claude.ai/code/session_01V56U6YWJWCau586KQfVdgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V56U6YWJWCau586KQfVdgE)_