### PR TITLE
feat: add first plugin eval suite for dx-plan-validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ docs/brainstorming/
 .mcp.json
 logo.JPG
 tools/screenshots/
+
+# Eval run artifacts (timestamped; regenerate with `claude plugin eval`)
+plugins/*/evals/results/

--- a/plugins/dx-core/evals/plan-validate-finds-gap/README.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/README.md
@@ -1,0 +1,77 @@
+# Eval: plan-validate-finds-gap
+
+First eval suite in this repo. Subject: the `dx-plan-validate` skill.
+
+## The fixture
+
+`resources/spec/` is planted into the empty sandbox workspace by
+`resources/setup.sh`. It contains a spec directory with **one deliberate
+defect**:
+
+| Requirement | Covered by |
+|---|---|
+| R1 — delay calls | Step 1 |
+| R2 — `.cancel()` | Step 2 |
+| **R3 — throw TypeError** | **nothing** |
+
+R1 and R2 are distractors. The correct report names R3 and only R3, i.e.
+`2/3 covered`. Because the answer is known in advance, the graders can check
+both **recall** (did it find the real gap) and **precision** (did it invent
+extra ones).
+
+## The graders — one per oracle type
+
+| Grader | Type | Oracle |
+|---|---|---|
+| `wrote-report` | `file_exists` | structural — was the report created |
+| `coverage-2-of-3` | `regex` contains | exact — recall |
+| `no-extra-gaps` | `regex` not_contains | exact — precision (rejects `1/3`, `0/3`) |
+| `gap-is-explained` | `llm` | fuzzy — a rubric, judged 2-of-3 |
+
+## Running it
+
+```bash
+TMPDIR=/tmp CLAUDE_CODE_WALNUT_SPIRE=1 \
+  claude plugin eval plugins/dx-core --case plan-validate-finds-gap \
+  --runs 3 --ablation none --scaffold --no-publish \
+  --allow-tools Write Bash
+```
+
+`TMPDIR=/tmp` matters: sandbox `.claude/` discovery walks *up* from the run
+directory, so a temp dir under `$HOME` lets the child find `~/.claude/skills`
+and contaminates the baseline. `CLAUDE_CODE_WALNUT_SPIRE=1` opens the
+early-access gate — do not commit it anywhere public.
+
+Pin `--model` and `--judge-model` before comparing scores across time,
+otherwise a model rollout reads as a regression.
+
+## Result, 2026-08-15
+
+`--runs 3` → **score 1.00, 100% pass, $1.10, 173s.** All 12 grader checks
+passed; the judge voted 9/9 PASS. No variance.
+
+## The interesting finding: the LLM judge failed the sanity check
+
+A suite that only ever passes proves nothing — it may be rubber-stamping. So
+the fixture was temporarily *fixed* (Step 3 added, covering R3) and re-run.
+The eval correctly went red overall (**0.75, exit 1**) — but not uniformly:
+
+- `coverage-2-of-3` (regex) **caught it.** The report said `3/3`, no match.
+- `gap-is-explained` (llm) **voted PASS PASS PASS** — on a report that
+  explicitly stated `3/3 covered` and `✅ Requirement R3 — covered by Step 3`,
+  which the rubric names as an explicit FAIL condition.
+
+The rubric encoded ground truth as prose ("Only R3 is genuinely uncovered by
+the plan"). When the input changed, that premise became false, and a
+confidently-written, well-structured report talked the judge out of the rubric.
+The regex could not be talked out of anything.
+
+**Takeaways.** Sanity-check every eval against a known-bad input, or you are
+only measuring that the suite is green. Prefer deterministic graders when an
+exact oracle exists. And treat a judge as a component that itself needs
+validating — the current literature on verifier reliability is about exactly
+this failure.
+
+Open follow-up: rewrite the rubric so it does not assume which fixture it is
+looking at (state the coverage claim to verify, not the ground truth), then
+re-run the sanity check and confirm the judge flips to FAIL.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/case.yaml
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/case.yaml
@@ -1,0 +1,7 @@
+schema_version: "1.1"
+name: plan-validate-finds-gap
+
+# case.yaml exists only to carry context.* — prompt.md cannot hold these keys.
+# Everything else (prompt, tools, limits) lives in prompt.md next to this file.
+context:
+  scaffold_script: resources/setup.sh

--- a/plugins/dx-core/evals/plan-validate-finds-gap/graders/coverage-2-of-3.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/graders/coverage-2-of-3.md
@@ -1,0 +1,11 @@
+---
+type: regex
+target: { source: file, path: .ai/specs/demo/validation-report.md }
+pattern: '2\s*/\s*3'
+match: contains
+---
+
+Exact oracle — RECALL. The fixture has 3 requirements and exactly one (R3) is
+uncovered, so the report's coverage count must read 2/3.
+
+A run that misses the planted gap reports 3/3 and fails here.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/graders/gap-is-explained.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/graders/gap-is-explained.md
@@ -1,0 +1,22 @@
+---
+type: llm
+focus: { source: file, path: .ai/specs/demo/validation-report.md }
+weight: 1
+---
+
+The report reviews an implementation plan against three requirements:
+
+- R1 — debounce(fn, ms) delays calls
+- R2 — the wrapper exposes .cancel()
+- R3 — debounce throws a TypeError when fn is not a function
+
+Only R3 is genuinely uncovered by the plan. R1 and R2 are each covered by a step.
+
+PASS if the report identifies R3 (input validation / the TypeError requirement)
+as the uncovered requirement, AND does not claim that R1 or R2 is uncovered.
+
+FAIL if it reports full coverage, if it names R1 or R2 as uncovered, or if it
+is so vague that a reader could not tell which requirement is missing.
+
+Judge only the requirement-coverage finding. Ignore scope-creep, dependency,
+test-coverage, and reuse remarks — they are out of scope for this rubric.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/graders/no-extra-gaps.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/graders/no-extra-gaps.md
@@ -1,0 +1,13 @@
+---
+type: regex
+target: { source: file, path: .ai/specs/demo/validation-report.md }
+pattern: '[01]\s*/\s*3'
+match: not_contains
+---
+
+Exact oracle — PRECISION. R1 and R2 are correctly covered and exist as
+distractors. A run that invents extra gaps reports 1/3 or 0/3 and fails here.
+
+This is the grader that catches a "validator" which simply flags everything.
+Without it, a report claiming all three requirements are uncovered would still
+look plausible to a reader.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/graders/wrote-report.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/graders/wrote-report.md
@@ -1,0 +1,8 @@
+---
+type: file_exists
+path: "**/validation-report.md"
+---
+
+Structural oracle. The skill's contract says it writes its report to
+`$SPEC_DIR/validation-report.md`. Note this matches files *created* during the
+run — a file that already existed would not count.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/prompt.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/prompt.md
@@ -1,0 +1,16 @@
+---
+name: plan-validate-finds-gap
+description: >
+  dx-plan-validate is given a plan with exactly one planted defect —
+  requirement R3 has no covering step. R1 and R2 are correctly covered and
+  act as distractors. The correct report names R3 and only R3.
+tags: [outcome, plan-validate]
+plugins: ["../.."]
+runs: 3
+max_turns: 30
+timeout_seconds: 900
+allowed_tools: [Read, Glob, Grep, Skill, Bash, Write]
+---
+
+Use the dx-plan-validate skill to validate the implementation plan in
+`.ai/specs/demo` against its requirements.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/resources/setup.sh
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/resources/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Plants the fixture into the empty eval sandbox workspace.
+# Runs as: bash resources/setup.sh, with cwd = the sandbox workspace.
+set -euo pipefail
+cp -r "$(dirname "$0")/spec/." .

