### PR TITLE
Refactor hooks.json and branch-guard.sh

### DIFF
--- a/plugins/dx-core/hooks/hooks.json
+++ b/plugins/dx-core/hooks/hooks.json
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'BRANCH=$(git branch --show-current 2>/dev/null); if [ \"$BRANCH\" = \"main\" ] || [ \"$BRANCH\" = \"master\" ] || [ \"$BRANCH\" = \"development\" ] || [ \"$BRANCH\" = \"develop\" ]; then echo \"BLOCKED: Do not commit on $BRANCH. Create a feature/* or bugfix/* branch first.\" >&2; exit 2; fi'",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-guard.sh\"",
             "statusMessage": "Checking branch protection..."
           }
         ]

--- a/plugins/dx-core/hooks/scripts/branch-guard.sh
+++ b/plugins/dx-core/hooks/scripts/branch-guard.sh
@@ -1,25 +1,9 @@
 #!/usr/bin/env bash
-# branch-guard.sh — Deny commits on protected branches
-# Used by PreToolUse hook. Reads tool info from stdin (JSON).
-# Returns permissionDecision: deny if on a protected branch.
-
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-
-# Only check for commit commands
-case "$TOOL_NAME" in
-  Bash|execute|shell) ;;
-  *) exit 0 ;;
-esac
-
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-if ! echo "$COMMAND" | grep -q 'git commit'; then
-  exit 0
-fi
+# branch-guard.sh — Block commits on protected branches.
+# This script is called by PreToolUse matcher: Bash(git commit*).
 
 BRANCH=$(git branch --show-current 2>/dev/null)
-case "$BRANCH" in
-  main|master|development|develop)
-    echo "{\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"BLOCKED: Do not commit on $BRANCH. Create a feature/* or bugfix/* branch first.\"}"
-    ;;
-esac
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ] || [ "$BRANCH" = "development" ] || [ "$BRANCH" = "develop" ]; then
+  echo "BLOCKED: Do not commit on $BRANCH. Create a feature/* or bugfix/* branch first." >&2
+  exit 2
+fi


### PR DESCRIPTION
## What does this PR do?

Extract branch guard logic to branch-guard.sh

## Why?

The PreToolUse hook in hooks.json was enforcing branch protection via a inline bash -c '...' command. 

Dead code — hooks/scripts/branch-guard.sh already existed for this exact purpose but was never actually called.

## What changed

Rewrote branch-guard.sh to match the current inline behavior exactly: outputs a blocked message to stderr and exits with code 2 on protected branches (main, master, develop, development), exits 0 otherwise. No external dependencies (jq removed).

Updated hooks.json PreToolUse to call bash "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/branch-guard.sh" instead of the inline command.

## No behavior change

The blocking logic, protected branch list, error message, and exit codes are identical to what was there before. This is a pure refactor — no functional difference at runtime, confirmed with a test in a temporary git repo.
