### PR TITLE
docs: remove early-access flag name from public eval README

### DIFF
--- a/plugins/dx-core/evals/plan-validate-finds-gap/README.md
+++ b/plugins/dx-core/evals/plan-validate-finds-gap/README.md
@@ -30,8 +30,16 @@ extra ones).
 
 ## Running it
 
+`claude plugin eval` is in early access and gated per organization. If it
+prints `` `plugin eval` is currently in early access ``, enablement has not
+reached this machine — some clients need an enablement environment variable,
+which Anthropic provides during early-access onboarding. Set it in your shell
+or `~/.claude/settings.json` `env`, not in this repo. Self-test by running
+`claude plugin eval` in an empty directory: `No eval cases found …` means it
+is enabled.
+
 ```bash
-TMPDIR=/tmp CLAUDE_CODE_WALNUT_SPIRE=1 \
+TMPDIR=/tmp \
   claude plugin eval plugins/dx-core --case plan-validate-finds-gap \
   --runs 3 --ablation none --scaffold --no-publish \
   --allow-tools Write Bash
@@ -39,8 +47,7 @@ TMPDIR=/tmp CLAUDE_CODE_WALNUT_SPIRE=1 \
 
 `TMPDIR=/tmp` matters: sandbox `.claude/` discovery walks *up* from the run
 directory, so a temp dir under `$HOME` lets the child find `~/.claude/skills`
-and contaminates the baseline. `CLAUDE_CODE_WALNUT_SPIRE=1` opens the
-early-access gate — do not commit it anywhere public.
+and contaminates the baseline.
 
 Pin `--model` and `--judge-model` before comparing scores across time,
 otherwise a model rollout reads as a regression.


### PR DESCRIPTION
## What does this PR do?

Removes the `plugin eval` early-access enablement variable name from
`plugins/dx-core/evals/plan-validate-finds-gap/README.md` (added in #188),
replacing it with guidance that does not pin a specific flag.

The README now documents what the closed gate looks like, that some clients
need an enablement variable obtained during early-access onboarding, where to
set it (shell or `~/.claude/settings.json` `env` — **not** this repo), and the
empty-directory self-test that distinguishes "not enabled" from "no cases
found".

Verified zero occurrences of the flag name remain anywhere in the tree.

## Why?

The README instructed readers not to commit the variable anywhere public,
while naming it in a public repo — a self-contradiction, surfaced in review.

Resolved by removing rather than softening the wording, for three reasons:

1. The name is not a credential and grants no access, but Anthropic's guidance
   is to obtain it during early-access onboarding rather than circulate it, and
   `plugin eval` is deliberately undocumented publicly.
2. Early-access flag names churn, and once the feature is generally available
   no variable is needed at all — a pinned name would decay into a misleading
   instruction without anyone noticing.
3. Pointing readers at repo-scoped settings was wrong on mechanics anyway:
   project-scoped `env` is filtered by an allowlist before workspace trust, so
   a committed value would not take effect.

## Type of Change

- [ ] Bug fix (patch)
- [ ] New skill/agent (minor)
- [ ] Enhancement to existing skill/agent (minor)
- [ ] Breaking change (major)
- [x] Documentation only

## Checklist

- [x] No hardcoded org URLs, project names, paths, or branch names
- [ ] New config fields documented in `docs/reference/config-reference.md` — n/a, no config fields
- [ ] Skill/agent catalogs updated if applicable — n/a, no skill or agent changed
- [x] Shell scripts are `chmod +x` — no scripts changed
- [ ] Version bumped in all 4 version files — n/a, docs-only (`docs:` does not trigger a release)
- [x] Tested manually by running the skill in a test project — the eval suite this documents was run at `--runs 3` (score 1.00) plus a known-bad sanity check (0.75, exit 1) in #188

## Environment Tested

| Field | Value |
|-------|-------|
| Platform | Claude Code |
| Model | Opus 5 |
| OS | Linux 6.18.5 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfLJgNbpe5Dw9LwF53d4tQ)_