--- a/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/lib/dx-common.sh
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/lib/dx-common.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# dx-common.sh — Shared library for dx plugin skills
+#
+# Can be used two ways:
+#
+# 1. As a CLI (from SKILL.md instructions):
+#    bash .ai/lib/dx-common.sh find-spec-dir 2416553
+#    bash .ai/lib/dx-common.sh slugify 2416553 "Enhance Card Layout Switcher"
+#    bash .ai/lib/dx-common.sh yaml-val compile
+#
+# 2. As a library (from other scripts):
+#    source .ai/lib/dx-common.sh
+#    SPEC_DIR=$(find_spec_dir "2416553")
+#    SLUG=$(slugify "2416553" "Enhance Card Layout Switcher")
+#    CMD=$(yaml_val "compile")
+
+set -euo pipefail
+
+SPECS_DIR="${SPECS_DIR:-.ai/specs}"
+CONFIG_FILE="${CONFIG_FILE:-.ai/config.yaml}"
+
+# --- Functions ---
+
+# Find the spec directory for a given work item ID, slug, or most recent
+# Usage: find_spec_dir [work-item-id-or-slug]
+# Output: prints the spec directory path to stdout (trailing slash)
+# Exit codes: 0 = found, 1 = not found
+find_spec_dir() {
+  local input="${1:-}"
+
+  if [[ -n "$input" ]]; then
+    # Try numeric ID match first: specs/<id>-*/
+    local dir
+    dir=$(ls -d "${SPECS_DIR}/${input}"-*/ 2>/dev/null | head -1) || true
+    if [[ -n "$dir" ]]; then
+      echo "$dir"
+      return 0
+    fi
+    # Try slug match: specs/*<input>*/
+    dir=$(ls -d "${SPECS_DIR}/"*"${input}"*/ 2>/dev/null | head -1) || true
+    if [[ -n "$dir" ]]; then
+      echo "$dir"
+      return 0
+    fi
+    echo "ERROR: No spec directory found for '${input}'" >&2
+    return 1
+  else
+    # Find most recently modified spec file (bug or story flows)
+    local latest
+    latest=$(ls -t ${SPECS_DIR}/*/raw-bug.md 2>/dev/null | head -1) || true
+    if [[ -z "$latest" ]]; then
+      latest=$(ls -t ${SPECS_DIR}/*/explain.md 2>/dev/null | head -1) || true
+    fi
+    if [[ -z "$latest" ]]; then
+      latest=$(ls -t ${SPECS_DIR}/*/raw-story.md 2>/dev/null | head -1) || true
+    fi
+    if [[ -n "$latest" ]]; then
+      echo "$(dirname "$latest")/"
+      return 0
+    fi
+    echo "ERROR: No spec directories found" >&2
+    return 1
+  fi
+}
+
+# Generate a concise 2-4 word slug from a work item title
+# Usage: slugify <work-item-id> "<title>"
+# Output: prints the spec directory name (e.g., "2416553-enhance-component")
+slugify() {
+  local id="${1:?Usage: slugify <work-item-id> \"<title>\"}"
+  local title="${2:?Usage: slugify <work-item-id> \"<title>\"}"
+
+  # Check if a spec directory already exists for this ID — reuse it
+  local existing
+  existing=$(ls -d "${SPECS_DIR}/${id}"-*/ 2>/dev/null | head -1 || true)
+  if [[ -n "$existing" ]]; then
+    basename "${existing%/}"
+    return 0
+  fi
+
+  # Generate slug from title
+  local stop_words="a|an|the|to|for|of|in|on|is|it|and|or|with|by|at|from|as|be|this|that|are|was|were|vs|has|have"
+
+  local slug
+  slug=$(echo "$title" \
+    | sed -E 's/\[[^]]*\]//g' \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E "s/[^a-z0-9 ]/ /g" \
+    | tr -s ' ' \
+    | sed 's/^ //;s/ $//' \
+    | tr ' ' '\n' \
+    | grep -v -w -E "${stop_words}" \
+    | head -4 \
+    | tr '\n' '-' \
+    | sed 's/-$//' || true)
+
+  echo "${id}-${slug}"
+}
+
+# Simple YAML value reader (key: value on its own line)
+# Usage: yaml_val <key>
+# Output: prints the value (trimmed, unquoted)
+yaml_val() {
+  local key="$1"
+  if [ -f "$CONFIG_FILE" ]; then
+    grep -E "^\s*${key}:" "$CONFIG_FILE" 2>/dev/null | head -1 | sed "s/^[^:]*:\s*//" | sed 's/^"//' | sed 's/"$//' | xargs
+  fi
+}
+
+# Scalar value under a named top-level block (2-space indented child key).
+# Usage: yaml_block_val <block> <key>   e.g. yaml_block_val project platform
+# Stops at the next top-level (column-0) key so it never bleeds into siblings.
+yaml_block_val() {
+  local block="$1" key="$2"
+  [ -f "${CONFIG_FILE:-}" ] || return 0
+  awk -v blk="$block" -v k="$key" '
+    $0 ~ "^"blk":[[:space:]]*$" { inb=1; next }
+    inb && /^[^[:space:]#]/ { inb=0 }
+    inb && $0 ~ "^[[:space:]]+"k":" {
+      sub("^[[:space:]]+"k":[[:space:]]*", ""); sub(/[[:space:]]+#.*$/, ""); gsub(/^"|"$/, ""); print; exit
+    }
+  ' "$CONFIG_FILE" | xargs
+}
+
+# Emit the top-level repos: list as TSV rows: name<TAB>role<TAB>platform<TAB>brand<TAB>ado-project
+# Missing fields are emitted empty. List items are `  - name: X` with 4-space child keys.
+# Usage: repos_table
+repos_table() {
+  [ -f "${CONFIG_FILE:-}" ] || return 0
+  awk '
+    function flush() {
+      if (name != "") printf "%s\t%s\t%s\t%s\t%s\n", name, role, platform, brand, adoproj
+      name=""; role=""; platform=""; brand=""; adoproj=""
+    }
+    /^repos:[[:space:]]*$/ { inr=1; next }
+    inr && /^[^[:space:]#-]/ { flush(); inr=0 }
+    inr && /^[[:space:]]*-[[:space:]]*name:/ { flush(); sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, ""); sub(/[[:space:]]+#.*$/, ""); gsub(/^"|"$/, ""); name=$0; next }
+    inr && /^[[:space:]]+role:/        { v=$0; sub(/^[[:space:]]+role:[[:space:]]*/, "", v); sub(/[[:space:]]+#.*$/, "", v); gsub(/^"|"$/, "", v); role=v; next }
+    inr && /^[[:space:]]+platform:/     { v=$0; sub(/^[[:space:]]+platform:[[:space:]]*/, "", v); sub(/[[:space:]]+#.*$/, "", v); gsub(/^"|"$/, "", v); platform=v; next }
+    inr && /^[[:space:]]+brand:/        { v=$0; sub(/^[[:space:]]+brand:[[:space:]]*/, "", v); sub(/[[:space:]]+#.*$/, "", v); gsub(/^"|"$/, "", v); brand=v; next }
+    inr && /^[[:space:]]+ado-project:/  { v=$0; sub(/^[[:space:]]+ado-project:[[:space:]]*/, "", v); sub(/[[:space:]]+#.*$/, "", v); gsub(/^"|"$/, "", v); adoproj=v; next }
+    END { if (inr) flush() }
+  ' "$CONFIG_FILE"
+}
+
+# Check that a required file exists
+# Usage: require_file <path> [label]
+# Exit codes: 0 = exists, 1 = missing (prints error)
+require_file() {
+  local path="$1" label="${2:-$1}"
+  if [ ! -f "$path" ]; then
+    echo "ERROR: Required file missing: $label ($path)" >&2
+    return 1
+  fi
+}
+
+# Check that a required directory exists
+# Usage: require_dir <path> [label]
+# Exit codes: 0 = exists, 1 = missing (prints error)
+require_dir() {
+  local path="$1" label="${2:-$1}"
+  if [ ! -d "$path" ]; then
+    echo "ERROR: Required directory missing: $label ($path)" >&2
+    return 1
+  fi
+}
+
+# Resolve one AEM instance's URL/user/pass from the AEM_INSTANCES env var.
+# AEM_INSTANCES is the single source of truth for AEM credentials — the same
+# value the AEM MCP server reads. Format (comma-separated entries):
+#   name:url:user:pass        e.g. local:http://localhost:4502:admin:admin,qa:https://qa-author.example.com:user:pass
+# The URL contains colons (scheme + port), so we anchor: name = before the
+# FIRST colon, pass = after the LAST colon, user = the field before pass, and
+# url = everything in between. (A literal ':' in a password is unsupported —
+# same limitation as the AEM MCP server's own parser.)
+#
+# Usage: aem_instance <name> [field]
+#   field omitted  -> prints three eval-able lines: AEM_URL=... / AEM_USER=... / AEM_PASS=...
+#   field=url|user|pass -> prints just that value
+# Exit codes: 0 = found, 1 = AEM_INSTANCES unset or instance not found
+aem_instance() {
+  local name="${1:-qa}" field="${2:-}"
+  local instances="${AEM_INSTANCES:-}"
+  if [ -z "$instances" ]; then
+    echo "ERROR: AEM_INSTANCES is not set" >&2
+    return 1
+  fi
+  local entry rest userpass url user pass
+  local IFS=','
+  for entry in $instances; do
+    [ "${entry%%:*}" = "$name" ] || continue
+    rest="${entry#*:}"        # url:user:pass
+    pass="${rest##*:}"        # after last colon
+    userpass="${rest%:*}"     # url:user
+    user="${userpass##*:}"    # after last colon of url:user
+    url="${userpass%:*}"      # url (may contain colons)
+    case "$field" in
+      url)  echo "$url" ;;
+      user) echo "$user" ;;
+      pass) echo "$pass" ;;
+      "")   printf 'AEM_URL=%s\nAEM_USER=%s\nAEM_PASS=%s\n' "$url" "$user" "$pass" ;;
+      *)    echo "ERROR: unknown field '$field' (use url|user|pass)" >&2; return 1 ;;
+    esac
+    return 0
+  done
+  echo "ERROR: instance '$name' not found in AEM_INSTANCES" >&2
+  return 1
+}
+
+# --- CLI dispatch (when run directly, not sourced) ---
+
+# Detect if script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  CMD="${1:-}"
+  shift || true
+
+  case "$CMD" in
+    find-spec-dir)
+      find_spec_dir "$@"
+      ;;
+    slugify)
+      slugify "$@"
+      ;;
+    yaml-val)
+      yaml_val "$@"
+      ;;
+    yaml-block-val)
+      yaml_block_val "$@"
+      ;;
+    repos-table)
+      repos_table "$@"
+      ;;
+    require-file)
+      require_file "$@"
+      ;;
+    require-dir)
+      require_dir "$@"
+      ;;
+    aem-instance)
+      aem_instance "$@"
+      ;;
+    *)
+      echo "Usage: dx-common.sh <command> [args...]" >&2
+      echo "" >&2
+      echo "Commands:" >&2
+      echo "  find-spec-dir [id-or-slug]    Find spec directory" >&2
+      echo "  slugify <id> \"<title>\"         Generate spec dir name" >&2
+      echo "  yaml-val <key>                Read value from config.yaml" >&2
+      echo "  require-file <path> [label]   Assert file exists" >&2
+      echo "  require-dir <path> [label]    Assert directory exists" >&2
+      echo "  aem-instance <name> [field]   Resolve url/user/pass from AEM_INSTANCES" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/specs/demo/explain.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/specs/demo/explain.md
@@ -1,0 +1,23 @@
+# Debounce Utility
+
+## What & Why
+
+We need a small `debounce` helper in `src/utils/debounce.js` so that rapid
+input events (search-as-you-type) fire the handler once instead of on every
+keystroke.
+
+## Requirements
+
+1. **R1 — Delay calls.** `debounce(fn, ms)` returns a wrapped function that
+   invokes `fn` only after `ms` milliseconds have passed with no new call.
+2. **R2 — Cancellable.** The returned function exposes a `.cancel()` method
+   that discards any pending invocation.
+3. **R3 — Validate input.** `debounce` throws a `TypeError` when `fn` is not a
+   function.
+
+## Acceptance Criteria
+
+- Calling the wrapped function 5 times in 50ms with `ms = 100` results in
+  exactly one invocation of `fn`.
+- Calling `.cancel()` before the delay elapses results in zero invocations.
+- `debounce(null, 100)` throws a `TypeError`.

--- a/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/specs/demo/implement.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/resources/spec/.ai/specs/demo/implement.md
@@ -1,0 +1,19 @@
+# Implementation Plan: Debounce Utility
+
+## Step 1 — Create the debounce module
+
+**Action:** Create `src/utils/debounce.js`.
+
+Implement `debounce(fn, ms)` returning a wrapper that clears and resets a
+`setTimeout` on every call, so `fn` runs once after `ms` of quiet.
+
+**Test:** `npm test -- debounce` — asserts one invocation for 5 rapid calls.
+
+## Step 2 — Add the cancel method
+
+**Action:** Modify `src/utils/debounce.js`.
+
+Attach a `.cancel()` method to the returned wrapper that calls
+`clearTimeout` on the pending timer id.
+
+**Test:** `npm test -- debounce` — asserts zero invocations after `.cancel()`.


### PR DESCRIPTION
Introduces `plugins/dx-core/evals/` — the repo's first behavioral eval, using
the first-party `claude plugin eval` harness (undocumented publicly; shipped
gated since CC 2.1.198). Closes the shape of TODO #1, which had been tracked
against a hand-rolled bash runner that never landed.

The case plants one known defect in a spec fixture (requirement R3 has no
covering step; R1/R2 are correct distractors) so the graders can measure both
recall and precision. Four graders span all three oracle types: file_exists
(structural), two regex checks (exact), and an llm rubric (fuzzy).

Result at --runs 3: score 1.00, 100% pass, $1.10.

Sanity-checking the suite against a known-bad input — fixture temporarily
repaired so all three requirements were covered — surfaced a real finding: the
regex grader caught the change (0.75, exit 1) while the llm judge voted
PASS PASS PASS on a report explicitly stating "3/3 covered", a condition the
rubric names as FAIL. The rubric encoded ground truth as prose and a
well-structured report talked the judge out of it. Documented in the case
README with a follow-up to make the rubric fixture-independent.

Also gitignores plugins/*/evals/results/ (timestamped run artifacts).

Claude-Session: https://claude.ai/code/session_01GfLJgNbpe5Dw9LwF53d4tQ